### PR TITLE
dockertest.environment: Add set_selinux_context and use it for volumes

### DIFF
--- a/dockertest/environment.py
+++ b/dockertest/environment.py
@@ -175,3 +175,29 @@ class EnvCheck(AllGoodBase):
         return {'args': fullpath, 'bufsize': 1, 'stdout': subprocess.PIPE,
                 'stderr': subprocess.PIPE, 'close_fds': True, 'shell': True,
                 'env': self.config}
+
+
+def set_selinux_context(pwd, context=None, recursive=True):
+    """
+    When selinux is enabled it sets the context by chcon -t ...
+    :param pwd: target directory
+    :param context: desired context (public_content_rw_t by default)
+    :param recursive: set context recursively (-R)
+    :raise OSError: In case of failure
+    """
+    if context is None:
+        context = "public_content_rw_t"
+    if recursive:
+        flags = 'R'
+    else:
+        flags = ''
+    # changes context in case selinux is supported and is enabled
+    _cmd = ("type -P selinuxenabled || exit 0 ; "
+            "selinuxenabled || exit 0 ; "
+            "chcon -%st %s %s" % (flags, context, pwd))
+    cmd = subprocess.Popen(_cmd, stdout=subprocess.PIPE,
+                           stderr=subprocess.PIPE, shell=True)
+    if cmd.wait() != 0:
+        raise OSError("Fail to set selinux context by '%s' (%s):\nSTDOUT:\n%s"
+                      "\nSTDERR:\n%s" % (_cmd, cmd.poll(), cmd.stdout.read(),
+                                         cmd.stderr.read()))

--- a/subtests/docker_cli/rm/rm.py
+++ b/subtests/docker_cli/rm/rm.py
@@ -22,6 +22,7 @@ from dockertest.subtest import SubSubtestCaller
 from dockertest.containers import DockerContainers
 from dockertest.images import DockerImage
 from dockertest.output import OutputGood
+from dockertest import environment
 
 class rm(SubSubtestCaller):
     config_section = 'docker_cli/rm'
@@ -99,6 +100,7 @@ class rm_sub_base(SubSubtest):
 
     def init_static_data(self):
         volume = self.sub_stuff['volume'] = self.tmpdir
+        environment.set_selinux_context(volume, "svirt_sandbox_file_t")
         start_filename = os.path.join(volume, 'start')
         self.sub_stuff['start_filename'] = start_filename
         ssfile = open(start_filename, "wb")

--- a/subtests/docker_cli/run_volumes/run_volumes.py
+++ b/subtests/docker_cli/run_volumes/run_volumes.py
@@ -22,6 +22,8 @@ from dockertest.subtest import SubSubtestCaller
 from dockertest.xceptions import DockerCommandError
 from dockertest.xceptions import DockerExecError
 from dockertest.xceptions import DockerTestNAError
+from dockertest import environment
+import subprocess
 
 
 class run_volumes(SubSubtestCaller):
@@ -62,6 +64,7 @@ class volumes_base(SubSubtest):
                 raise DockerTestNAError("host_path '%s' invalid." % host_path)
             if not cntr_path or len(cntr_path) < 4:
                 raise DockerTestNAError("cntr_path '%s' invalid." % cntr_path)
+            environment.set_selinux_context(host_path, "svirt_sandbox_file_t")
             # keys must coorespond with those used in *_template strings
             args = volumes_base.make_test_files(os.path.abspath(host_path))
             args += (host_path, cntr_path)

--- a/subtests/docker_cli/run_volumes/volumes_one_source.py
+++ b/subtests/docker_cli/run_volumes/volumes_one_source.py
@@ -18,6 +18,7 @@ from dockertest.dockercmd import DockerCmd
 from dockertest.images import DockerImage
 from run_volumes import volumes_base
 import hashlib
+from dockertest import environment
 
 
 class volumes_one_source(volumes_base):
@@ -30,6 +31,7 @@ class volumes_one_source(volumes_base):
         exec_command = self.config['exec_command']
         cntr_path = self.config['cntr_path']
         host_path = self.tmpdir
+        environment.set_selinux_context(host_path, "svirt_sandbox_file_t")
         vols = ['--volume="%s:%s"' % (host_path, cntr_path)]
         fqin = [DockerImage.full_name_from_defaults(self.config)]
         for _ in range(num_containers):


### PR DESCRIPTION
Docker --volumes requires 'svirt_sandbox_file_t' context. This patch
adds function set_selinux_context and uses it everywhere we create
shared directories with container.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
