### PR TITLE
subtests.docker_cli: Add detach and interaction test

### DIFF
--- a/config_defaults/subtests/docker_cli/detach.ini
+++ b/config_defaults/subtests/docker_cli/detach.ini
@@ -1,0 +1,20 @@
+[docker_cli/detach]
+remove_after_test = yes
+subsubtests = basic,stress,multi_session
+container_options_csv = --interactive
+container_name_prefix = test
+container_tty = --tty
+container_command = bash
+
+[docker_cli/detach/basic]
+
+[docker_cli/detach/stress]
+# TODO: BUG: When sleep is removed, change this to 100
+no_iterations = 3
+session_log = STORE
+
+
+[docker_cli/detach/multi_session]
+# TODO: BUG: When sleep is removed, change this to 100
+no_iterations = 3
+session_log = STORE

--- a/config_defaults/subtests/docker_cli/interaction.ini
+++ b/config_defaults/subtests/docker_cli/interaction.ini
@@ -1,0 +1,24 @@
+[docker_cli/interaction]
+remove_after_test = yes
+subsubtests = interactive_tty,interactive_nontty,attached_tty,attached_nontty
+# TODO: Move some of these arguments to default_config.ini
+container_command = bash
+session_attached = no
+
+[docker_cli/interaction/interactive_tty]
+container_options_csv = --interactive,--tty
+is_tty = yes
+
+[docker_cli/interaction/interactive_nontty]
+container_options_csv = --interactive
+is_tty = no
+
+[docker_cli/interaction/attached_tty]
+container_options_csv = --interactive,--tty=true
+is_tty = yes
+session_attached = yes
+
+[docker_cli/interaction/attached_nontty]
+container_options_csv = --interactive,--tty=0
+is_tty = no
+session_attached = yes

