### PR TITLE
dockertest.containers: Add get_unique_name function

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -577,6 +577,12 @@ Several variations of running the stop command
    and optionally ``docker_registry_host`` and/or ``docker_registry_user``.
    i.e. Copy ``config_defaults/defaults.ini`` to ``config_custom/defaults.ini``
    and modify the values.
+* The ``top_name_prefix`` is prefix of the tested container followed by
+* The ``run_options_csv`` modifies the running container options.
+* The ``stop_options_csv`` specifies the stop command options
+  random characters to make it unique.
+* The ``exec_cmd`` modifies the container command
+* The ``stop_duration`` sets the acceptable stop command duration (+-2s)
 
 ----------------------------------
 Dockertest API Reference


### PR DESCRIPTION
The first commit is from another pull request. In the actual commit the `stop` test is modified to use this function.

Please note that this pull request is dependent on https://github.com/autotest/autotest/pull/811
