### PR TITLE
control: Prevent AttributeError in cleanup

### DIFF
--- a/control
+++ b/control
@@ -165,8 +165,9 @@ def run_test(control_path, url, tag, timeout):
     finally:
         imp.acquire_lock()
         # Filter by internal module name, not sys.modules key.
-        modnames = [modname for (modname, module) in sys.modules.items()
-                    if module is not None and module.__name__.count('docker')]
+        modnames = [modname for (modname, module) in sys.modules.iteritems()
+                    if (hasattr(module, '__name__') and
+                        module.__name__.count('docker'))]
         for modname in modnames:
             del sys.modules[modname]
         imp.release_lock()


### PR DESCRIPTION
Apparently not all modules have **name** attribute, today I saw this exception:

<pre>
sudo ./autotest-local --verbose run docker --args='docker_cli/stop'
...
11:46:23 ERROR| JOB ERROR: Unhandled AttributeError: 
Traceback (most recent call last):
  File "/home/medic/Work/Projekty/autotest/autotest-ldoktor/client/job.py", line 1036, in _run_step_fn
    exec('__ret = %s(*__args, **__dargs)' % fn, local_vars, local_vars)
  File "<string>", line 1, in <module>
  File "/home/medic/Work/Projekty/autotest/autotest-ldoktor/client/tests/docker/control", line 169, in run_test
    if module is not None and module.__name__.count('docker')]
  File "/usr/lib/python2.7/site-packages/six.py", line 115, in __getattr__
    raise AttributeError
AttributeError

11:46:23 INFO | END ABORT       ----    ----    timestamp=1398678383    localtime=Apr 28 11:46:23       Unhandled AttributeError: 
  Traceback (most recent call last):
    File "/home/medic/Work/Projekty/autotest/autotest-ldoktor/client/job.py", line 1036, in _run_step_fn
      exec('__ret = %s(*__args, **__dargs)' % fn, local_vars, local_vars)
    File "<string>", line 1, in <module>
    File "/home/medic/Work/Projekty/autotest/autotest-ldoktor/client/tests/docker/control", line 169, in run_test
      if module is not None and module.__name__.count('docker')]
    File "/usr/lib/python2.7/site-packages/six.py", line 115, in __getattr__
      raise AttributeError
  AttributeError
</pre>


btw these modules I'm talking about:

<pre>
11:54:45 INFO | six.moves.BaseHTTPServer <six.MovedModule object at 0x213a050>
11:54:45 INFO | six.moves.tkinter_constants <six.MovedModule object at 0x213a410>
11:54:45 INFO | six.moves.html_parser <six.MovedModule object at 0x2134ed0>
11:54:45 INFO | six.moves.winreg <six.MovedModule object at 0x213a7d0>
11:54:45 INFO | six.moves.http_cookies <six.MovedModule object at 0x2134e50>
11:54:45 INFO | six.moves.tkinter_filedialog <six.MovedModule object at 0x213a2d0>
11:54:45 INFO | six.moves.tkinter_scrolledtext <six.MovedModule object at 0x213a310>
11:54:45 INFO | six.moves.tkinter_messagebox <six.MovedModule object at 0x213a590>
11:54:45 INFO | six.moves.tkinter_font <six.MovedModule object at 0x213a550>
11:54:45 INFO | six.moves.tkinter_ttk <six.MovedModule object at 0x213a3d0>
11:54:45 INFO | six.moves.CGIHTTPServer <six.MovedModule object at 0x213a090>
11:54:45 INFO | six.moves.http_cookiejar <six.MovedModule object at 0x2134e10>
11:54:45 INFO | six.moves.SimpleHTTPServer <six.MovedModule object at 0x213a0d0>
11:54:45 INFO | six.moves.queue <six.MovedModule object at 0x213a150>
11:54:45 INFO | six.moves.tkinter_colorchooser <six.MovedModule object at 0x213a490>
11:54:45 INFO | six.moves.tkinter_tix <six.MovedModule object at 0x213a390>
11:54:45 INFO | six.moves.tkinter <six.MovedModule object at 0x213a250>
11:54:45 INFO | six.moves.reprlib <six.MovedModule object at 0x213a190>
11:54:45 INFO | six.moves.tkinter_dialog <six.MovedModule object at 0x213a290>
11:54:45 INFO | six.moves.tkinter_dnd <six.MovedModule object at 0x213a450>
11:54:45 INFO | six.moves.tkinter_commondialog <six.MovedModule object at 0x213a4d0>
11:54:45 INFO | six.moves.tkinter_tksimpledialog <six.MovedModule object at 0x213a5d0>
11:54:45 INFO | six.moves.tkinter_tkfiledialog <six.MovedModule object at 0x213a510>
11:54:45 INFO | six.moves.tkinter_simpledialog <six.MovedModule object at 0x213a350>
11:54:45 INFO | six.moves.xmlrpc_client <six.MovedModule object at 0x213a790>
11:54:45 INFO | six.moves.dbm_gnu <six.MovedModule object at 0x2134dd0>
11:54:45 INFO | six.moves.html_entities <six.MovedModule object at 0x2134e90>
</pre>


Regards,
Lukáš