--- a/dockertest/containers.py
+++ b/dockertest/containers.py
@@ -70,6 +70,12 @@ class DockerContainer(object):  # pylint: disable=R0902
 
         :param other: An instance of this class (or subclass) for comparison.
         """
+        if isinstance(other, str):      # Compare valid identifiers
+            if (self.image_name == other or self.long_id == other or
+                self.long_id[:12] == other):
+                return True
+            else:
+                return False
         self_val = [getattr(self, name) for name in self.__slots__]
         other_val = [getattr(other, name) for name in self.__slots__]
         for _self, _other in zip(self_val, other_val):

--- a/dockertest/dockercmd.py
+++ b/dockertest/dockercmd.py
@@ -5,8 +5,8 @@ Frequently used docker CLI operations/data
 
 # Pylint runs from a different directory, it's fine to import this way
 # pylint: disable=W0403
-
 import time
+
 from autotest.client import utils
 from subtest import SubBase
 from xceptions import (DockerNotImplementedError,
@@ -476,3 +476,10 @@ class AsyncDockerCmd(DockerCmdBase):
             # Current elapsed time
             duration = time.time() - self._async_job.start_time
         return duration
+
+    def kill(self, sig=9):
+        """
+        Sends signal to the process
+        :param sig: Which signal to send [9]
+        """
+        return self._async_job.sp.send_signal(sig)

--- a/subtests/docker_cli/detach/detach.py
+++ b/subtests/docker_cli/detach/detach.py
@@ -1,0 +1,494 @@
+"""
+Tests the ctrl+p ctrl+q detach method
+"""
+# Okay to be less-strict for these cautions/warnings in subtests
+# pylint: disable=C0103,C0111,R0904,C0103
+import time
+
+from autotest.client.shared import utils
+import dexpect
+from dockertest import config, subtest, xceptions
+from dockertest.containers import DockerContainers
+from dockertest.dockercmd import DockerCmdBase, AsyncDockerCmd
+from dockertest.dockercmd import NoFailDockerCmd
+from dockertest.images import DockerImage
+import os
+
+
+def not_equal(self, first, second, iteration, msg):
+    self.failif(first != second, msg + "(%s != %s, iteration %s"
+                % (first, second, iteration))
+
+
+def session_responsive(session, timeout=5, internal_timeout=1):
+    """
+    Sends `true` command and queues for output. When output obtained => True
+    :warning: Don't set internal_timeout too low unless stressed machine
+              might not response quickly enough.
+    """
+    end_time = time.time() + timeout
+    while time.time() < end_time:
+        try:
+            session.cmd_status("true", internal_timeout)
+            out = session.read_nonblocking(2)
+            if out:
+                raise Exception("This shouldn't happened; out:\n%s" % out)
+            return True
+        except dexpect.ShellError:
+            pass
+    try:    # +1 iteration in case we missed end_time of milliseconds...
+        session.cmd_status("true", internal_timeout)
+        out = session.read_nonblocking(2)
+        if out:
+            raise Exception("This shouldn't happened; out:\n%s" % out)
+        return True
+    except dexpect.ShellError:
+        pass
+    return False
+
+
+class LogMe(object):
+
+    """
+    This class stores the provided function and calls it when __str__ is used
+    """
+
+    def __init__(self, func):
+        self.func = func
+
+    def __str__(self):
+        return self.func()
+
+
+class InteractiveAsyncDockerCmd(AsyncDockerCmd):
+
+    """
+    Execute docker command as asynchronous background process on ``execute()``
+    with PIPE as stdin and allows use of stdin(data) to interact with process.
+    """
+
+    def __init__(self, subtest, subcmd, subargs=None, timeout=None,
+                 verbose=True):
+        super(InteractiveAsyncDockerCmd, self).__init__(subtest, subcmd,
+                                                        subargs, timeout,
+                                                        verbose)
+        self._stdin = None
+        self._stdout_idx = 0
+
+    def execute(self, stdin=None):
+        """
+        Start execution of asynchronous docker command
+        """
+        self.close()
+        ps_stdin, self._stdin = os.pipe()
+        ret = super(InteractiveAsyncDockerCmd, self).execute(ps_stdin)
+        os.close(ps_stdin)
+        if stdin:
+            self.stdin(stdin)
+        return ret
+
+    def stdin(self, data):
+        """
+        Sends data to stdin (partial send is possible!)
+        :param data: Data to be send
+        :return: Number of written data
+        """
+        return os.write(self._stdin, data)
+
+    def close(self):
+        """
+        Closes opened file descriptors. Always call this before exit!
+        """
+        if self._stdin is not None:
+            os.close(self._stdin)
+            self._stdin = None
+
+    def __del__(self):
+        super(InteractiveAsyncDockerCmd, self).__del__()
+        self.close()
+
+
+class InteractiveBash(InteractiveAsyncDockerCmd):
+
+    """
+    This test detaches from docker into bash. In order to be able to do this
+    I need to execute bash directly and then using sendline execute container
+    """
+    @property
+    def command(self):
+        return "bash -l"
+
+
+class LogInClenupSubSubtest(subtest.SubSubtest):
+
+    def __init__(self, parent_subtest):
+        super(LogInClenupSubSubtest, self).__init__(parent_subtest)
+        #: Dictionary of stringalizable items, which must be printed during
+        #: cleanup. This is intended for unexpected exceptions.
+        self.log_in_cleanup = {}
+
+    def cleanup(self):
+        super(LogInClenupSubSubtest, self).cleanup()
+        if self.log_in_cleanup:
+            self.logwarning("There are some uncleaned objects left:")
+            for key, value in self.log_in_cleanup.iteritems():
+                self.logwarning("%s: %s" % (key, value))
+
+
+class detach(subtest.SubSubtestCaller):
+
+    """ Subtest caller """
+    pass
+
+
+class detach_base(LogInClenupSubSubtest):
+
+    def initialize(self):
+        """
+        Creates dexpect session with host's bash, than starts container in it
+        and stores host and container hostnames.
+        """
+        super(detach_base, self).initialize()
+        # Prepare a container
+        session_log = self.config.get('session_log')
+        if session_log == 'STORE':
+            self.sub_stuff['session_log'] = dexpect.STORE
+        elif session_log == 'NONE':
+            self.sub_stuff['session_log'] = None
+        else:   # by default log to debug output
+            self.sub_stuff['session_log'] = self.logdebug
+        docker_containers = DockerContainers(self.parent_subtest)
+        prefix = self.config["container_name_prefix"]
+        name = docker_containers.get_unique_name(prefix, length=4)
+        self.sub_stuff['container_name'] = name
+        config.none_if_empty(self.config)
+        subargs = self.config.get('container_options_csv')
+        if subargs:
+            subargs = [arg for arg in subargs.split(',')]
+        else:
+            subargs = []
+        tty = self.config.get('container_tty')
+        if tty:
+            subargs.append(tty)
+        subargs.append("--name %s" % name)
+        fin = DockerImage.full_name_from_defaults(self.config)
+        subargs.append(fin)
+        subargs.append("bash")
+        subargs.append("-c")
+        subargs.append(self.config['container_command'])
+        # full `docker run` command
+        cmd = DockerCmdBase(self.parent_subtest, 'run', subargs).command
+        # interactive bash in AsyncDockerCmd-like object
+        dkrcmd = InteractiveBash(self.parent_subtest, 'dumm', [])
+        dkrcmd.execute()
+        # connect session to dkrcmd (we don't have tty => no echo =>
+        # is_responsive() fails. session.cmd() works fine
+        session = dexpect.ShellSession(dkrcmd, name=name, tty=False,
+                                       log_func=self.sub_stuff['session_log'])
+        if self.sub_stuff['session_log'] == dexpect.STORE:
+            _ = session.get_log_records
+            self.log_in_cleanup['session1_log'] = LogMe(_)
+        self.failif(not session_responsive(session), "Session not responsive "
+                    "after returning from container to bash.")
+        self.sub_stuff['host_hostname'] = session.cmd("echo $HOSTNAME",
+                                                      timeout=10)
+        # After this command container should be in the foreground
+        session.sendline(cmd)
+        # TODO: FIXME: Adjust this to the latest version before the merge
+        if not tty or 'false' in str(tty).lower():
+            self.sub_stuff['container_is_tty'] = False
+            session.set_tty(False, 0)
+        else:
+            self.sub_stuff['container_is_tty'] = True
+            session.set_tty(True, 0)
+        self.failif(not session_responsive(session), "Container not "
+                    "initialized in 5s.")
+        self.sub_stuff['session'] = session
+        self.sub_stuff['attach_cmd'] = DockerCmdBase(self.parent_subtest,
+                                                     'attach', [name]).command
+        self.sub_stuff['container_hostname'] = session.cmd("echo $HOSTNAME",
+                                                           timeout=10)
+        if (self.sub_stuff['host_hostname']
+                == self.sub_stuff['container_hostname']):
+            msg = ("Hostname of host and container seems to be the same. "
+                   "Either container didn't started or your host uses the "
+                   "same name '%s'" % self.sub_stuff['host_hostname'])
+            raise xceptions.DockerTestNAError(msg)
+
+    def postprocess(self):
+        """
+        When everything went correctly, remove last log records.
+        """
+        super(detach_base, self).postprocess()
+        # All sessions are already closed, remove them from log_in_cleanup
+        for name in ('session1_log', 'session2_log'):
+            if name in self.log_in_cleanup:
+                del self.log_in_cleanup[name]
+
+    def cleanup(self):
+        """
+        Close all sessions and remove the container
+        """
+        super(detach_base, self).cleanup()
+        # Stop session
+        for name in ('session', 'session2'):
+            session = self.sub_stuff.get(name)
+            if session and session.is_alive():
+                session.terminate()
+        # Remove container
+        if self.sub_stuff.get('container_name') is None:
+            return  # Docker was not created, we are clean
+        containers = DockerContainers(self.parent_subtest)
+        name = self.sub_stuff['container_name']
+        conts = containers.list_containers_with_name(name)
+        if conts == []:
+            return  # Docker was created, but apparently doesn't exist, clean
+        elif len(conts) > 1:
+            msg = ("Multiple containers matches name %s, not removing any of "
+                   "them...", name)
+            raise xceptions.DockerTestError(msg)
+        NoFailDockerCmd(self.parent_subtest, 'rm', ['--force', '--volumes',
+                                                    name]).execute()
+
+
+class basic(detach_base):
+
+    """
+    1) Create bash session
+    2) Start interactive docker container inside
+    3) Start ping 127.0.0.1 inside the container
+    4) Detach using ctrl+p ctrl+q
+    5) Attach using docker attach $name
+    6) Detach using ctrl+p ctrl+q
+    7) Attach again using docker attach $name
+    8) Stop ping (ctrl+c), execute true inside container
+    9) stop container (ctrl+d) and execute true inside host
+    """
+
+    def run_once(self):
+        super(basic, self).run_once()
+        session = self.sub_stuff['session']
+
+        self.loginfo("Initiating ping process...")
+        session.sendline('ping 127.0.0.1')
+        self.failif(not session.read_nonblocking(2), "No output after ping "
+                    "command execution.")
+        self.failif(not session.read_nonblocking(2), "No new output 2s "
+                    "after ping command execution")
+
+        self.loginfo("Detaching...")
+        session.send_control('p')
+        time.sleep(1)       # FIXME: Workaround the known problem
+        session.send_control('q')
+        time.sleep(1)       # FIXME: Workaround the known problem
+        session.set_tty(False, 0)    # we should be in bash (no echo, no tty)
+        self.failif(not session_responsive(session), "Session not responsive "
+                    "after returning from container to bash.")
+        not_equal(self, session.cmd("echo $HOSTNAME", timeout=10),
+                  self.sub_stuff['host_hostname'], "NONE", "Hostname mismatch,"
+                  " docker detach probably failed.")
+        session.read_nonblocking()  # read-out everything
+        out = session.read_nonblocking(2)
+        self.failif(out, "Unexpected output in underlying bash after "
+                    "detaching the container:\n%s" % out)
+
+        self.loginfo("Attaching...")
+        session.sendline(self.sub_stuff['attach_cmd'])
+        session.read_nonblocking()  # read-out everything
+        session.set_tty(self.sub_stuff['container_is_tty'], 5)
+        self.failif(not session.read_nonblocking(2), "No new output 2s "
+                    "after re-attaching the container")
+
+        self.loginfo("Detaching from attached docker...")
+        session.send_control('p')
+        time.sleep(1)       # FIXME: Workaround the known problem
+        session.send_control('q')
+        time.sleep(1)       # FIXME: Workaround the known problem
+        session.set_tty(False, 0)    # we should be in bash (no echo, no tty)
+        self.failif(not session_responsive(session), "Session not responsive "
+                    "after returning from container to bash.")
+        not_equal(self, session.cmd("echo $HOSTNAME", timeout=10),
+                  self.sub_stuff['host_hostname'], "NONE", "Hostname mismatch,"
+                  " docker detach probably failed.")
+        session.read_nonblocking()  # read-out everything
+        out = session.read_nonblocking(2)
+        self.failif(out, "Unexpected output in underlying bash after "
+                    "detaching the attached container:\n%s" % out)
+
+        self.loginfo("Attaching for the second time...")
+        session.sendline(self.sub_stuff['attach_cmd'])
+        session.read_nonblocking()  # read-out everything
+        session.set_tty(self.sub_stuff['container_is_tty'], 5)
+        self.failif(not session.read_nonblocking(2), "No new output 2s "
+                    "after re-attaching the container")
+
+        self.loginfo("Stopping the ping process...")
+        session.send_control('c')
+        session.read_up_to_prompt(5)
+        out = session.read_nonblocking(2)
+        self.failif(out, "Unexpected output after killing the ping process "
+                    "by ctrl+c\n%s" % out)
+
+        self.loginfo("Verifying container response...")
+        not_equal(self, session.cmd("echo $HOSTNAME", timeout=10),
+                  self.sub_stuff['container_hostname'], "NONE", "Hostname "
+                  "mismatch, docker detach probably failed.")
+        session.send_control('d')   # exit the container
+        session.set_tty(False, 0)    # we should be in bash (no echo, no tty)
+        self.failif(not session_responsive(session), "Session not responsive "
+                    "after returning from container to bash.")
+        self.loginfo("Verifying host response...")
+        not_equal(self, session.cmd("echo $HOSTNAME", timeout=10),
+                  self.sub_stuff['host_hostname'], "NONE", "Hostname mismatch,"
+                  " docker detach probably failed.")
+        # exit session
+        session.send_control('d')
+
+
+class stress(detach_base):
+
+    """
+    1) Dettach from docker
+    2) Attach to docker
+    3) GOTO 1 (unless no_iteration is reached)
+    """
+
+    def run_once(self):
+        super(stress, self).run_once()
+        session = self.sub_stuff['session']
+        no_iterations = self.config['no_iterations']
+        self.log_in_cleanup['session1_log'] = LogMe(session.get_log_records)
+        session.set_logging(dexpect.STORE)
+        self.loginfo("Starting %s iterations of detach/check/attach/check..."
+                     % no_iterations)
+        for i in xrange(no_iterations):
+            # Detaching...
+            session.send_control('p')
+            time.sleep(1)       # FIXME: Workaround the known problem
+            session.send_control('q')
+            time.sleep(1)       # FIXME: Workaround the known problem
+            session.set_tty(False, 0)  # we should be in bash (no echo, no tty)
+            self.failif(not session_responsive(session), "Session not "
+                        "responsive after returning from container to bash.")
+            not_equal(self, session.cmd("echo $HOSTNAME", timeout=10),
+                      self.sub_stuff['host_hostname'], i, "Hostname mismatch, "
+                      " docker detach probably failed.")
+
+            # Attaching...
+            session.sendline(self.sub_stuff['attach_cmd'])
+            session.set_tty(self.sub_stuff['container_is_tty'], 5)
+            not_equal(self, session.cmd("echo $HOSTNAME", timeout=10),
+                      self.sub_stuff['container_hostname'], i, "Hostname "
+                      "mismatch, docker attach probably failed.")
+            session.set_logging(dexpect.STORE)  # log only last iteration
+
+        self.loginfo("%s iterations passed, stopping the container...",
+                     no_iterations)
+        session.set_logging(self.sub_stuff['session_log'])  # Use default logs
+        if self.sub_stuff['session_log'] == dexpect.STORE:
+            self.log_in_cleanup['session1_log'] = session.get_log_records
+        session.send_control('d')   # exit the container
+        session.set_tty(False, 0)    # we should be in bash (no echo, no tty)
+        self.failif(not session_responsive(session), "Session not responsive "
+                    "after returning from container to bash.")
+        self.loginfo("Verifying host response...")
+        session.sendline()
+        session.read_up_to_prompt(10)
+        not_equal(self, session.cmd("echo $HOSTNAME", timeout=10),
+                  self.sub_stuff['host_hostname'], "<after>", "Hostname "
+                  "mismatch, docker probably didn't finish.")
+        # exit session
+        session.send_control('d')
+
+
+class multi_session(detach_base):
+
+    """
+    1) Create another session
+    2) session1 -> start writing command
+    3) session2 -> add part of the command and detach
+    4) session1 -> add part of the command
+    5) session2 -> reattach and add last part of the command
+    6) session1 -> execute the command
+    7) GOTO 2 (unless no_iteration is reached)
+    """
+
+    def initialize(self):
+        super(multi_session, self).initialize()
+        dkrcmd = InteractiveBash(self.parent_subtest, 'dumm', [])
+        dkrcmd.execute()
+        # connect session to dkrcmd (we don't have tty => no echo =>
+        # is_responsive() fails. session.cmd() works fine
+        name = "%s-2" % self.sub_stuff['container_name']
+        session2 = dexpect.ShellSession(dkrcmd, name=name, tty=False,
+                                        log_func=self.sub_stuff['session_log'])
+        if self.sub_stuff['session_log'] == dexpect.STORE:
+            _ = session2.get_log_records
+            self.log_in_cleanup['session2_log'] = LogMe(_)
+        self.sub_stuff['session2'] = session2
+        session2.sendline(self.sub_stuff['attach_cmd'])
+        session2.set_tty(self.sub_stuff['container_is_tty'], 5)
+        not_equal(self, session2.cmd("echo $HOSTNAME", timeout=10),
+                  self.sub_stuff['container_hostname'], "<before>", "Hostname "
+                  "mismatch, docker attach probably failed.")
+
+    def run_once(self):
+        super(multi_session, self).run_once()
+        session1 = self.sub_stuff['session']
+        session2 = self.sub_stuff['session2']
+
+        no_iterations = self.config['no_iterations']
+        self.loginfo("Starting %s iterations of multi_session test..."
+                     % no_iterations)
+        for i in xrange(no_iterations):
+            # Detaching...
+            rand1, rand2, rand3 = (utils.generate_random_string(4)
+                                   for _ in xrange(3))
+            session1.send('echo ')
+            session1.read_until_output_matches([r'.*echo $'], timeout=5)
+            session2.send(rand1)
+            session2.read_until_output_matches([r'.*%s$' % rand1], timeout=5)
+            time.sleep(1)       # FIXME: Workaround the known problem
+            session2.send_control('p')
+            time.sleep(1)       # FIXME: Workaround the known problem
+            session2.send_control('q')
+            time.sleep(1)       # FIXME: Workaround the known problem
+            # No interaction in detached session should affect container
+            session2.set_tty(False, 0)    # we should be in bash (no echo, no tty)
+            self.failif(not session_responsive(session2), "Session not "
+                        "responsive after returning from container to bash.")
+            not_equal(self, session2.cmd("echo $HOSTNAME", timeout=10),
+                      self.sub_stuff['host_hostname'], i, "Hostname mismatch, "
+                      " docker detach probably failed.")
+            session1.send(rand2)
+            session1.read_until_output_matches([r'.*%s$' % rand2], timeout=5)
+            # Attaching...
+            session2.sendline(self.sub_stuff['attach_cmd'])
+            session2.send(rand3)
+            session2.read_until_output_matches([r'.*%s$' % rand3], timeout=5)
+            out = session1.cmd('')  # Command is already written, use '\n'
+            not_equal(self, out.strip(), rand1 + rand2 + rand3, i, "echo "
+                      "$RANDOM output mismatch.")
+            session1.set_logging(dexpect.STORE)  # log only last iteration
+            session2.set_logging(dexpect.STORE)  # log only last iteration
+
+        self.loginfo("%s iterations passed, stopping the container...",
+                     no_iterations)
+        session1.set_logging(self.sub_stuff['session_log'])  # Use default logs
+        session2.set_logging(self.sub_stuff['session_log'])
+        self.loginfo("Verifying host response...")
+        session1.send_control('d')   # exit the container
+        # Now container should finish and booth sessions should be in host bash
+        for session in (session1, session2):
+            session.set_tty(False, 0)  # we should be in bash (no echo, no tty)
+            self.failif(not session_responsive(session), "Session not "
+                        "responsive after returning from container to bash.")
+            not_equal(self, session.cmd("echo $HOSTNAME", timeout=10),
+                      self.sub_stuff['host_hostname'], "<after>", "Hostname "
+                      "mismatch, docker probably didn't finish. (%s)"
+                      % (session.name))
+            # exit session
+            session.send_control('d')
+            not_alive = lambda: not session.is_alive
+            self.failif(utils.wait_for(not_alive, 5, step=0.1),
+                        "Session is alive even thought we used ctrl+d")

--- a/subtests/docker_cli/detach/dexpect.py
+++ b/subtests/docker_cli/detach/dexpect.py
@@ -1,0 +1,798 @@
+"""
+This module implements pexpect-alike objects to interact with terminal.
+It's simplified and tailored to execute simple bash and interact primarily
+with `docker`.
+
+:copyright: 2014 Red Hat Inc.
+"""
+import random
+import re
+import select
+import signal
+import string
+import subprocess
+import time
+
+
+STORE = -1
+
+
+class ExpectError(Exception):
+
+    """
+    General Expect exception
+    """
+
+    def __init__(self, patterns, output):
+        Exception.__init__(self, patterns, output)
+        self.patterns = patterns
+        self.output = output
+
+    def _pattern_str(self):
+        """ Format the pattern output nicely """
+        if len(self.patterns) == 1:
+            return "pattern %r" % self.patterns[0]
+        else:
+            return "patterns %r" % self.patterns
+
+    def __str__(self):
+        return ("Unknown error occurred while looking for %s    (output: %r)" %
+                (self._pattern_str(), self.output))
+
+
+class ExpectTimeoutError(ExpectError):
+
+    """
+    Expect timed out
+    """
+
+    def __str__(self):
+        return ("Timeout expired while looking for %s    (output: %r)" %
+                (self._pattern_str(), self.output))
+
+
+class ExpectProcessTerminatedError(ExpectError):
+
+    """
+    Process terminated
+    """
+
+    def __init__(self, patterns, status, output):
+        ExpectError.__init__(self, patterns, output)
+        self.status = status
+
+    def __str__(self):
+        return ("Process terminated while looking for %s    "
+                "(status: %s,    output: %r)" % (self._pattern_str(),
+                                                 self.status, self.output))
+
+
+class ShellError(Exception):
+
+    """
+    General shell exception
+    """
+
+    def __init__(self, cmd, output):
+        Exception.__init__(self, cmd, output)
+        self.cmd = cmd
+        self.output = output
+
+    def __str__(self):
+        return ("Could not execute shell command %r    (output: %r)" %
+                (self.cmd, self.output))
+
+
+class ShellTimeoutError(ShellError):
+
+    """
+    Shell timed out
+    """
+
+    def __str__(self):
+        return ("Timeout expired while waiting for shell command to "
+                "complete: %r    (output: %r)" % (self.cmd, self.output))
+
+
+class ShellProcessTerminatedError(ShellError):
+
+    """
+    Raised when the shell process itself (e.g. bash) terminates unexpectedly
+    """
+
+    def __init__(self, cmd, status, output):
+        ShellError.__init__(self, cmd, output)
+        self.status = status
+
+    def __str__(self):
+        return ("Shell process terminated while waiting for command to "
+                "complete: %r    (status: %s,    output: %r)" %
+                (self.cmd, self.status, self.output))
+
+
+class ShellCmdError(ShellError):
+
+    """
+    Raised when a command executed in a shell terminates with a nonzero
+    exit code (status)
+    """
+
+    def __init__(self, cmd, status, output):
+        ShellError.__init__(self, cmd, output)
+        self.status = status
+
+    def __str__(self):
+        return ("Shell command failed: %r    (status: %s,    output: %r)" %
+                (self.cmd, self.status, self.output))
+
+
+class ShellStatusError(ShellError):
+
+    """
+    Raised when the command's exit status cannot be obtained
+    """
+
+    def __str__(self):
+        return ("Could not get exit status of command: %r    (output: %r)" %
+                (self.cmd, self.output))
+
+
+def safe_execute(cmd, timeout=5):
+    """
+    This function executes process inside shell and waits for finish
+    :param timeout: Maximal execution time before interruption
+    :raise ShellTimeoutError: When process doesn't finish on time
+    :raise ShellCmdError: When exit status is not 0
+    :return: standard output (without stderr)
+    """
+    proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
+    for _ in xrange(timeout * 10):
+        if proc.poll() is not None:
+            break
+        time.sleep(0.1)
+    else:
+        proc.terminate()
+        proc.kill()
+        raise ShellTimeoutError(cmd, "STDOUT:\n%s\nSTDERR:\n%s"
+                                % (proc.stdout.read(), proc.stderr.read()))
+    if proc.poll() != 0:
+        raise ShellCmdError(cmd, proc.poll(), "STDOUT:\n%s\nSTDERR:\n%s"
+                            % (proc.stdout.read(), proc.stderr.read()))
+    return proc.stdout.read()
+
+
+def generate_random_string(length):
+    """
+    Return a random string using alphanumeric characters.
+
+    :param length: Length of the string that will be generated.
+    :return: The generated random string.
+    """
+    chars = string.letters + string.digits
+    return "".join((random.choice(chars) for _ in xrange(length)))
+
+
+class Expect(object):
+
+    """
+    This class runs a child process in the background and provides expect-like
+    services.
+
+    :param command: Executed command (bash -i, docker attach $name, ...)
+    :param linesep: line separator ('\n', '\r\n', ...)
+    :param name: name of this session (used in logging)
+    :param log_func: logging function (file.write, logging.debug, ...)
+    :warning: This class is not pickable.
+    :warning: It is not 100% compatible with aexpect, nor pexpect
+    """
+
+    def __init__(self, process, linesep='\n', name=None,
+                 log_func=None):
+        self.process = process
+        self._stdout_idx = 0
+        self.linesep = linesep
+        self.name = name if name else ""
+        self._log = None
+        self._log_records = None
+        self.set_logging(log_func)
+        self.time_start = time.time()
+
+    def __del__(self):
+        """
+        Clean up before the object is removed.
+        """
+        self.terminate()
+
+    def terminate(self, timeout=0):
+        """
+        Terminates the managed process (-15 eventually followed by -9)
+        """
+        try:
+            self.process.wait(timeout)
+        except AssertionError:  # already dead
+            pass
+
+    def set_logging(self, log_func=None):
+        """
+        Sets logging function (when log_func is None, disable auto-logging)
+        """
+        self._log_records = None
+        if not log_func:    # non-verbose
+            self._log = None
+        elif log_func == STORE:
+            self._log_records = []
+            # _log has to be a function; pylint: disable=W0108
+            self._log = lambda msg: self._log_records.append(msg)
+            # pylint: enable=W0108
+        else:
+            assert hasattr(log_func, '__call__'), ("logging function has to be"
+                                                   " a function (%s)"
+                                                   % type(log_func))
+            self._log = log_func
+
+    def log(self, prefix, data):
+        """
+        Logs to self._log using following format "$prefix$name: $data"
+        :param prefix: Prefix ('>>', '<<', ...)
+        :param data: Data to write.
+        """
+        if not self._log:    # Logging disabled
+            return
+        else:
+            for line in data.splitlines(True):
+                self._log("%s%s: %r" % (prefix, self.name, line))
+
+    def get_log_records(self):
+        """
+        When STORE function for logging is used, this returns the stored
+        messages.
+        :return: all stored messages or None
+        """
+        if isinstance(self._log_records, list):
+            return "\n".join(self._log_records)
+        else:
+            return "Log not stored, use session.set_logging(dexpect.STORE)"
+
+    def get_pid(self):
+        """
+        Returns pid of the main command.
+        :warning: This pid might not be the current foreground process!
+        """
+        return self.process.process_id
+
+    @staticmethod
+    def get_custom_children_pids(ppid=None, line_filter=None):
+        """
+        Returns childrens of specified parent pid, useful when you execute
+        multiple processes inside the main process (eg. docker inside bash)
+        :param ppid: parent pid
+        :param line_filter: Function called on the splitted line (len=2)
+        :return: list of tuples [($PID, $CMD), ...]
+        """
+        try:
+            out = safe_execute("ps --ppid %s -o pid,cmd -h" % ppid)
+        except ShellCmdError:   # No pids
+            return []
+        pids = []
+        for line in out.splitlines():
+            line = tuple(_.strip() for _ in line.strip().split(" ", 1))
+            if len(line) != 2:
+                raise ValueError("Fail to parse pid/name from output: %s"
+                                 % out)
+            if not line_filter or line_filter(line):
+                pids.append(line)
+        return pids
+
+    def get_children_pids(self, line_filter=None):
+        """
+        Returns list of all children pids and process names.
+        """
+        return self.get_custom_children_pids(self.get_pid(), line_filter)
+
+    def is_alive(self):
+        """
+        True when the main process is alive
+        """
+        return not self.process.done
+
+    def get_status(self):
+        """
+        Return exit status or None if process has not ended
+        """
+        return self.process.exit_status
+
+    def send(self, data):
+        """
+        Sends data to the process
+        :param data: string
+        """
+        self.log(">>", data)
+        self.process.stdin(data)
+        # Old method preserved in case we need to roll back
+        # while data:
+        #     written = self.process.stdin(data)
+        #     data = data[written:]
+        # Probably not needed, re-enable in case of weird failures
+        # termios.tcflush(self._pty, termios.TCIOFLUSH)
+        # termios.tcdrain(self._pty)
+
+    def sendline(self, data=''):
+        """
+        Sends data + EOL to the process
+        :param data: string
+        """
+        self.send(data + self.linesep)
+
+    def send_control(self, char):
+        """
+        This sends a control character to the child such as Ctrl-C or
+        Ctrl-D. For example, to send a Ctrl-G (ASCII 7)::
+        child.sendcontrol('g')
+        :param char: single character you want to send (ctrl+$char)
+        :raise KeyError: When unable to map char to ctrl+comand
+        """
+        char = char.lower()
+        val = ord(char)
+        if val >= 97 and val <= 122:
+            val = val - 97 + 1  # ctrl+a = '\0x01'
+            return self.send(chr(val))
+        mapping = {'@': 0, '`': 0,
+                   '[': 27, '{': 27,
+                   '\\': 28, '|': 28,
+                   ']': 29, '}': 29,
+                   '^': 30, '~': 30,
+                   '_': 31,
+                   '?': 127}
+        # TODO: Usually this works fine, docker ignores ctrl+p,ctrl+q sequence
+        #       without time.sleep(1) no matter what else we do.
+        #            termios.tcflush(self._pty, termios.TCIOFLUSH)
+        #            termios.tcdrain(self._pty)
+        #            termios.tcsendbreak(self._pty, 0)
+        return self.send(chr(mapping[char]))
+
+    def kill(self, sig=signal.SIGKILL):
+        """
+        Sends signal to the main process
+        :param sig: Which signal to send (default: signal.SIGKILL)
+        """
+        return self.process.kill(sig)
+
+    def _poll_stdout(self, timeout):
+        """
+        Polls for new data in stdout
+        :param timeout: How long to wait (None = inf)
+        :return: True = new data available, False = no new data
+        """
+        if timeout is None:
+            end_time = False
+        else:
+            end_time = time.time() + timeout
+        while len(self.process.stdout) <= self._stdout_idx:
+            if end_time and time.time() > end_time:
+                break
+            time.sleep(0.1)
+        else:
+            return True
+        return False
+
+    def _try_read(self, timeout):
+        """
+        Try to read single piece of data
+        :return: Read data
+        """
+        if not self._poll_stdout(timeout):  # No new data
+            return ""
+        out = self.process.stdout
+        _idx = self._stdout_idx
+        self._stdout_idx = len(out)
+        return out[_idx:]
+
+    def read_nonblocking(self, internal_timeout=None, timeout=None):
+        """
+        Non-blocking read of data from the process
+        :param internal_timeout: Maximal wait for single new data to arrive
+        :param timeout: Maximal overall read duration
+        :return: Read data
+        """
+        if internal_timeout is None:
+            internal_timeout = 0.1
+        end_time = None
+        if timeout > 0:
+            end_time = time.time() + timeout
+        data = self._try_read(internal_timeout)
+        while end_time and time.time() < end_time:
+            _data = self._try_read(internal_timeout)
+            if not _data:   # No new data after internal timeout
+                self.log("<<", data)
+                return data
+            data += _data
+        self.log("<<", data)
+        return data
+
+    def read_until_output_matches(self, patterns, filter_func=lambda x: x,
+                                  timeout=60, internal_timeout=None):
+        """
+        Read using read_nonblocking until a match is found using
+        match_patterns, or until timeout expires. Before attempting to search
+        for a match, the data is filtered using the filter_func function
+        provided.
+
+        @brief: Read from child using read_nonblocking until a pattern
+                matches.
+        :param patterns: List of strings (regular expression patterns)
+        :param filter_func: Function to apply to the data read from the child
+                before attempting to match it against the patterns (should take
+                and return a string)
+        :param timeout: The duration (in seconds) to wait until a match is
+                found
+        :param internal_timeout: The timeout to pass to read_nonblocking
+        :return: Tuple containing the match index and the data read so far
+        :raise ExpectTimeoutError: Raised if timeout expires
+        :raise ExpectProcessTerminatedError: Raised if the child process
+                terminates while waiting for output
+        :raise ExpectError: Raised if an unknown error occurs
+        """
+        def match_patterns(cont, patterns):
+            """
+            Match cont against a list of patterns.
+
+            Return the index of the first pattern that matches a substring of
+            cont. None and empty strings in patterns are ignored.
+            If no match is found, return None.
+
+            :param cont: input string
+            :param patterns: List of strings (regular expression patterns).
+            """
+            for i in range(len(patterns)):
+                if not patterns[i]:
+                    continue
+                if re.search(patterns[i], cont):
+                    return i
+        out = ""
+        end_time = time.time() + timeout
+        while True:
+            # Read data from child
+            data = self.read_nonblocking(internal_timeout,
+                                         end_time - time.time())
+            # Look for patterns
+            out += data
+            match = match_patterns(filter_func(out), patterns)
+            if match is not None:
+                return match, out
+            # timeout
+            if end_time and time.time() > end_time:
+                break
+
+        # Check if the child has terminated
+        for _ in xrange(50):
+            if not self.is_alive():
+                raise ExpectProcessTerminatedError(patterns, self.get_status(),
+                                                   out)
+            time.sleep(0.1)
+        raise ExpectError(patterns, out)
+
+    def read_until_last_line_matches(self, patterns, timeout=60,
+                                     internal_timeout=None):
+        """
+        Read using read_nonblocking until the last non-empty line of the output
+        matches one of the patterns (using match_patterns), or until timeout
+        expires. Return a tuple containing the match index (or None if no match
+        was found) and the data read so far.
+
+        @brief: Read using read_nonblocking until the last non-empty line
+                matches a pattern.
+
+        :param patterns: A list of strings (regular expression patterns)
+        :param timeout: The duration (in seconds) to wait until a match is
+                found
+        :param internal_timeout: The timeout to pass to read_nonblocking
+        :return: A tuple containing the match index and the data read so far
+        :raise ExpectTimeoutError: Raised if timeout expires
+        :raise ExpectProcessTerminatedError: Raised if the child process
+                terminates while waiting for output
+        :raise ExpectError: Raised if an unknown error occurs
+        """
+        def get_last_nonempty_line(cont):
+            """ Returns the last non-empty line """
+            nonempty_lines = [l for l in cont.splitlines() if l.strip()]
+            if nonempty_lines:
+                return nonempty_lines[-1]
+            else:
+                return ""
+
+        return self.read_until_output_matches(patterns, get_last_nonempty_line,
+                                              timeout, internal_timeout)
+
+
+class ShellSession(Expect):
+
+    """
+    This class provides all services of Expect.  In addition, it
+    provides command running services, and a utility function to test the
+    process for responsiveness.
+    """
+
+    def __init__(self, process, linesep="\n", prompt=r"[\#\$]\s*$",
+                 status_test_command="echo $?", tty=True, timeout=5,
+                 name=None, log_func=None):
+        """
+        Initialize the class and run command as a child process.
+
+        :param process:
+        :param linesep: Line separator to be appended to strings sent to the
+                child process by sendline().
+        :param prompt: Regular expression describing the shell's prompt line.
+        :param status_test_command: Command to be used for getting the last
+                exit status of commands run inside the shell (used by
+                cmd_status_output() and friends).
+        :param tty: tty mode (True = interactive, False = non-interactive)
+        :param timeout: How long to test responsiveness (set to None when you
+                        spawn many sessions and check the responsiveness later)
+        :param name: name of this session (used in logging)
+        :param log_func: logging function (file.write, logging.debug, ...)
+        """
+        # Init the superclass
+        Expect.__init__(self, process, linesep, name, log_func)
+        # Initialize functions/variables used in code
+        self.prompt = None
+        self.read_up_to_prompt = None
+        self.get_last_status = None
+        self._return_number = None
+        # Remember some attributes
+        self._prompt = prompt
+        self.status_test_command = status_test_command
+        self.set_tty(tty, timeout)
+
+    def set_tty(self, tty, timeout=5):
+        """
+        Sets the tty mode
+        :param tty: True -> normal mode, False -> no echo mode (no prompt)
+        :param timeout: How long to wait until the terminal is responsive
+        :return: whether the terminal is responsive after the change
+        :warning: Unresponsive tty can discard data on the input, DO check
+                  the return status.
+        """
+        if tty:
+            self.prompt = self._prompt
+            self.read_up_to_prompt = self.read_up_to_prompt_tty
+            self.get_last_status = self.get_last_status_tty
+        else:
+            self.prompt = ""
+            self.read_up_to_prompt = self.read_up_to_prompt_nontty
+            self.get_last_status = self.get_last_status_nontty
+        return self.is_responsive(timeout)
+
+    @classmethod
+    def remove_command_echo(cls, cont, cmd):
+        """
+        Remove the sent command when present in the output.
+        :param cont: context/output
+        :param cmd: sent command
+        :return: output without the echoed command
+        """
+        if cont and cont.splitlines()[0] == cmd:
+            cont = "".join(cont.splitlines(True)[1:])
+        return cont
+
+    @classmethod
+    def remove_last_nonempty_line(cls, cont):
+        """
+        Removes the last nonempty line (and all foregoing empty ones)
+        """
+        return "".join(cont.rstrip().splitlines(True)[:-1])
+
+    def is_responsive(self, timeout=5):
+        """
+        Return True if the process responds to STDIN/terminal input.
+
+        Send a newline to the child process (e.g. SSH or Telnet) and read some
+        output using read_nonblocking().
+        If all is OK, some output should be available (e.g. the shell prompt).
+        In that case return True.  Otherwise return False.
+
+        :param timeout: Time duration to wait before the process is considered
+                unresponsive.
+        """
+        # Read all output that's waiting to be read, to make sure the output
+        # we read next is in response to the newline sent
+        self.read_nonblocking(internal_timeout=0, timeout=timeout)
+        # Send a newline
+        self.sendline()
+        # Wait up to timeout seconds for some output from the child
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            time.sleep(0.5)
+            if self.read_nonblocking(0, end_time - time.time()):
+                return True
+        # No output -- report unresponsive
+        return False
+
+    def read_up_to_prompt_tty(self, timeout=60, internal_timeout=None):
+        """
+        Read using read_nonblocking until the last non-empty line of the output
+        matches the prompt regular expression set by set_prompt, or until
+        timeout expires.
+        @brief: Read using read_nonblocking until the last non-empty line
+                matches the prompt.
+
+        :param timeout: The duration (in seconds) to wait until a match is
+                found
+        :param internal_timeout: The timeout to pass to read_nonblocking
+        :return: The data read so far
+        :raise ExpectTimeoutError: Raised if timeout expires
+        :raise ExpectProcessTerminatedError: Raised if the shell process
+                terminates while waiting for output
+        :raise ExpectError: Raised if an unknown error occurs
+        """
+        return self.read_until_last_line_matches([self.prompt], timeout,
+                                                 internal_timeout)[1]
+
+    def read_up_to_prompt_nontty(self, timeout=60, internal_timeout=None):
+        """
+        Executes echo $RANDOM_LINE and waits for it's occurence.
+        :param timeout: The duration (in seconds) to wait until a match is
+        found
+        :param internal_timeout: The timeout to pass to read_nonblocking
+        :return: The data read so far
+        :raise ExpectTimeoutError: Raised if timeout expires
+        :raise ExpectProcessTerminatedError: Raised if the shell process
+        terminates while waiting for output
+        :raise ExpectError: Raised if an unknown error occurs
+        """
+        def get_last_nonempty_line(cont):
+            """ Returns the last non-empty line """
+            nonempty_lines = [l for l in cont.splitlines() if l.strip()]
+            if nonempty_lines:
+                return nonempty_lines[-1]
+            else:
+                return ""
+        prompt = ("--< END OF THE COMMAND %s >--" % generate_random_string(12))
+        cmd = 'RET=$?; echo; echo "$RET %s"' % prompt
+        # 2xecho makes sure it's on the new line
+        self.sendline(cmd)
+        prompt = ["^" + self.prompt + r'(\d*) ' + prompt + "$"]
+        _, out = super(ShellSession,
+                       self).read_until_last_line_matches(prompt, timeout,
+                                                          internal_timeout)
+        self._return_number = int(re.match(prompt[0],
+                                           get_last_nonempty_line(out)
+                                           ).groups()[0])
+        out = re.sub(r'%s\r?\n?' % re.escape(cmd), '', out)
+        return out
+
+    def cmd_output(self, cmd, timeout=60, internal_timeout=None):
+        """
+        Send a command and return its output.
+
+        :param cmd: Command to send (must not contain newline characters)
+        :param timeout: The duration (in seconds) to wait for the prompt to
+                return
+        :param internal_timeout: The timeout to pass to read_nonblocking
+        :return: The output of cmd
+        :raise ShellTimeoutError: Raised if timeout expires
+        :raise ShellProcessTerminatedError: Raised if the shell process
+                terminates while waiting for output
+        :raise ShellError: Raised if an unknown error occurs
+        """
+        # TODO: Do we need logging? eg. if self.verbose: $name: msg
+        # logging.debug("Sending command: %s" % cmd)
+        self.read_nonblocking(0, timeout)
+        self.sendline(cmd)
+        try:
+            out = self.read_up_to_prompt(timeout, internal_timeout)
+        except ExpectError, exc:
+            out = self.remove_command_echo(exc.output, cmd)
+            if isinstance(exc, ExpectTimeoutError):
+                raise ShellTimeoutError(cmd, out)
+            elif isinstance(exc, ExpectProcessTerminatedError):
+                raise ShellProcessTerminatedError(cmd, exc.status, out)
+            else:
+                raise ShellError(cmd, out)
+
+        # Remove the echoed command and the final shell prompt
+        return self.remove_last_nonempty_line(self.remove_command_echo(out,
+                                                                       cmd))
+
+    def get_last_status_tty(self, internal_timeout=None):
+        """
+        Get status output of the last command when in tty mode.
+        :param internal_timeout: Internal timeout of the discovering command
+        :return: exit status (integer)
+        :raise ShellError: When unable to obtain/parse the code
+        """
+        # Send the 'echo $?' (or equivalent) command to get the exit status
+        stat = self.cmd_output(self.status_test_command, 10, internal_timeout)
+        # Get the first line consisting of digits only
+        digit_lines = [_ for _ in stat.splitlines() if _.strip().isdigit()]
+        if digit_lines:
+            return int(digit_lines[0].strip())
+        else:
+            raise ShellError(self.status_test_command, stat)
+
+    def get_last_status_nontty(self, internal_timeout=None):
+        """
+        Get status output of the last command when in non-tty mode
+        :param internal_timeout: Ignored
+        :return: exit status (integer)
+        :warning: This function only works when used after read_up_to_prompt
+                  (eg. when you use all cmd* functions)
+        """
+        return self._return_number
+        del internal_timeout    # unused parameter pylint: disable=W0101
+
+    def cmd_status_output(self, cmd, timeout=60, internal_timeout=None):
+        """
+        Send a command and return its exit status and output.
+
+        :param cmd: Command to send (must not contain newline characters)
+        :param timeout: The duration (in seconds) to wait for the prompt to
+                return
+        :param internal_timeout: The timeout to pass to read_nonblocking
+        :return: A tuple (status, output) where status is the exit status and
+                output is the output of cmd
+        :raise ShellTimeoutError: Raised if timeout expires
+        :raise ShellProcessTerminatedError: Raised if the shell process
+                terminates while waiting for output
+        :raise ShellStatusError: Raised if the exit status cannot be obtained
+        :raise ShellError: Raised if an unknown error occurs
+        """
+        out = self.cmd_output(cmd, timeout, internal_timeout)
+        try:
+            stat = self.get_last_status(internal_timeout)
+        except ShellError:
+            raise ShellStatusError(cmd, out)
+        return stat, out
+
+    def cmd_status(self, cmd, timeout=60, internal_timeout=None):
+        """
+        Send a command and return its exit status.
+
+        :param cmd: Command to send (must not contain newline characters)
+        :param timeout: The duration (in seconds) to wait for the prompt to
+                return
+        :param internal_timeout: The timeout to pass to read_nonblocking
+        :return: The exit status of cmd
+        :raise ShellTimeoutError: Raised if timeout expires
+        :raise ShellProcessTerminatedError: Raised if the shell process
+                terminates while waiting for output
+        :raise ShellStatusError: Raised if the exit status cannot be obtained
+        :raise ShellError: Raised if an unknown error occurs
+        """
+        return self.cmd_status_output(cmd, timeout, internal_timeout)[0]
+
+    def cmd(self, cmd, timeout=60, internal_timeout=None, ok_status=(0,),
+            ignore_all_errors=False):
+        """
+        Send a command and return its output. If the command's exit status is
+        nonzero, raise an exception.
+
+        :param cmd: Command to send (must not contain newline characters)
+        :param timeout: The duration (in seconds) to wait for the prompt to
+                return
+        :param internal_timeout: The timeout to pass to read_nonblocking
+        :param ok_status: do not raise ShellCmdError in case that exit status
+                is one of ok_status. (default is [0,])
+        :param ignore_all_errors: toggles whether or not an exception should be
+                raised  on any error.
+
+        :return: The output of cmd
+        :raise ShellTimeoutError: Raised if timeout expires
+        :raise ShellProcessTerminatedError: Raised if the shell process
+                terminates while waiting for output
+        :raise ShellError: Raised if the exit status cannot be obtained or if
+                an unknown error occurs
+        :raise ShellStatusError: Raised if the exit status cannot be obtained
+        :raise ShellError: Raised if an unknown error occurs
+        :raise ShellCmdError: Raised if the exit status is nonzero
+        """
+        try:
+            s, o = self.cmd_status_output(cmd, timeout, internal_timeout)
+            if s not in ok_status:
+                raise ShellCmdError(cmd, s, o)
+            return o
+        except Exception:
+            if ignore_all_errors:
+                pass
+            else:
+                raise

--- a/subtests/docker_cli/interaction/dexpect.py
+++ b/subtests/docker_cli/interaction/dexpect.py
@@ -1,0 +1,798 @@
+"""
+This module implements pexpect-alike objects to interact with terminal.
+It's simplified and tailored to execute simple bash and interact primarily
+with `docker`.
+
+:copyright: 2014 Red Hat Inc.
+"""
+import random
+import re
+import select
+import signal
+import string
+import subprocess
+import time
+
+
+STORE = -1
+
+
+class ExpectError(Exception):
+
+    """
+    General Expect exception
+    """
+
+    def __init__(self, patterns, output):
+        Exception.__init__(self, patterns, output)
+        self.patterns = patterns
+        self.output = output
+
+    def _pattern_str(self):
+        """ Format the pattern output nicely """
+        if len(self.patterns) == 1:
+            return "pattern %r" % self.patterns[0]
+        else:
+            return "patterns %r" % self.patterns
+
+    def __str__(self):
+        return ("Unknown error occurred while looking for %s    (output: %r)" %
+                (self._pattern_str(), self.output))
+
+
+class ExpectTimeoutError(ExpectError):
+
+    """
+    Expect timed out
+    """
+
+    def __str__(self):
+        return ("Timeout expired while looking for %s    (output: %r)" %
+                (self._pattern_str(), self.output))
+
+
+class ExpectProcessTerminatedError(ExpectError):
+
+    """
+    Process terminated
+    """
+
+    def __init__(self, patterns, status, output):
+        ExpectError.__init__(self, patterns, output)
+        self.status = status
+
+    def __str__(self):
+        return ("Process terminated while looking for %s    "
+                "(status: %s,    output: %r)" % (self._pattern_str(),
+                                                 self.status, self.output))
+
+
+class ShellError(Exception):
+
+    """
+    General shell exception
+    """
+
+    def __init__(self, cmd, output):
+        Exception.__init__(self, cmd, output)
+        self.cmd = cmd
+        self.output = output
+
+    def __str__(self):
+        return ("Could not execute shell command %r    (output: %r)" %
+                (self.cmd, self.output))
+
+
+class ShellTimeoutError(ShellError):
+
+    """
+    Shell timed out
+    """
+
+    def __str__(self):
+        return ("Timeout expired while waiting for shell command to "
+                "complete: %r    (output: %r)" % (self.cmd, self.output))
+
+
+class ShellProcessTerminatedError(ShellError):
+
+    """
+    Raised when the shell process itself (e.g. bash) terminates unexpectedly
+    """
+
+    def __init__(self, cmd, status, output):
+        ShellError.__init__(self, cmd, output)
+        self.status = status
+
+    def __str__(self):
+        return ("Shell process terminated while waiting for command to "
+                "complete: %r    (status: %s,    output: %r)" %
+                (self.cmd, self.status, self.output))
+
+
+class ShellCmdError(ShellError):
+
+    """
+    Raised when a command executed in a shell terminates with a nonzero
+    exit code (status)
+    """
+
+    def __init__(self, cmd, status, output):
+        ShellError.__init__(self, cmd, output)
+        self.status = status
+
+    def __str__(self):
+        return ("Shell command failed: %r    (status: %s,    output: %r)" %
+                (self.cmd, self.status, self.output))
+
+
+class ShellStatusError(ShellError):
+
+    """
+    Raised when the command's exit status cannot be obtained
+    """
+
+    def __str__(self):
+        return ("Could not get exit status of command: %r    (output: %r)" %
+                (self.cmd, self.output))
+
+
+def safe_execute(cmd, timeout=5):
+    """
+    This function executes process inside shell and waits for finish
+    :param timeout: Maximal execution time before interruption
+    :raise ShellTimeoutError: When process doesn't finish on time
+    :raise ShellCmdError: When exit status is not 0
+    :return: standard output (without stderr)
+    """
+    proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
+    for _ in xrange(timeout * 10):
+        if proc.poll() is not None:
+            break
+        time.sleep(0.1)
+    else:
+        proc.terminate()
+        proc.kill()
+        raise ShellTimeoutError(cmd, "STDOUT:\n%s\nSTDERR:\n%s"
+                                % (proc.stdout.read(), proc.stderr.read()))
+    if proc.poll() != 0:
+        raise ShellCmdError(cmd, proc.poll(), "STDOUT:\n%s\nSTDERR:\n%s"
+                            % (proc.stdout.read(), proc.stderr.read()))
+    return proc.stdout.read()
+
+
+def generate_random_string(length):
+    """
+    Return a random string using alphanumeric characters.
+
+    :param length: Length of the string that will be generated.
+    :return: The generated random string.
+    """
+    chars = string.letters + string.digits
+    return "".join((random.choice(chars) for _ in xrange(length)))
+
+
+class Expect(object):
+
+    """
+    This class runs a child process in the background and provides expect-like
+    services.
+
+    :param command: Executed command (bash -i, docker attach $name, ...)
+    :param linesep: line separator ('\n', '\r\n', ...)
+    :param name: name of this session (used in logging)
+    :param log_func: logging function (file.write, logging.debug, ...)
+    :warning: This class is not pickable.
+    :warning: It is not 100% compatible with aexpect, nor pexpect
+    """
+
+    def __init__(self, process, linesep='\n', name=None,
+                 log_func=None):
+        self.process = process
+        self._stdout_idx = 0
+        self.linesep = linesep
+        self.name = name if name else ""
+        self._log = None
+        self._log_records = None
+        self.set_logging(log_func)
+        self.time_start = time.time()
+
+    def __del__(self):
+        """
+        Clean up before the object is removed.
+        """
+        self.terminate()
+
+    def terminate(self, timeout=0):
+        """
+        Terminates the managed process (-15 eventually followed by -9)
+        """
+        try:
+            self.process.wait(timeout)
+        except AssertionError:  # already dead
+            pass
+
+    def set_logging(self, log_func=None):
+        """
+        Sets logging function (when log_func is None, disable auto-logging)
+        """
+        self._log_records = None
+        if not log_func:    # non-verbose
+            self._log = None
+        elif log_func == STORE:
+            self._log_records = []
+            # _log has to be a function; pylint: disable=W0108
+            self._log = lambda msg: self._log_records.append(msg)
+            # pylint: enable=W0108
+        else:
+            assert hasattr(log_func, '__call__'), ("logging function has to be"
+                                                   " a function (%s)"
+                                                   % type(log_func))
+            self._log = log_func
+
+    def log(self, prefix, data):
+        """
+        Logs to self._log using following format "$prefix$name: $data"
+        :param prefix: Prefix ('>>', '<<', ...)
+        :param data: Data to write.
+        """
+        if not self._log:    # Logging disabled
+            return
+        else:
+            for line in data.splitlines(True):
+                self._log("%s%s: %r" % (prefix, self.name, line))
+
+    def get_log_records(self):
+        """
+        When STORE function for logging is used, this returns the stored
+        messages.
+        :return: all stored messages or None
+        """
+        if isinstance(self._log_records, list):
+            return "\n".join(self._log_records)
+        else:
+            return "Log not stored, use session.set_logging(dexpect.STORE)"
+
+    def get_pid(self):
+        """
+        Returns pid of the main command.
+        :warning: This pid might not be the current foreground process!
+        """
+        return self.process.process_id
+
+    @staticmethod
+    def get_custom_children_pids(ppid=None, line_filter=None):
+        """
+        Returns childrens of specified parent pid, useful when you execute
+        multiple processes inside the main process (eg. docker inside bash)
+        :param ppid: parent pid
+        :param line_filter: Function called on the splitted line (len=2)
+        :return: list of tuples [($PID, $CMD), ...]
+        """
+        try:
+            out = safe_execute("ps --ppid %s -o pid,cmd -h" % ppid)
+        except ShellCmdError:   # No pids
+            return []
+        pids = []
+        for line in out.splitlines():
+            line = tuple(_.strip() for _ in line.strip().split(" ", 1))
+            if len(line) != 2:
+                raise ValueError("Fail to parse pid/name from output: %s"
+                                 % out)
+            if not line_filter or line_filter(line):
+                pids.append(line)
+        return pids
+
+    def get_children_pids(self, line_filter=None):
+        """
+        Returns list of all children pids and process names.
+        """
+        return self.get_custom_children_pids(self.get_pid(), line_filter)
+
+    def is_alive(self):
+        """
+        True when the main process is alive
+        """
+        return not self.process.done
+
+    def get_status(self):
+        """
+        Return exit status or None if process has not ended
+        """
+        return self.process.exit_status
+
+    def send(self, data):
+        """
+        Sends data to the process
+        :param data: string
+        """
+        self.log(">>", data)
+        self.process.stdin(data)
+        # Old method preserved in case we need to roll back
+        # while data:
+        #     written = self.process.stdin(data)
+        #     data = data[written:]
+        # Probably not needed, re-enable in case of weird failures
+        # termios.tcflush(self._pty, termios.TCIOFLUSH)
+        # termios.tcdrain(self._pty)
+
+    def sendline(self, data=''):
+        """
+        Sends data + EOL to the process
+        :param data: string
+        """
+        self.send(data + self.linesep)
+
+    def send_control(self, char):
+        """
+        This sends a control character to the child such as Ctrl-C or
+        Ctrl-D. For example, to send a Ctrl-G (ASCII 7)::
+        child.sendcontrol('g')
+        :param char: single character you want to send (ctrl+$char)
+        :raise KeyError: When unable to map char to ctrl+comand
+        """
+        char = char.lower()
+        val = ord(char)
+        if val >= 97 and val <= 122:
+            val = val - 97 + 1  # ctrl+a = '\0x01'
+            return self.send(chr(val))
+        mapping = {'@': 0, '`': 0,
+                   '[': 27, '{': 27,
+                   '\\': 28, '|': 28,
+                   ']': 29, '}': 29,
+                   '^': 30, '~': 30,
+                   '_': 31,
+                   '?': 127}
+        # TODO: Usually this works fine, docker ignores ctrl+p,ctrl+q sequence
+        #       without time.sleep(1) no matter what else we do.
+        #            termios.tcflush(self._pty, termios.TCIOFLUSH)
+        #            termios.tcdrain(self._pty)
+        #            termios.tcsendbreak(self._pty, 0)
+        return self.send(chr(mapping[char]))
+
+    def kill(self, sig=signal.SIGKILL):
+        """
+        Sends signal to the main process
+        :param sig: Which signal to send (default: signal.SIGKILL)
+        """
+        return self.process.kill(sig)
+
+    def _poll_stdout(self, timeout):
+        """
+        Polls for new data in stdout
+        :param timeout: How long to wait (None = inf)
+        :return: True = new data available, False = no new data
+        """
+        if timeout is None:
+            end_time = False
+        else:
+            end_time = time.time() + timeout
+        while len(self.process.stdout) <= self._stdout_idx:
+            if end_time and time.time() > end_time:
+                break
+            time.sleep(0.1)
+        else:
+            return True
+        return False
+
+    def _try_read(self, timeout):
+        """
+        Try to read single piece of data
+        :return: Read data
+        """
+        if not self._poll_stdout(timeout):  # No new data
+            return ""
+        out = self.process.stdout
+        _idx = self._stdout_idx
+        self._stdout_idx = len(out)
+        return out[_idx:]
+
+    def read_nonblocking(self, internal_timeout=None, timeout=None):
+        """
+        Non-blocking read of data from the process
+        :param internal_timeout: Maximal wait for single new data to arrive
+        :param timeout: Maximal overall read duration
+        :return: Read data
+        """
+        if internal_timeout is None:
+            internal_timeout = 0.1
+        end_time = None
+        if timeout > 0:
+            end_time = time.time() + timeout
+        data = self._try_read(internal_timeout)
+        while end_time and time.time() < end_time:
+            _data = self._try_read(internal_timeout)
+            if not _data:   # No new data after internal timeout
+                self.log("<<", data)
+                return data
+            data += _data
+        self.log("<<", data)
+        return data
+
+    def read_until_output_matches(self, patterns, filter_func=lambda x: x,
+                                  timeout=60, internal_timeout=None):
+        """
+        Read using read_nonblocking until a match is found using
+        match_patterns, or until timeout expires. Before attempting to search
+        for a match, the data is filtered using the filter_func function
+        provided.
+
+        @brief: Read from child using read_nonblocking until a pattern
+                matches.
+        :param patterns: List of strings (regular expression patterns)
+        :param filter_func: Function to apply to the data read from the child
+                before attempting to match it against the patterns (should take
+                and return a string)
+        :param timeout: The duration (in seconds) to wait until a match is
+                found
+        :param internal_timeout: The timeout to pass to read_nonblocking
+        :return: Tuple containing the match index and the data read so far
+        :raise ExpectTimeoutError: Raised if timeout expires
+        :raise ExpectProcessTerminatedError: Raised if the child process
+                terminates while waiting for output
+        :raise ExpectError: Raised if an unknown error occurs
+        """
+        def match_patterns(cont, patterns):
+            """
+            Match cont against a list of patterns.
+
+            Return the index of the first pattern that matches a substring of
+            cont. None and empty strings in patterns are ignored.
+            If no match is found, return None.
+
+            :param cont: input string
+            :param patterns: List of strings (regular expression patterns).
+            """
+            for i in range(len(patterns)):
+                if not patterns[i]:
+                    continue
+                if re.search(patterns[i], cont):
+                    return i
+        out = ""
+        end_time = time.time() + timeout
+        while True:
+            # Read data from child
+            data = self.read_nonblocking(internal_timeout,
+                                         end_time - time.time())
+            # Look for patterns
+            out += data
+            match = match_patterns(filter_func(out), patterns)
+            if match is not None:
+                return match, out
+            # timeout
+            if end_time and time.time() > end_time:
+                break
+
+        # Check if the child has terminated
+        for _ in xrange(50):
+            if not self.is_alive():
+                raise ExpectProcessTerminatedError(patterns, self.get_status(),
+                                                   out)
+            time.sleep(0.1)
+        raise ExpectError(patterns, out)
+
+    def read_until_last_line_matches(self, patterns, timeout=60,
+                                     internal_timeout=None):
+        """
+        Read using read_nonblocking until the last non-empty line of the output
+        matches one of the patterns (using match_patterns), or until timeout
+        expires. Return a tuple containing the match index (or None if no match
+        was found) and the data read so far.
+
+        @brief: Read using read_nonblocking until the last non-empty line
+                matches a pattern.
+
+        :param patterns: A list of strings (regular expression patterns)
+        :param timeout: The duration (in seconds) to wait until a match is
+                found
+        :param internal_timeout: The timeout to pass to read_nonblocking
+        :return: A tuple containing the match index and the data read so far
+        :raise ExpectTimeoutError: Raised if timeout expires
+        :raise ExpectProcessTerminatedError: Raised if the child process
+                terminates while waiting for output
+        :raise ExpectError: Raised if an unknown error occurs
+        """
+        def get_last_nonempty_line(cont):
+            """ Returns the last non-empty line """
+            nonempty_lines = [l for l in cont.splitlines() if l.strip()]
+            if nonempty_lines:
+                return nonempty_lines[-1]
+            else:
+                return ""
+
+        return self.read_until_output_matches(patterns, get_last_nonempty_line,
+                                              timeout, internal_timeout)
+
+
+class ShellSession(Expect):
+
+    """
+    This class provides all services of Expect.  In addition, it
+    provides command running services, and a utility function to test the
+    process for responsiveness.
+    """
+
+    def __init__(self, process, linesep="\n", prompt=r"[\#\$]\s*$",
+                 status_test_command="echo $?", tty=True, timeout=5,
+                 name=None, log_func=None):
+        """
+        Initialize the class and run command as a child process.
+
+        :param process:
+        :param linesep: Line separator to be appended to strings sent to the
+                child process by sendline().
+        :param prompt: Regular expression describing the shell's prompt line.
+        :param status_test_command: Command to be used for getting the last
+                exit status of commands run inside the shell (used by
+                cmd_status_output() and friends).
+        :param tty: tty mode (True = interactive, False = non-interactive)
+        :param timeout: How long to test responsiveness (set to None when you
+                        spawn many sessions and check the responsiveness later)
+        :param name: name of this session (used in logging)
+        :param log_func: logging function (file.write, logging.debug, ...)
+        """
+        # Init the superclass
+        Expect.__init__(self, process, linesep, name, log_func)
+        # Initialize functions/variables used in code
+        self.prompt = None
+        self.read_up_to_prompt = None
+        self.get_last_status = None
+        self._return_number = None
+        # Remember some attributes
+        self._prompt = prompt
+        self.status_test_command = status_test_command
+        self.set_tty(tty, timeout)
+
+    def set_tty(self, tty, timeout=5):
+        """
+        Sets the tty mode
+        :param tty: True -> normal mode, False -> no echo mode (no prompt)
+        :param timeout: How long to wait until the terminal is responsive
+        :return: whether the terminal is responsive after the change
+        :warning: Unresponsive tty can discard data on the input, DO check
+                  the return status.
+        """
+        if tty:
+            self.prompt = self._prompt
+            self.read_up_to_prompt = self.read_up_to_prompt_tty
+            self.get_last_status = self.get_last_status_tty
+        else:
+            self.prompt = ""
+            self.read_up_to_prompt = self.read_up_to_prompt_nontty
+            self.get_last_status = self.get_last_status_nontty
+        return self.is_responsive(timeout)
+
+    @classmethod
+    def remove_command_echo(cls, cont, cmd):
+        """
+        Remove the sent command when present in the output.
+        :param cont: context/output
+        :param cmd: sent command
+        :return: output without the echoed command
+        """
+        if cont and cont.splitlines()[0] == cmd:
+            cont = "".join(cont.splitlines(True)[1:])
+        return cont
+
+    @classmethod
+    def remove_last_nonempty_line(cls, cont):
+        """
+        Removes the last nonempty line (and all foregoing empty ones)
+        """
+        return "".join(cont.rstrip().splitlines(True)[:-1])
+
+    def is_responsive(self, timeout=5):
+        """
+        Return True if the process responds to STDIN/terminal input.
+
+        Send a newline to the child process (e.g. SSH or Telnet) and read some
+        output using read_nonblocking().
+        If all is OK, some output should be available (e.g. the shell prompt).
+        In that case return True.  Otherwise return False.
+
+        :param timeout: Time duration to wait before the process is considered
+                unresponsive.
+        """
+        # Read all output that's waiting to be read, to make sure the output
+        # we read next is in response to the newline sent
+        self.read_nonblocking(internal_timeout=0, timeout=timeout)
+        # Send a newline
+        self.sendline()
+        # Wait up to timeout seconds for some output from the child
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            time.sleep(0.5)
+            if self.read_nonblocking(0, end_time - time.time()):
+                return True
+        # No output -- report unresponsive
+        return False
+
+    def read_up_to_prompt_tty(self, timeout=60, internal_timeout=None):
+        """
+        Read using read_nonblocking until the last non-empty line of the output
+        matches the prompt regular expression set by set_prompt, or until
+        timeout expires.
+        @brief: Read using read_nonblocking until the last non-empty line
+                matches the prompt.
+
+        :param timeout: The duration (in seconds) to wait until a match is
+                found
+        :param internal_timeout: The timeout to pass to read_nonblocking
+        :return: The data read so far
+        :raise ExpectTimeoutError: Raised if timeout expires
+        :raise ExpectProcessTerminatedError: Raised if the shell process
+                terminates while waiting for output
+        :raise ExpectError: Raised if an unknown error occurs
+        """
+        return self.read_until_last_line_matches([self.prompt], timeout,
+                                                 internal_timeout)[1]
+
+    def read_up_to_prompt_nontty(self, timeout=60, internal_timeout=None):
+        """
+        Executes echo $RANDOM_LINE and waits for it's occurence.
+        :param timeout: The duration (in seconds) to wait until a match is
+        found
+        :param internal_timeout: The timeout to pass to read_nonblocking
+        :return: The data read so far
+        :raise ExpectTimeoutError: Raised if timeout expires
+        :raise ExpectProcessTerminatedError: Raised if the shell process
+        terminates while waiting for output
+        :raise ExpectError: Raised if an unknown error occurs
+        """
+        def get_last_nonempty_line(cont):
+            """ Returns the last non-empty line """
+            nonempty_lines = [l for l in cont.splitlines() if l.strip()]
+            if nonempty_lines:
+                return nonempty_lines[-1]
+            else:
+                return ""
+        prompt = ("--< END OF THE COMMAND %s >--" % generate_random_string(12))
+        cmd = 'RET=$?; echo; echo "$RET %s"' % prompt
+        # 2xecho makes sure it's on the new line
+        self.sendline(cmd)
+        prompt = ["^" + self.prompt + r'(\d*) ' + prompt + "$"]
+        _, out = super(ShellSession,
+                       self).read_until_last_line_matches(prompt, timeout,
+                                                          internal_timeout)
+        self._return_number = int(re.match(prompt[0],
+                                           get_last_nonempty_line(out)
+                                           ).groups()[0])
+        out = re.sub(r'%s\r?\n?' % re.escape(cmd), '', out)
+        return out
+
+    def cmd_output(self, cmd, timeout=60, internal_timeout=None):
+        """
+        Send a command and return its output.
+
+        :param cmd: Command to send (must not contain newline characters)
+        :param timeout: The duration (in seconds) to wait for the prompt to
+                return
+        :param internal_timeout: The timeout to pass to read_nonblocking
+        :return: The output of cmd
+        :raise ShellTimeoutError: Raised if timeout expires
+        :raise ShellProcessTerminatedError: Raised if the shell process
+                terminates while waiting for output
+        :raise ShellError: Raised if an unknown error occurs
+        """
+        # TODO: Do we need logging? eg. if self.verbose: $name: msg
+        # logging.debug("Sending command: %s" % cmd)
+        self.read_nonblocking(0, timeout)
+        self.sendline(cmd)
+        try:
+            out = self.read_up_to_prompt(timeout, internal_timeout)
+        except ExpectError, exc:
+            out = self.remove_command_echo(exc.output, cmd)
+            if isinstance(exc, ExpectTimeoutError):
+                raise ShellTimeoutError(cmd, out)
+            elif isinstance(exc, ExpectProcessTerminatedError):
+                raise ShellProcessTerminatedError(cmd, exc.status, out)
+            else:
+                raise ShellError(cmd, out)
+
+        # Remove the echoed command and the final shell prompt
+        return self.remove_last_nonempty_line(self.remove_command_echo(out,
+                                                                       cmd))
+
+    def get_last_status_tty(self, internal_timeout=None):
+        """
+        Get status output of the last command when in tty mode.
+        :param internal_timeout: Internal timeout of the discovering command
+        :return: exit status (integer)
+        :raise ShellError: When unable to obtain/parse the code
+        """
+        # Send the 'echo $?' (or equivalent) command to get the exit status
+        stat = self.cmd_output(self.status_test_command, 10, internal_timeout)
+        # Get the first line consisting of digits only
+        digit_lines = [_ for _ in stat.splitlines() if _.strip().isdigit()]
+        if digit_lines:
+            return int(digit_lines[0].strip())
+        else:
+            raise ShellError(self.status_test_command, stat)
+
+    def get_last_status_nontty(self, internal_timeout=None):
+        """
+        Get status output of the last command when in non-tty mode
+        :param internal_timeout: Ignored
+        :return: exit status (integer)
+        :warning: This function only works when used after read_up_to_prompt
+                  (eg. when you use all cmd* functions)
+        """
+        return self._return_number
+        del internal_timeout    # unused parameter pylint: disable=W0101
+
+    def cmd_status_output(self, cmd, timeout=60, internal_timeout=None):
+        """
+        Send a command and return its exit status and output.
+
+        :param cmd: Command to send (must not contain newline characters)
+        :param timeout: The duration (in seconds) to wait for the prompt to
+                return
+        :param internal_timeout: The timeout to pass to read_nonblocking
+        :return: A tuple (status, output) where status is the exit status and
+                output is the output of cmd
+        :raise ShellTimeoutError: Raised if timeout expires
+        :raise ShellProcessTerminatedError: Raised if the shell process
+                terminates while waiting for output
+        :raise ShellStatusError: Raised if the exit status cannot be obtained
+        :raise ShellError: Raised if an unknown error occurs
+        """
+        out = self.cmd_output(cmd, timeout, internal_timeout)
+        try:
+            stat = self.get_last_status(internal_timeout)
+        except ShellError:
+            raise ShellStatusError(cmd, out)
+        return stat, out
+
+    def cmd_status(self, cmd, timeout=60, internal_timeout=None):
+        """
+        Send a command and return its exit status.
+
+        :param cmd: Command to send (must not contain newline characters)
+        :param timeout: The duration (in seconds) to wait for the prompt to
+                return
+        :param internal_timeout: The timeout to pass to read_nonblocking
+        :return: The exit status of cmd
+        :raise ShellTimeoutError: Raised if timeout expires
+        :raise ShellProcessTerminatedError: Raised if the shell process
+                terminates while waiting for output
+        :raise ShellStatusError: Raised if the exit status cannot be obtained
+        :raise ShellError: Raised if an unknown error occurs
+        """
+        return self.cmd_status_output(cmd, timeout, internal_timeout)[0]
+
+    def cmd(self, cmd, timeout=60, internal_timeout=None, ok_status=(0,),
+            ignore_all_errors=False):
+        """
+        Send a command and return its output. If the command's exit status is
+        nonzero, raise an exception.
+
+        :param cmd: Command to send (must not contain newline characters)
+        :param timeout: The duration (in seconds) to wait for the prompt to
+                return
+        :param internal_timeout: The timeout to pass to read_nonblocking
+        :param ok_status: do not raise ShellCmdError in case that exit status
+                is one of ok_status. (default is [0,])
+        :param ignore_all_errors: toggles whether or not an exception should be
+                raised  on any error.
+
+        :return: The output of cmd
+        :raise ShellTimeoutError: Raised if timeout expires
+        :raise ShellProcessTerminatedError: Raised if the shell process
+                terminates while waiting for output
+        :raise ShellError: Raised if the exit status cannot be obtained or if
+                an unknown error occurs
+        :raise ShellStatusError: Raised if the exit status cannot be obtained
+        :raise ShellError: Raised if an unknown error occurs
+        :raise ShellCmdError: Raised if the exit status is nonzero
+        """
+        try:
+            s, o = self.cmd_status_output(cmd, timeout, internal_timeout)
+            if s not in ok_status:
+                raise ShellCmdError(cmd, s, o)
+            return o
+        except Exception:
+            if ignore_all_errors:
+                pass
+            else:
+                raise

--- a/subtests/docker_cli/interaction/docker_manager.py
+++ b/subtests/docker_cli/interaction/docker_manager.py
@@ -1,0 +1,143 @@
+"""
+This module helps managing in-test created containers/images and other objects
+
+:copyright: Red Hat, Inc.
+"""
+import time
+
+from dockertest import xceptions
+from dockertest.dockercmd import NoFailDockerCmd
+from dockertest.images import DockerImage
+from interaction import InteractiveAsyncDockerCmd
+
+
+class DockerManager(object):
+    """
+    This class implements "docker manager" - an object which helps to create,
+    maintain and destroy in-test used containers, images and other stuff.
+    :warning: This function is not thread-safe, use your own locking!
+    """
+    def __init__(self, subtest):
+        #: Subtest this DockerManager is related to
+        self.subtest = subtest
+        #: List of created containers
+        self.containers = []
+        #: List of created images
+        self.images = []
+
+    def create_container(self, cmd, subargs=None, name=None, image=None,
+                         timeout=None, verbose=True,
+                         docker_cmd=InteractiveAsyncDockerCmd):
+        """
+        Creates container and adds it into containers cache (for cleanup)
+        :param cmd: Container's main process (bash -c $cmd or custom list)
+        :param subargs: A list of strings containing additional args
+        :param name: Name of the container (if existing, random chars appended)
+        :param image: Override default image
+        :param timeout: Override default cmd timeout
+        :param verbose: Verbosity of the Docker Command
+        :param docker_cmd: ASYNC docker_cmd to be used
+        :return: tuple(this DockerContainer, executed docker_cmd)
+        """
+        # Prepare docker cmd
+        if not name:
+            name = "container"
+        name = self.subtest.containers.get_unique_name(name)
+        if subargs is None:
+            subargs = []
+        subargs.append("--name %s" % name)
+        if not image:
+            _config = self.subtest.config
+            image = DockerImage.full_name_from_defaults(_config)
+        subargs.append(image)
+        if isinstance(cmd, list):
+            subargs.extend(cmd)
+        else:
+            subargs.extend(("bash", "-c", cmd))
+        # Store name and execute
+        self.containers.append(name)
+        process = docker_cmd(subtest=self.subtest, subcmd="run",
+                             subargs=subargs, timeout=timeout, verbose=verbose)
+        process.execute()
+        # Wait until it occurs in `docker ps`
+        container = None
+        end_time = time.time() + 60
+        while time.time() < end_time:
+            conts = self.subtest.containers.list_containers_with_name(name)
+            if len(conts) == 1:
+                container = conts[0]
+                break
+            elif len(conts) > 1:
+                msg = ("Multiple containers matching the name %s." % name)
+                raise xceptions.DockerTestError(msg)
+            time.sleep(0.5)
+        if not container:
+            msg = ("Can't find the created container with the name %s in "
+                   "`docker ps` in 60s." % name)
+            raise xceptions.DockerTestError(msg)
+        # Replace name with container
+        self.containers.append(container)
+        self.containers.remove(name)    # this will remove the first container
+        return container, process
+
+    def add_container(self, container):
+        """
+        Add custom container to the list of created containers
+        """
+        if container in self.containers:
+            raise xceptions.DockerKeyError("Container %s already in cache (%s)"
+                                           % (container, self.containers))
+        self.containers.append(container)
+
+    def rm_container(self, container):
+        """
+        Remove container from the list of created containers
+        """
+        self.containers.remove(container)
+
+    def add_image(self, image):
+        """
+        Add image to the list of created images
+        """
+        if image in self.images:
+            raise xceptions.DockerKeyError("Container %s already in cache (%s)"
+                                           % (image, self.images))
+        self.images.append(image)
+
+    def rm_image(self, image):
+        """
+        Remove image from the list of created images
+        """
+        self.images.remove(image)
+
+    def cleanup_containers(self):
+        """
+        Safely removes all created containers
+        """
+        docker_containers = self.subtest.containers
+        while self.containers:
+            container = self.containers.pop()
+            if isinstance(container, str):
+                conts = docker_containers.list_containers_with_name(container)
+            else:
+                container = container.long_id
+                conts = docker_containers.list_containers_with_cid(container)
+            if len(conts) == 0:
+                continue  # Docker was created, but apparently doesn't exist
+            elif len(conts) > 1:
+                msg = ("Multiple containers matches name %s, not removing any "
+                       "of them...", container)
+                raise xceptions.DockerTestError(msg)
+            NoFailDockerCmd(self.subtest, 'rm', ['--force', '--volumes',
+                                                 container]).execute()
+
+    def cleanup_images(self):
+        """
+        Safely removes all created images
+        """
+        for image in self.images:
+            msg = ("I'd really love to help you removing image %s, but nobody "
+                   "told me how.\nYours faitfully, Autotest docker\n"
+                   "PS: all of these %s images were not removed. Ha haaa"
+                   % (image, self.images))
+            raise NotImplementedError(msg)

--- a/subtests/docker_cli/interaction/interaction.py
+++ b/subtests/docker_cli/interaction/interaction.py
@@ -1,0 +1,247 @@
+"""
+Simple interaction
+"""
+# Okay to be less-strict for these cautions/warnings in subtests
+# pylint: disable=C0103,C0111,R0904,C0103
+import os
+import time
+
+from autotest.client.shared import utils
+from dexpect import ShellSession, ShellError
+from dockertest import subtest
+from dockertest.dockercmd import NoFailDockerCmd, AsyncDockerCmd
+
+
+class LogInClenupSubSubtest(subtest.SubSubtest):
+
+    def __init__(self, parent_subtest):
+        super(LogInClenupSubSubtest, self).__init__(parent_subtest)
+        #: Dictionary of stringalizable items, which must be printed during
+        #: cleanup. This is intended for unexpected exceptions.
+        self.log_in_cleanup = {}
+
+    def cleanup(self):
+        super(LogInClenupSubSubtest, self).cleanup()
+        if self.log_in_cleanup:
+            self.logwarning("There are some uncleaned objects left:")
+            try:
+                while True:
+                    item = self.log_in_cleanup.popitem()
+                    self.logwarning("%s: %s" % item)
+            except KeyError:
+                pass
+
+
+class TooledSubSubtest(LogInClenupSubSubtest):
+
+    def __init__(self, parent_subtest):
+        super(TooledSubSubtest, self).__init__(parent_subtest)
+        from dockertest.images import DockerImages
+        from dockertest.containers import DockerContainers
+        from docker_manager import DockerManager
+        self.containers = DockerContainers(self.parent_subtest)
+        self.images = DockerImages(self.parent_subtest)
+        self.manager = DockerManager(self)
+
+
+class InteractiveAsyncDockerCmd(AsyncDockerCmd):
+
+    """
+    Execute docker command as asynchronous background process on ``execute()``
+    with PIPE as stdin and allows use of stdin(data) to interact with process.
+    """
+
+    def __init__(self, subtest, subcmd, subargs=None, timeout=None,
+                 verbose=True):
+        super(InteractiveAsyncDockerCmd, self).__init__(subtest, subcmd,
+                                                        subargs, timeout,
+                                                        verbose)
+        self._stdin = None
+        self._stdout_idx = 0
+
+    def execute(self, stdin=None):
+        """
+        Start execution of asynchronous docker command
+        """
+        self.close()
+        ps_stdin, self._stdin = os.pipe()
+        ret = super(InteractiveAsyncDockerCmd, self).execute(ps_stdin)
+        os.close(ps_stdin)
+        if stdin:
+            self.stdin(stdin)
+        return ret
+
+    def stdin(self, data):
+        """
+        Sends data to stdin (partial send is possible!)
+        :param data: Data to be send
+        :return: Number of written data
+        """
+        return os.write(self._stdin, data)
+
+    def close(self):
+        """
+        Closes opened file descriptors. Always call this before exit!
+        """
+        if self._stdin is not None:
+            os.close(self._stdin)
+            self._stdin = None
+
+    def __del__(self):
+        super(InteractiveAsyncDockerCmd, self).__del__()
+        self.close()
+
+
+def wait_for_alive(sub_test, container):
+    """
+    :return: True when container is alive
+    """
+    def is_alive(sub_test, container):
+        cmd = NoFailDockerCmd(sub_test, "inspect",
+                              ["-f", "'{{.State.Running}}'", container])
+        out = cmd.execute().stdout
+        if "true" in out.lower():
+            return True
+        else:
+            return False
+    return utils.wait_for(lambda: is_alive(sub_test, container.long_id), 5)
+
+
+def session_responsive(session, timeout=3, internal_timeout=1):
+    """
+    Sends `true` command and queues for output. When output obtained => True
+    :warning: Don't set internal_timeout too low unless stressed machine
+              might not response quickly enough.
+    """
+    end_time = time.time() + timeout
+    while time.time() < end_time:
+        try:
+            session.cmd_status("true", internal_timeout)
+            out = session.read_nonblocking(2)
+            if out:
+                raise Exception("This shouldn't happened; out:\n%s" % out)
+            return True
+        except ShellError:
+            pass
+    try:    # +1 iteration in case we missed end_time of milliseconds...
+        session.cmd_status("true", internal_timeout)
+        out = session.read_nonblocking(2)
+        if out:
+            raise Exception("This shouldn't happened; out:\n%s" % out)
+        return True
+    except ShellError:
+        pass
+    return False
+
+
+class interaction(subtest.SubSubtestCaller):
+
+    """ Subtest caller """
+    pass
+
+
+class interaction_base(TooledSubSubtest):
+
+    def initialize(self):
+        """
+        Creates dexpect session with host's bash, than starts container in it
+        and stores host and container hostnames.
+        """
+        super(interaction_base, self).initialize()
+        # Prepare a container
+        config = self.config
+        ret = self.manager.create_container(config['container_command'],
+                                            config['container_options_csv'].split(','))
+        self.sub_stuff['container'] = container = ret[0]
+        self.sub_stuff['process'] = process = ret[1]
+        # No we have container up and running
+        if self.config.get('session_attached'):
+            self.failif(not wait_for_alive(self, container),
+                        "Container did not started in 5s")
+            attach = InteractiveAsyncDockerCmd(self, "attach",
+                                               [container.long_id])
+            attach.execute()
+            session = ShellSession(attach, tty=config['is_tty'],
+                                   name=container.container_name + '_1',
+                                   log_func=self.logdebug)
+        else:
+            session = ShellSession(process, tty=config['is_tty'],
+                                   name=container.container_name + '_1',
+                                   log_func=self.logdebug)
+        self.sub_stuff['session'] = session
+
+    def run_once(self):
+        super(interaction_base, self).run_once()
+        session = self.sub_stuff['session']
+        self.failif(not session_responsive(session), "Session not responsive.")
+        self.failif(session.cmd_status("ls"), "ls command failed.")
+        session.send_control('s')
+        if self.config['is_tty']:
+            self.failif(session_responsive(session), "Session is responsive "
+                        "even though we sent ctrl+s")
+        else:
+            ret = session.cmd_status_output("true")
+            self.failif(ret[0] != 127, "ctrl+s should pass \x12 directly to "
+                        "the stdin. After that true command was executed "
+                        "including this \x12 as first character, which should"
+                        "result in err 127, got %s instead. Out:\n%s"
+                        % (ret[0], ret[1]))
+        session.send_control('q')
+        if self.config['is_tty']:
+            self.failif(not session_responsive(session), "Session not "
+                        "responsive after sending ctrl+q.")
+        else:
+            ret = session.cmd_status_output("true")
+            self.failif(ret[0] != 127, "ctrl+q should pass \x10 directly to "
+                        "the stdin. After that true command was executed "
+                        "including this \x10 as first character, which should"
+                        "result in err 127, got %s instead. Out:\n%s"
+                        % (ret[0], ret[1]))
+        session.sendline("")    # there might be some chars present...
+        session.sendline('exit')
+        not_alive = lambda: not session.is_alive()
+        self.failif(not utils.wait_for(not_alive, 5), "Session is alive "
+                    "even though exit was executed.")
+
+    def cleanup(self):
+        """
+        Close all sessions and remove the container
+        """
+        super(interaction_base, self).cleanup()
+        # Stop session
+        print self.config['remove_after_test']
+        if self.config['remove_after_test'] is True:
+            self.manager.cleanup_containers()
+            self.manager.cleanup_images()
+
+
+class interactive_tty(interaction_base):
+
+    """
+    Using the --interactive mode
+    """
+    pass
+
+
+class interactive_nontty(interaction_base):
+
+    """
+    Using the --interactive mode
+    """
+    pass
+
+
+class attached_tty(interaction_base):
+
+    """
+    Using the --detached mode
+    """
+    pass
+
+
+class attached_nontty(interaction_base):
+
+    """
+    Using the --detached mode
+    """
+    pass


### PR DESCRIPTION
This pull request implements the https://github.com/autotest/autotest-docker/pull/192 inside the test instead of framework to give it time to stabilize before turning it into framework. I believe that this implementation is cleaner and easier to follow than hybrid implementation from https://github.com/autotest/autotest-docker/pull/194

Kind regards,
Lukáš