### PR TITLE
subtests.docker_cli.wait: Make it deterministic

### DIFF
--- a/config_defaults/subtests/docker_cli/wait.ini
+++ b/config_defaults/subtests/docker_cli/wait.ini
@@ -6,6 +6,7 @@ exec_cmd_cont0 = sleep 10; exit 1
 exec_cmd_cont1 = exit 2
 exec_cmd_cont2 = exit 3
 use_names = RANDOM
+# random_seed - can be set to override the initial random seed used in test
 # wait_for - which containers we should wait for. Either use index of the
 #            the container, or '_' + string. The leading char will be removed!
 subsubtests = no_wait,wait_first,wait_last,wait_missing

--- a/index.rst
+++ b/index.rst
@@ -950,6 +950,8 @@ Several variations of running the restart command
    This command has to contain ``exit $NUM``, which is used as docker exit
    status and could contain ``sleep $NUM`` which signals the duration after
    which the container finishes.
+*  ``use_names`` - translate ids to names [IDS, NAMES, RANDOM]
+*  ``random_seed`` - overrides the initial random seed used in test
 *  The ``wait_for`` specifies the containers the wait command should wait for.
    Use index of ``containers`` or ``_$your_string``. In the second
    case the leading character ``_`` will be removed.

--- a/subtests/docker_cli/wait/wait.py
+++ b/subtests/docker_cli/wait/wait.py
@@ -92,15 +92,24 @@ class wait_base(SubSubtest):
                                           [cont_id])
         cont['test_cmd_stdin'] = cmd
 
-    def init_use_names(self, use_names=False):
-        if use_names:
+    def init_use_names(self, use_names='IDS'):
+        if use_names == 'IDS':  # IDs are already set
+            return
+        else:
+            if use_names == 'RANDOM':    # log the current seed
+                if self.config.get("random_seed"):
+                    rand = self.config.get("random_seed")
+                else:
+                    rand = random.random()
+                self.loginfo("Using random seed: %s", rand)
+                rand = random.Random(rand)
             conts = self.sub_stuff['containers']
             containers = DockerContainers(self.parent_subtest)
             containers = containers.list_containers()
             cont_ids = [cont['id'] for cont in conts]
             for cont in containers:
                 if cont.long_id in cont_ids:
-                    if use_names is not True and random.choice((True, False)):
+                    if use_names == 'RANDOM' and rand.choice((True, False)):
                         continue    # 50% chance of using id vs. name
                     # replace the id with name
                     cont_idx = cont_ids.index(cont.long_id)


### PR DESCRIPTION
Fixes https://github.com/autotest/autotest-docker/issues/120

This patch modifies the config to by default use names only in
one subtests. All other subtests use ids. This way we have
deterministic behavior while still testing booth ways.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>