### PR TITLE
Kill 'clic' from dockertest/images & container

### DIFF
--- a/dockertest/containers_unittests.py
+++ b/dockertest/containers_unittests.py
@@ -240,7 +240,7 @@ class DockerContainersTest(DockerContainersTestBase):
         self.assertNotEqual(len(dcc.json_by_name("suspicious_pare")), 0)
 
     def test_noports(self):
-        dcc = self.containers.DockerContainersCLICheck(self.fake_subtest)
+        dcc = self.containers.DockerContainersCLI(self.fake_subtest)
         short_id = "ac8c9fa367f9"
         cl = [c for c in dcc.list_containers() if c.cmp_id(short_id)]
         self.assertEqual(len(cl), 1)

--- a/dockertest/images.py
+++ b/dockertest/images.py
@@ -453,6 +453,8 @@ class DockerImagesCLI(DockerImagesBase):
     Docker command supported DockerImage-like instance collection and helpers.
     """
 
+    # TODO: Add boolean option to run cmdresult through output checkers
+
     def __init__(self, subtest, timeout=None, verbose=False):
         super(DockerImagesCLI, self).__init__(subtest,
                                               timeout,
@@ -510,22 +512,6 @@ class DockerImagesCLI(DockerImagesBase):
         return self.docker_cmd("rmi %s" % full_name, self.timeout)
 
 
-class DockerImagesCLICheck(DockerImagesCLI):
-    """
-    Extended ``DockerContainersCLI`` for passing test options and checking output.
-    """
-
-    #: This is probably test-subject related, be a bit more noisy
-    verbose = True
-
-    def docker_cmd(self, cmd, timeout=None):
-        cmdresult = super(DockerImagesCLICheck,
-                          self).docker_cmd(cmd, timeout)
-        # Throws exception if checks fail
-        OutputGood(cmdresult)
-        return cmdresult
-
-
 class DockerImages(object):
     """
     Encapsulates ``DockerImage`` interfaces for manipulation with docker images.
@@ -533,7 +519,7 @@ class DockerImages(object):
 
     #: Mapping of interface short-name string to DockerImagesBase subclass.
     #: (shortens line-length when instantiating)
-    interfaces = {"cli": DockerImagesCLI, 'clic': DockerImagesCLICheck}
+    interfaces = {"cli": DockerImagesCLI}
 
     def __init__(self, subtest, interface_name="cli",
                  timeout=None, verbose=False):

--- a/dockertest/images_unittests.py
+++ b/dockertest/images_unittests.py
@@ -314,9 +314,9 @@ class DockerImageTestBasic(ImageTestBase):
     def test_docker_images_lowlevel(self):
         self.assertRaises(KeyError, self.images.DockerImages,
                           self.fake_subtest, 'missing')
-        images = self.images.DockerImages(self.fake_subtest, "clic")
-        self.assertEqual(images.interface_name, "DockerImagesCLICheck")
-        self.assertEqual(images.interface_shortname, "clic")
+        images = self.images.DockerImages(self.fake_subtest, "cli")
+        self.assertEqual(images.interface_name, "DockerImagesCLI")
+        self.assertEqual(images.interface_shortname, "cli")
 
         self.assertEqual(images.docker_cmd("command_pass").command,
                          '/foo/bar command_pass')

--- a/subtests/docker_cli/psa/psa.py
+++ b/subtests/docker_cli/psa/psa.py
@@ -15,7 +15,18 @@ from dockertest import images
 from dockertest.output import OutputGood
 from dockertest.dockercmd import DockerCmd
 from dockertest.dockercmd import NoFailDockerCmd
-from dockertest.containers import DockerContainers
+from dockertest.containers import DockerContainersCLI
+
+class DockerContainersCLICheck(DockerContainersCLI):
+    #: This is probably test-subject related, be a bit more noisy
+    verbose = True
+
+    def docker_cmd(self, cmd, timeout=None):
+        cmdresult = super(DockerContainersCLICheck,
+                          self).docker_cmd(cmd, timeout)
+        # Throws exception if checks fail
+        OutputGood(cmdresult)
+        return cmdresult
 
 class psa(subtest.Subtest):
     config_section = 'docker_cli/psa'
@@ -35,7 +46,7 @@ class psa(subtest.Subtest):
         command = ("\"rm -f stop; trap '/usr/bin/date > stop' SIGURG; "
                    "while ! [ -f stop ]; do :; done\"")
         subargs.append(command)
-        self.stuff['cl0'] = DockerContainers(self, 'cli').get_container_list()
+        self.stuff['cl0'] = DockerContainersCLI(self).get_container_list()
         dkrcmd = DockerCmd(self, 'run', subargs)
         self.stuff['cmdresult'] = dkrcmd.execute()
         self.stuff['container_id'] = open(cidfile, 'rb').read().strip()
@@ -47,7 +58,7 @@ class psa(subtest.Subtest):
                      % self.config['wait_start'])
         time.sleep(self.config['wait_start'])
         # This is the test-subject, need to check output of docker command
-        clic = DockerContainers(self, 'clic')
+        clic = DockerContainersCLICheck(self)
         self.stuff['cl1'] = clic.get_container_list()
         sig = getattr(signal, 'SIGURG')  # odd-ball, infreq. used.
         self.loginfo("Signaling container with signal %s", sig)
@@ -72,11 +83,14 @@ class psa(subtest.Subtest):
         # TODO: Use 'inspect' command output to get actual PID
         #       and utils.pid_is_alive(PID) to verify it's stopped
         # Might as well do some more checking
-        dc = DockerContainers(self, 'cli')  # check output
+        dc = DockerContainersCLI(self)  # check output
         cnts = dc.list_containers_with_name(self.stuff['container_name'])
         self.failif(len(cnts) < 1, "Test container not found in list")
         cnt = cnts[0]
-        self.failif(str(cnt.status) != "Exit 0", "Exit status mismatch")
+        estat1 = str(cnt.status).startswith("Exit 0") # pre docker 0.9.1
+        estat2 = str(cnt.status).startswith("Exited (0)") # docker 0.9.1 & later
+        self.failif(not (estat1 or estat2), "Exit status mismatch: %s"
+                                            % str(cnt))
 
     def cleanup(self):
         super(psa, self).cleanup()


### PR DESCRIPTION
-  Neither of these subclasses is a true external-interface
  extension and will lead to combersome interface in the
  future.  Since it's used by only a single test, just
  move it there.
-  Found docker 0.9.1 changes formatting of 'ps -a' output
  for STATUS.  Updated containers module to account for this,
  added some debugging.
-  Found docker 0.9.1 changes content of STATUS column causing
  ps test to incorrectly fail.  Updated checks to account for
  both 'old way' and 'new way'
-  Fixed up unittests
-  Added TODO's to fix this missing functionality in more
  general way later.
-  Double-checked there are no references in docs

Signed-off-by: Chris Evich cevich@redhat.com
