### PR TITLE
subtests..build: Download busybox from internet

### DIFF
--- a/config_defaults/subtests/docker_cli/build.ini
+++ b/config_defaults/subtests/docker_cli/build.ini
@@ -1,7 +1,8 @@
 [docker_cli/build]
 # Test options
 docker_build_options = -rm
-busybox_path = /usr/sbin/busybox
+# Don't use the http:// prefix
+busybox_url = www.busybox.net/downloads/binaries/latest/busybox-i486
 source_files = basic_tree.tar,basic_devices.tar,Dockerfile
 build_timeout_seconds = 120
 image_name_prefix = docker_test_

--- a/subtests/docker_cli/build/build.py
+++ b/subtests/docker_cli/build/build.py
@@ -31,8 +31,20 @@ class build(subtest.Subtest):
             dst = os.path.join(self.srcdir, filename)
             shutil.copy(src, dst)
         # Must exist w/in directory holding Dockerfile
-        bb_dst = os.path.join(self.srcdir, 'busybox')
-        shutil.copy(self.config['busybox_path'], bb_dst)
+        from httplib import HTTPConnection
+        import logging
+        url = self.config['busybox_url'].split("/", 1)
+        logging.debug("Downloading busybox from http://%s%s location",
+                      url[0], url[1])
+        url[1] = "/" + url[1]     # Add the removed '/'
+        conn = HTTPConnection(url[0])
+        conn.request("GET", url[1])
+        resp = conn.getresponse()
+        data = resp.read()
+        busybox = os.open(os.path.join(self.srcdir, 'busybox'),
+                          os.O_WRONLY | os.O_CREAT, 0755)
+        os.write(busybox, data)
+        os.close(busybox)
 
     def initialize(self):
         super(build, self).initialize()


### PR DESCRIPTION
Download busybox (GPLv2) from the public repository in setup() phase instead
of package dependency.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
