### PR TITLE
RFC: Event handler

### DIFF
--- a/config_defaults/subtests/docker_cli/top.ini
+++ b/config_defaults/subtests/docker_cli/top.ini
@@ -2,6 +2,6 @@
 docker_timeout = 60
 # TODO: Why no processes are displayed when using docker top all and --tty=false?
 #       (when using docker top, processes are displayed correctly)
-run_options_csv = --tty=true,--interactive=true,--detach=true
+run_options_csv = --tty=false,--interactive=true,--sig-proxy=true
 container_name_prefix = test
 remove_after_test = yes

--- a/dockertest/event_handler.py
+++ b/dockertest/event_handler.py
@@ -1,0 +1,190 @@
+import time
+import re
+import tempfile
+
+
+START = ("-start", "-allocate_interface")
+RUN = ("-create",) + START
+FINISH = ("-release_interface", "-inspect",)
+LIST = ("-containers",)
+REMOVE = ("-container_delete",)
+
+
+class Event(object):
+    slots = ("type", "req_id", "cont_id", "status")
+
+    def __init__(self, ev_type, req_id, cont_id, status=None):
+        self.type = ev_type
+        self.req_id = req_id
+        self.cont_id = cont_id
+        self.status = status
+
+    def __str__(self):
+        return "%s %s %s %s" % (self.type, self.req_id, self.cont_id,
+                                self.status)
+
+    def __eq__(self, other):
+        if isinstance(other, Event):
+            return self.__eq_event__(other)
+        elif isinstance(other, str):
+            return self.__eq_str__(other)
+        elif isinstance(other, dict):
+            return self.__eq_dict__(other)
+        else:
+            raise ValueError("Can't compare to %s" % other)
+
+    def __eq_event__(self, other):
+        for slot in self.slots:
+            if getattr(self, slot) != getattr(other, slot):
+                return False
+        return True
+
+    def __eq_str__(self, other):
+        if self.type == other:
+            return True
+        else:
+            return False
+
+    def __eq_dict__(self, other):
+        for slot in self.slots:
+            try:
+                value = other['slot']
+                if value != getattr(self, slot):
+                    return False
+            except KeyError:
+                pass
+        return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+class EventHandler(object):
+    _re = re.compile(r'\[[^\|]+\|(\w{8})\] ([+-])job (\w+)\((\w*[^\)]*)\)( = \w+ '
+                     r'\((\d+)\))?\n?')
+
+    def __init__(self, messages=None):
+        if messages is None:
+            messages = '/var/log/messages'
+        self.messages = open(messages, 'r', 0)
+        self._service_offset = self._find_offset(self.messages)
+        self._offset = self._service_offset + 8
+        self.messages.seek(0, 2)    # Move to the end
+
+    def _find_offset(self, messages):
+        for line in messages.xreadlines():
+            for keyword in (' kernel: ', ' docker: ', ' NetworkManager: '):
+                idx = line.find(keyword)
+                if idx > 0:
+                    return idx + 1
+        else:
+            raise ValueError("Can't find /var/log/messages offset of services")
+
+    def _parse_line(self, line):
+        if line[self._service_offset:self._offset] != "docker: ":
+            return  # Not the "docker:" line
+        res = self._re.match(line[self._offset:])
+        if not res:
+            return  # Line doesn't match job prescription
+        res = res.groups()
+        # +-$job_name, req_id, container_id, result/None
+        return Event(res[1] + res[2], res[0], res[3], res[5] or None)
+
+    def get_events(self):
+        events = []
+        self.messages.seek(0, 1)    # Without the seek my python won't read
+        for line in self.messages.xreadlines():
+            event = self._parse_line(line)
+            if event:
+                events.append(event)
+        return events
+
+    def wait_for(self, events, timeout=None):
+        """
+        :return: Last registered event (you can get req_id and cont_id from it)
+        """
+        if not events:  # No events, just wait and move to the end of the file
+            if timeout:
+                time.sleep(timeout)
+            self.messages.seek(0, 2)
+            return
+        handled = {}
+        if timeout is None:
+            condition = lambda: True
+        else:
+            endtime = time.time() + timeout
+            condition = lambda: time.time() < endtime
+        while condition():
+            for event in self.get_events():
+                if event in events:
+                    if event.req_id not in handled:     # New req_id
+                        handled[event.req_id] = list(events)
+                    try:
+                        handled[event.req_id].remove(event)     # Try remove
+                    except ValueError:
+                        pass    # Event occured twice
+                    if handled[event.req_id] == []:
+                        return event     # all request were registered
+        raise StopIteration("Events did not occur until timeout. Missing "
+                            "events: %s" % handled)
+
+
+_HEAD = """Apr 17 15:34:28 t530 kernel: IPv6: ADDRCONF(NETDEV_UP): em1: link is not ready
+"""
+_START_FAIL = """Apr 17 16:13:21 t530 docker: 2014/04/17 16:13:21 POST /v1.10/containers/asdf/start
+Apr 17 16:13:21 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] +job start(asdf)
+Apr 17 16:13:21 t530 docker: No such container: asdf
+Apr 17 16:13:21 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] -job start(asdf) = ERR (1)
+Apr 17 16:13:21 t530 docker: [error] server.go:951 Error: No such container: asdf
+Apr 17 16:13:21 t530 docker: [error] server.go:86 HTTP Error: statusCode=404 No such container: asdf
+"""
+_RUN = """Apr 17 15:43:24 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] +job create()
+Apr 17 15:43:24 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] -job create() = OK (0)
+Apr 17 15:43:24 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] +job inspect(a95d4e2c17791dff303d33524e6cadb5337b0fe6456b9d18cfc58b67a292ee5d, container)
+Apr 17 15:43:24 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] -job inspect(a95d4e2c17791dff303d33524e6cadb5337b0fe6456b9d18cfc58b67a292ee5d, container) = OK (0)
+Apr 17 15:43:24 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] +job attach(a95d4e2c17791dff303d33524e6cadb5337b0fe6456b9d18cfc58b67a292ee5d)
+Apr 17 15:43:24 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] +job start(a95d4e2c17791dff303d33524e6cadb5337b0fe6456b9d18cfc58b67a292ee5d)
+Apr 17 15:43:24 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] +job allocate_interface(a95d4e2c17791dff303d33524e6cadb5337b0fe6456b9d18cfc58b67a292ee5d)
+Apr 17 15:43:24 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] -job allocate_interface(a95d4e2c17791dff303d33524e6cadb5337b0fe6456b9d18cfc58b67a292ee5d) = OK (0)
+Apr 17 15:43:24 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] -job start(a95d4e2c17791dff303d33524e6cadb5337b0fe6456b9d18cfc58b67a292ee5d) = OK (0)
+Apr 17 15:43:24 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] +job resize(a95d4e2c17791dff303d33524e6cadb5337b0fe6456b9d18cfc58b67a292ee5d, 24, 80)
+Apr 17 15:43:24 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] -job resize(a95d4e2c17791dff303d33524e6cadb5337b0fe6456b9d18cfc58b67a292ee5d, 24, 80) = OK (0)
+Apr 17 15:43:24 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] -job start(a95d4e2c17791dff303d33524e6cadb5337b0fe6456b9d18cfc58b67a292ee5d) = OK (0)
+"""
+
+_FINISH = """Apr 17 15:43:30 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] +job release_interface(a95d4e2c17791dff303d33524e6cadb5337b0fe6456b9d18cfc58b67a292ee5d)
+Apr 17 15:43:30 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] -job release_interface(a95d4e2c17791dff303d33524e6cadb5337b0fe6456b9d18cfc58b67a292ee5d) = OK (0)
+Apr 17 15:43:30 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] -job attach(a95d4e2c17791dff303d33524e6cadb5337b0fe6456b9d18cfc58b67a292ee5d) = OK (0)
+Apr 17 15:43:30 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] +job inspect(a95d4e2c17791dff303d33524e6cadb5337b0fe6456b9d18cfc58b67a292ee5d, container)
+Apr 17 15:43:30 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] -job inspect(a95d4e2c17791dff303d33524e6cadb5337b0fe6456b9d18cfc58b67a292ee5d, container) = OK (0)
+"""
+
+_LIST = """Apr 17 15:43:35 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] +job containers()
+Apr 17 15:43:35 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] -job containers() = OK (0)
+"""
+_REMOVE = """Apr 17 15:43:35 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] +job container_delete(a95d4e2c1779)
+Apr 17 15:43:36 t530 docker: [/home/medic/Work/Projekty/Docker/root|39d80f36] -job container_delete(a95d4e2c1779) = OK (0)
+"""
+
+
+if __name__ == '__main__':
+    log = tempfile.NamedTemporaryFile('w', bufsize=0)
+    print log.name
+    log.write(_HEAD)
+    events = EventHandler(log.name)
+    try:
+        events.wait_for(_RUN, 0.1)
+    except StopIteration, details:
+        print details
+
+    log.write(_START_FAIL)
+    print events.wait_for(["+start", "-start"], 0.1)
+
+    log.write(_RUN)
+    print events.wait_for(RUN, 0.1)
+
+    log.write(_FINISH)
+    log.write(_LIST)
+    log.write(_REMOVE)
+    print events.wait_for(FINISH + LIST + REMOVE, 0.1)
+    print events.wait_for([], 0.1)  # wait for nothing (just moves at the end


