### PR TITLE
dockertest.dockercmd_unittest: Add unittests for dockercmd

### DIFF
--- a/dockertest/dockercmd.py
+++ b/dockertest/dockercmd.py
@@ -5,12 +5,12 @@ Frequently used docker CLI operations/data
 # Pylint runs from a different directory, it's fine to import this way
 # pylint: disable=W0403
 
-from autotest.client.shared import error
 from autotest.client import utils
+from autotest.client.shared import error
 from subtest import Subtest
-from xceptions import DockerCommandError
-from xceptions import  DockerNotImplementedError
-from xceptions import DockerExecError
+from xceptions import (DockerNotImplementedError, DockerCommandError,
+                       DockerExecError)
+
 
 class DockerCmdBase(object):
     """
@@ -99,6 +99,7 @@ class DockerCmdBase(object):
                                   self.docker_options,
                                   self.subcmd)).strip()
 
+
 class DockerCmd(DockerCmdBase):
     """
     Setup a call docker subcommand as if by CLI w/ subtest config integration
@@ -121,6 +122,7 @@ class DockerCmd(DockerCmdBase):
             # Something internal must have gone wrong
             raise DockerCommandError(str(detail.result_obj))
 
+
 class NoFailDockerCmd(DockerCmd):
     """
     Setup a call docker subcommand as if by CLI w/ subtest config integration
@@ -132,7 +134,7 @@ class NoFailDockerCmd(DockerCmd):
 
         :param stdin: String or file-like containing standard input contents
         :raise: DockerCommandError on incorrect usage
-        :raise: DockerExecError on if command retuns non-zero exit code
+        :raise: DockerExecError on if command returns non-zero exit code
         :return: A CmdResult instance
         """
         try:
@@ -141,6 +143,7 @@ class NoFailDockerCmd(DockerCmd):
         # Prevent caller from needing to import this exception class
         except error.CmdError, detail:
             raise DockerExecError(str(detail.result_obj))
+
 
 class MustFailDockerCmd(DockerCmd):
     """
@@ -153,7 +156,7 @@ class MustFailDockerCmd(DockerCmd):
 
         :param stdin: String or file-like containing standard input contents
         :raise: DockerCommandError on incorrect usage
-        :raise: DockerExecError on if command retuns zero exit code
+        :raise: DockerExecError on if command returns zero exit code
         :return: A CmdResult instance
         """
         try:
@@ -168,6 +171,7 @@ class MustFailDockerCmd(DockerCmd):
                                   % str(cmdresult))
         else:
             return cmdresult
+
 
 class AsyncDockerCmd(DockerCmdBase):
     """

--- a/dockertest/dockercmd_unittests.py
+++ b/dockertest/dockercmd_unittests.py
@@ -2,8 +2,16 @@
 
 # Pylint runs from a different directory, it's fine to import this way
 # pylint: disable=W0403
+# There is magic requiring attributes defined outside the __init__
+# pylint: disable=W0201
 
-import unittest, tempfile, shutil, os, sys, types
+import os
+import shutil
+import sys
+import tempfile
+import types
+import unittest
+
 
 # DO NOT allow this function to get loose in the wild!
 def mock(mod_path):
@@ -14,7 +22,7 @@ def mock(mod_path):
     child_name = name_list.pop()
     child_mod = sys.modules.get(mod_path, types.ModuleType(child_name))
     if len(name_list) == 0:  # child_name is left-most basic module
-        if not sys.modules.has_key(child_name):
+        if child_name not in sys.modules:
             sys.modules[child_name] = child_mod
         return sys.modules[child_name]
     else:
@@ -27,21 +35,23 @@ def mock(mod_path):
             sys.modules[mod_path] = child_mod
         return sys.modules[mod_path]
 
-# Just pack whatever args received into attributes
-class FakeCmdResult(object):
+
+class FakeCmdResult(object):    # pylint: disable=R0903
+    """ Just pack whatever args received into attributes """
     def __init__(self, **dargs):
         for key, val in dargs.items():
             setattr(self, key, val)
 
-# Don't actually run anything!
+
 def run(command, *args, **dargs):
+    """ Don't actually run anything! """
     result = FakeCmdResult(command=command, args=args, dargs=dargs)
     # store myself to allow special AsyncJob magic
     result.result = result
     if 'unittest_fail' in command:
         result.exit_status = 1
         if not dargs['ignore_status']:
-            exc = Exception()   # We mock the CmdError, create suitable Exc here
+            exc = Exception()   # CmdError is mocked, create suitable Exc here
             exc.command = command
             exc.result_obj = result
             raise exc
