### PR TITLE
made error message clearer when no subsubtests are enabled

### DIFF
--- a/dockertest/subtest.py
+++ b/dockertest/subtest.py
@@ -436,6 +436,8 @@ class SubSubtestCaller(Subtest):
         """
         super(SubSubtestCaller, self).initialize()
         # Private to this instance, outside of __init__
+        if not self.config['subsubtests']:
+            raise DockerTestNAError("No subsubtests enabled in configuration.")
         self.subsubtest_names = self.config['subsubtests'].strip().split(",")
 
     def try_all_stages(self, name, subsubtest):


### PR DESCRIPTION
Simple fix for https://github.com/autotest/autotest-docker/issues/89

Signed-off-by: James Molet jmolet@redhat.com