### PR DESCRIPTION
This is a RFC for event_handler class, which should help with timing
issues of docker. It parses /var/log/messages and allows you to wait
for given docker events, eg. "docker run" sequence.

You have to keep in mind, that by parsing events you don't directly interact with the container, thus you can't know, whether inside commands already finished.

Anyway, the beginnings, timings of the "run" and "attach" commands:
<pre>
Without
09:39:28 INFO | 1.8835067749e-05
09:39:28 INFO | 3.00407409668e-05

With
09:57:34 INFO | 0.324712991714
09:57:34 INFO | 0.0300760269165

With + stress --timeout 240s -c 4 -m 1 -i 1 -d 1 in background:
10:37:04 INFO | 13.4338970184
</pre>

you can see it waits until the container is really initialized. Anyway it doesn't wait for the inside command to be executed, as the modified `docker_cli/top` test demonstrates:
<pre>
Without:
10:23:28 INFO | Exit status: -15
10:23:28 ERROR| Duration: 0.0262169837952

With:
10:23:59 INFO | Exit status: 255
10:23:59 INFO | Duration: 0.474253892899

With + sleep 0.1:
10:25:40 INFO | Exit status: 9
10:25:40 INFO | Duration: 4.45453619957

With + sleep 1 + stress --timeout 240s -c 4 -m 1 -i 1 -d 1:
10:37:09 INFO | Exit status: 9
10:37:09 INFO | Duration: 18.4349918365
</pre>

You can see that without events it's very hard to set the timeouts correctly. With it it might be a bit easier, but still you'd need to add small wait for the command initialization. Anyway it should be guaranteed, that the container exists.

When you rely on the in-container-command, you should put "echo SOMETHING_UNIQUE" after the initialization and `utils.wait_for()` it. Then you have 100% guarantee it was executed. I'm considering some utils about this including the output starting from last_viewed or the whole history.

Regards,
Lukáš