@@ -49,8 +59,6 @@ def run(command, *args, **dargs):
         result.exit_status = 0
     return result
 
-class DummyClass:
-    pass
 
 # Mock module and mock function run in one command
 setattr(mock('autotest.client.utils'), 'run', run)
@@ -101,22 +109,25 @@ class DockerCmdTestBase(unittest.TestCase):
 
     def _make_fake_subtest(self):
         class FakeSubtestException(Exception):
-            def __init__(fake_self, *args, **dargs):
+            def __init__(fake_self, *_args, **_dargs):  # pylint: disable=E0213
                 super(FakeSubtestException, self).__init__()
+
         class FakeSubtest(self.subtest.Subtest):
             version = "1.2.3"
             config_section = self.config_section
             iteration = 1
             iterations = 1
-            def __init__(fake_self, *args, **dargs):
+
+            def __init__(fake_self, *_args, **_dargs):  # pylint: disable=E0213
                 config_parser = self.config.Config()
                 fake_self.config = config_parser.get(self.config_section)
                 for symbol in ('execute', 'setup', 'initialize', 'run_once',
                                'postprocess_iteration', 'postprocess',
                                'cleanup', 'failif',):
                     setattr(fake_self, symbol, FakeSubtestException)
-                for symbol in ('logdebug', 'loginfo', 'logwarning', 'logerror'):
-                    setattr(fake_self, symbol, lambda *a, **d:None)
+                for symbol in ('logdebug', 'loginfo', 'logwarning',
+                               'logerror'):
+                    setattr(fake_self, symbol, lambda *_a, **_d: None)
         return FakeSubtest()
 
     def setUp(self):
@@ -150,8 +161,8 @@ class DockerCmdTestBase(unittest.TestCase):
 
 class DockerCmdTestBasic(DockerCmdTestBase):
 
-    defaults = {'docker_path':'/foo/bar', 'docker_options':'--not_exist',
-                'docker_timeout':"42.0"}
+    defaults = {'docker_path': '/foo/bar', 'docker_options': '--not_exist',
+                'docker_timeout': "42.0"}
     customs = {}
     config_section = "Foo/Bar/Baz"
 
@@ -176,7 +187,6 @@ class DockerCmdTestBasic(DockerCmdTestBase):
                           self.dockercmd.DockerCmdBase, "ThisIsNotSubtest",
                           "fake_subcmd")
 
-
     def test_dockercmd(self):
         docker_command = self.dockercmd.DockerCmd(self.fake_subtest,
                                                   'fake_subcommand',
@@ -190,7 +200,9 @@ class DockerCmdTestBasic(DockerCmdTestBase):
         self.assertEqual(str(docker_command), expected)
         cmdresult = docker_command.execute()
         self.assertEqual(cmdresult.command, expected)
+        # mocked cmdresult has '.dargs' pylint: disable=E1101
         self.assertAlmostEqual(cmdresult.dargs['timeout'], 1234567.0)
+        # pylint: enable=E1101
         # Verify can change some stuff
         docker_command.timeout = 0
         docker_command.subcmd = ''
@@ -199,7 +211,9 @@ class DockerCmdTestBasic(DockerCmdTestBase):
         expected = ("%s %s" % (self.defaults['docker_path'],
                                self.defaults['docker_options']))
         self.assertEqual(cmdresult.command, expected)
+        # mocked cmdresult has '.dargs' pylint: disable=E1101
         self.assertEqual(cmdresult.dargs['timeout'], 0)
+        # pylint: enable=E1101
 
     def test_no_fail_docker_cmd(self):
         docker_command = self.dockercmd.NoFailDockerCmd(self.fake_subtest,
@@ -223,12 +237,15 @@ class DockerCmdTestBasic(DockerCmdTestBase):
 
 
 class AsyncDockerCmd(DockerCmdTestBase):
-    defaults = {'docker_path':'/foo/bar', 'docker_options':'--not_exist',
-                'docker_timeout':"42.0"}
+    defaults = {'docker_path': '/foo/bar', 'docker_options': '--not_exist',
+                'docker_timeout': "42.0"}
     customs = {}
     config_section = "Foo/Bar/Baz"
 
     def test_basi_workflow(self):
+        class DummyClass(object):   # pylint: disable=R0903
+            """ Clean class used for mocking """
+            pass
         docker_cmd = self.dockercmd.AsyncDockerCmd(self.fake_subtest,
                                                    'fake_subcommand',
                                                    timeout=123)


### PR DESCRIPTION
Next set of unittests for dockercmd complemented by pep8/pylint fixes.
