### PR TITLE
[RFC] External bugzilla tracking module

### DIFF
--- a/config_defaults/defaults.ini
+++ b/config_defaults/defaults.ini
@@ -41,3 +41,11 @@ docker_registry_user =
 envcheck_skip =
 # CSV of possibly existing image IDs to ignore
 envcheck_ignore_iids =
+
+##### Bugzilla checking options #####
+
+bugzilla_enable = yes
+bugzilla_username =
+bugzilla_password =
+bugzilla_url = https://bugzilla.redhat.com/xmlrpc.cgi
+bugzilla_fixed_states = ON_QA,MODIFIED,VERIFIED,RELEASE_PENDING,POST,CLOSED

--- a/config_defaults/subtests/docker_cli/info.ini
+++ b/config_defaults/subtests/docker_cli/info.ini
@@ -1,0 +1,2 @@
+[docker_cli/info]
+bugzilla_blockers = 1093021

--- a/dockertest/subtest.py
+++ b/dockertest/subtest.py
@@ -29,6 +29,7 @@ from xceptions import DockerTestFail
 from xceptions import DockerTestNAError
 from xceptions import DockerTestError
 from xceptions import DockerSubSubtestNAError
+from trackers import Trackers
 
 
 class Subtest(test.test):
@@ -128,8 +129,13 @@ class Subtest(test.test):
 
     def execute(self, *args, **dargs):
         """**Do not override**, needed to pull data from super class"""
-        super(Subtest, self).execute(iterations=self.iterations,
-                                     *args, **dargs)
+        try:
+            Trackers(self)
+        except DockerTestNAError as e:
+            self.loginfo(e.message)
+        else:
+            super(Subtest, self).execute(iterations=self.iterations,
+                                         *args, **dargs)
 
     # These methods can optionally be overridden by subclasses
 

--- a/dockertest/trackers.py
+++ b/dockertest/trackers.py
@@ -1,0 +1,88 @@
+"""
+This module provides helper classes that allow the testware
+to connect to external tools and trackers such as bugzilla.
+"""
+
+# Pylint runs from a different directory, it's fine to import this way
+# pylint: disable=W0403
+
+from xceptions import DockerTestNAError
+import bugzilla
+import logging
+
+class Trackers(object):
+    """
+    This class provides a simple interface to initalize and run
+    all trackers at once for a subtest.
+    :param subtest: The Subtest object which to set trackers for.
+    """
+    def __init__(self, subtest):
+        bz_blockers = BugzillaBlocker(subtest)
+        bz_blockers.skip_if_blockers()
+
+
+class BugzillaBlocker(object):
+    """
+    This class connects to bugzilla and provides functionality that
+    will skip a subtest if there is an open bug against it.
+    :param subtest: The Subtest object this bugzilla blocker is attached to.
+    """
+    def __init__(self, subtest):
+        self.subtest = subtest
+        config = subtest.config
+
+        def get_conf(field):
+            """ Safe way to get config field """
+            if field in config:
+                return config[field]
+            else:
+                return None
+
+        #the bugzilla module is very noisy
+        log = logging.getLogger("bugzilla")
+        log.setLevel(logging.WARNING)
+        log = logging.getLogger("urllib3")
+        log.setLevel(logging.WARNING)
+
+        url = config['bugzilla_url']
+        username = get_conf('bugzilla_username')
+        password = get_conf('bugzilla_password')
+        self.rhbz = bugzilla.Bugzilla(url=url)
+        if username and password:
+            self.rhbz.login(user=username, password=password)
+
+        self.fixed_states = config['bugzilla_fixed_states'].split(',')
+
+        blockers = get_conf('bugzilla_blockers')
+        if blockers:
+            if isinstance(blockers, (str, unicode)):
+                self.blockers = [int(x) for x in blockers.split(',')]
+            else:
+                self.blockers = [blockers]
+        else:
+            self.blockers = []
+
+        self.enabled = config['bugzilla_enable']
+
+    def get_open_bzs(self):
+        """
+        This method returns a list of bugs that are not in a closed state
+        :return: List of open bugs
+        """
+        bugs = self.rhbz.getbugs(self.blockers)
+        bzs = [x.id for x in bugs if x.status not in self.fixed_states]
+        return bzs
+
+    def skip_if_blockers(self):
+        """
+        This method will throw a skip exception if there are blocking bugzilla
+        bugs.
+        :raise DockerTestNAError: If there are blocking bugs.
+        """
+        bugs = self.get_open_bzs()
+        if self.enabled and bugs:
+            raise DockerTestNAError("Skpping test due to open "
+                                    "bugzilla bug(s): %s" % (bugs))
+        elif self.enabled and self.blockers:
+            self.subtest.loginfo("Previously blocked by bugzilla "
+                                 "bug(s): %s" % (self.blockers))

--- a/index.rst
+++ b/index.rst
@@ -336,6 +336,20 @@ file is loaded *either* from ``config_defaults`` *or* ``config_custom``.
    ``enable = false`` (or ``no``) option to any config file
    will turn off just that test.
 
+``bugzilla`` configuration options
+----------------------------------
+
+This section controlls the bugzilla tracking module.  The module allows
+subtests to be tagged or "blocked" with bugzilla numbers, and if the bug is
+open, it will save time and skip the test.
+
+*  ``bugzilla_enable`` yes/no that turns the bugzilla checking module on/off
+*  ``bugzilla_username`` username in which to log into bugzilla (optional)
+*  ``bugzilla_password`` password in which to log into bugzilla (optional)
+*  ``bugzilla_url`` URL to the bugzilla instance.
+*  ``bugzilla_fixed_states`` Bug states which are considered closed, allowing
+   the test to run .
+
 ``example`` Sub-test
 =======================
 

--- a/subtests/docker_cli/info/info.py
+++ b/subtests/docker_cli/info/info.py
@@ -17,6 +17,8 @@ import os
 
 class info(subtest.Subtest):
 
+    config_section = 'docker_cli/info'
+
     def run_once(self):
         super(info, self).run_once()
         # 1. Run with no options


### PR DESCRIPTION
Signed-off-by: James Molet jmolet@redhat.com

This module ads bugzilla tracking and blocking to subtests.  If a test is blocked by a bug it will throw a warning, and skip the test instead of trying to run a test that will not work.

To block a test by a bug, simply add the bug numbers in csv format to the test's .ini config file using the `bugzilla_blockers` keyword.

It seems that this way of doing thing is more inline with the current style this testware is set up than the `@decorator` style of blocking.  It also allows for expansion of other tracking tools into the trackers.py file

This is an initial RFE commit.  Any ideas on how to implement this would be welcome.
