### PR TITLE
pep8 for commit, invalid, psa, rmi, and tag tets

### DIFF
--- a/subtests/docker_cli/commit/check_default_cmd.py
+++ b/subtests/docker_cli/commit/check_default_cmd.py
@@ -25,7 +25,7 @@ class check_default_cmd(commit_base):
     config_section = 'docker_cli/commit/check_default_cmd'
 
     def postprocess(self):
-        super(commit_base, self).postprocess()
+        self.loginfo("postprocess()")
         # Raise exception if problems found
         OutputGood(self.sub_stuff['cmdresult'])
         self.failif(self.sub_stuff['cmdresult'].exit_status != 0,

--- a/subtests/docker_cli/invalid/invalid.py
+++ b/subtests/docker_cli/invalid/invalid.py
@@ -56,7 +56,8 @@ class invalid_base(subtest.SubSubtest):
         self.sub_stuff['arg_inpars'] = arg_inpars
         self.sub_stuff['arg_invals'] = arg_invals
 
-    def array_args(self, section, conf_arg, arg1, arg2):
+    @staticmethod
+    def array_args(section, conf_arg, arg1, arg2):
         args = []
         if section == 'option':
             args = conf_arg + arg1 + arg2

--- a/subtests/docker_cli/psa/psa.py
+++ b/subtests/docker_cli/psa/psa.py
@@ -127,7 +127,7 @@ class psa(subtest.Subtest):
     def cleanup(self):
         super(psa, self).cleanup()
         cid = self.stuff.get('container_id')
-        if ((self.config['remove_after_test']) and (cid is not None)):
+        if self.config['remove_after_test'] and cid is not None:
             self.logdebug("Cleaning container %s", cid)
             # We need to know about this breaking anyway, let it raise!
             nfdc = NoFailDockerCmd(self, "rm", ['--force',

--- a/subtests/docker_cli/rmi/delete_wrong_name.py
+++ b/subtests/docker_cli/rmi/delete_wrong_name.py
@@ -37,7 +37,7 @@ class delete_wrong_name(rmi_base):
         # Private to this instance, outside of __init__
 
     def postprocess(self):
-        super(rmi_base, self).postprocess()
+        super(delete_wrong_name, self).postprocess()
         # Raise exception if problems found
         OutputGood(self.sub_stuff['cmdresult'], ignore_error=True)
         if self.config["docker_expected_result"] == "FAIL":

--- a/subtests/docker_cli/tag/tag.py
+++ b/subtests/docker_cli/tag/tag.py
@@ -137,11 +137,12 @@ class change_tag(tag_base):
 
     def generate_special_name(self):
         img = self.sub_stuff['image_list'][0]
-        tag = "%s_%s" % (img.tag, utils.generate_random_string(8))
+        _tag = "%s_%s" % (img.tag, utils.generate_random_string(8))
         repo = img.repo
         registry = img.repo_addr
         registry_user = img.user
-        new_img_name = DockerImage.full_name_from_component(repo, tag,
+        new_img_name = DockerImage.full_name_from_component(repo,
+                                                            _tag,
                                                             registry,
                                                             registry_user)
         return new_img_name


### PR DESCRIPTION
Signed-off-by: James Molet jmolet@redhat.com

run_pylint.sh clean for: 

 subtests/docker_cli/commit/check_default_cmd.py
 subtests/docker_cli/invalid/invalid.py
 subtests/docker_cli/psa/psa.py
 subtests/docker_cli/rmi/delete_wrong_name.py
 subtests/docker_cli/tag/tag.py
