### PR TITLE
dockertest.images: Fix repo_split_p regexp

### DIFF
--- a/dockertest/images.py
+++ b/dockertest/images.py
@@ -44,7 +44,7 @@ class DockerImage(object): # pylint: disable=R0902
     #: parsing, spec defined in docker-io documentation.  e.g.
     #: ``[registry_hostname[:port]/][user_name/]
     #: (repository_name[:version_tag])``
-    repo_split_p = re.compile(r"(.+?(:\w+?)?/)?(\w+/)?(\w+)(:\w+)?")
+    repo_split_p = re.compile(r"(.+?(:\w+?)?/)?(\w+/)?([^:.]+)(:\w+)?")
 
     # Many arguments are simply required here
     # pylint: disable=R0913


### PR DESCRIPTION
Docker looks for either '.' or ':' in order to distinguish between
repo_addr or user name, thus the name could contain other characters
and not just \w.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
