### PR TITLE
all: Automatic PEP8 fixes

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -13,7 +13,9 @@ serve to show the default.
 # Okay to be less-strict for these
 # pylint: disable=C0103,C0111,R0904,C0103,C0301,W0622
 
-import sys, os, types
+import sys
+import os
+import types
 
 #: The documentation version for this instance of the test.  It is compared
 #: to the API version before every test.  This ensures any API changes
@@ -107,7 +109,7 @@ html_theme = 'default'
 #: Theme options are theme-specific and customize the look and feel of a theme
 #: further.  For a list of options available for each theme, see the
 #: documentation.
-html_theme_options = {'stickysidebar':True}
+html_theme_options = {'stickysidebar': True}
 
 #: Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = []
@@ -181,21 +183,21 @@ htmlhelp_basename = 'DockerAutotestdoc'
 # -- Options for LaTeX output --------------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
 }
 
 #: Grouping the document tree into LaTeX files. List of tuples
 #: (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'DockerAutotest.tex', u'Docker Autotest Documentation',
-   u'Chris Evich', 'manual'),
+    ('index', 'DockerAutotest.tex', u'Docker Autotest Documentation',
+     u'Chris Evich', 'manual'),
 ]
 
 #: The name of an image file (relative to this directory) to place at the top of
@@ -238,9 +240,9 @@ man_show_urls = False
 #: (source start file, target name, title, author,
 #: dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'DockerAutotest', u'Docker Autotest Documentation',
-   u'Chris Evich', 'DockerAutotest', 'One line description of project.',
-   'Miscellaneous'),
+    ('index', 'DockerAutotest', u'Docker Autotest Documentation',
+     u'Chris Evich', 'DockerAutotest', 'One line description of project.',
+     'Miscellaneous'),
 ]
 
 #: Documents to append as an appendix to all manuals.
@@ -288,7 +290,7 @@ setattr(mock('autotest.client.shared.error'), 'TestFail', Exception)
 setattr(mock('autotest.client.shared.error'), 'TestError', Exception)
 setattr(mock('autotest.client.shared.error'), 'TestNAError', Exception)
 setattr(mock('autotest.client.shared.error'), 'AutotestError', Exception)
-setattr(mock('autotest.client.shared.version'), 'get_version', lambda : "0.15.0")
+setattr(mock('autotest.client.shared.version'), 'get_version', lambda: "0.15.0")
 mock('autotest.client.shared.base_job')
 mock('autotest.client.shared.job')
 mock('autotest.client.job')

--- a/dockertest/config.py
+++ b/dockertest/config.py
@@ -37,6 +37,7 @@ DEFAULTSFILE = 'defaults.ini'
 
 
 class ConfigSection(object):
+
     """
     Wraps SafeConfigParser with static section handling
 
@@ -204,6 +205,7 @@ class ConfigSection(object):
 
 
 class ConfigDict(MutableMapping):
+
     r"""
     Wraps ConfigSection instance in a dict-like, hides SafeConfigParser details.
 
@@ -266,10 +268,11 @@ class ConfigDict(MutableMapping):
     def write(filelike):
         """Raise an IOError exception, instance is read-only"""
         raise xceptions.DockerIOError("Instance does not permit writing to %s"
-                                       % filelike.name)
+                                      % filelike.name)
 
 
 class Config(dict):
+
     r"""
     Global dict-like of dict-like(s) per section with defaulting values.
 
@@ -321,7 +324,7 @@ class Config(dict):
         for filename in filenames:
             fullpath = os.path.join(dirpath, filename)
             if (filename.startswith('.') or
-                not filename.endswith('.ini')):
+                    not filename.endswith('.ini')):
                 continue
             config_file = open(fullpath, 'r')
             # Temp use sections variable for reading sections list

--- a/dockertest/config_unittests.py
+++ b/dockertest/config_unittests.py
@@ -35,6 +35,7 @@ def mock(mod_path):
 
 
 class DockerKeyError(Exception):
+
     """ Fake class for errors """
     pass
 

--- a/dockertest/containers_unittests.py
+++ b/dockertest/containers_unittests.py
@@ -10,6 +10,7 @@ import tempfile
 import os
 import shutil
 
+
 class ContainersTestBase(unittest.TestCase):
 
     def setUp(self):
@@ -95,6 +96,7 @@ def mock(mod_path):
 
 # Just pack whatever args received into attributes
 class FakeCmdResult(object):
+
     def __init__(self, **dargs):
         for key, val in dargs.items():
             setattr(self, key, val)
@@ -115,9 +117,9 @@ def run(command, *_args, **_dargs):
         "Domainname": ""
     }
 }]""",
-    stderr='',
-    exit_status=0,
-    duration=1.21)
+                             stderr='',
+                             exit_status=0,
+                             duration=1.21)
     return FakeCmdResult(command=command.strip(),
                          stdout=r"""
 CONTAINER ID                                                       IMAGE                             COMMAND                                            CREATED             STATUS              PORTS                                            NAMES               SIZE
@@ -129,9 +131,9 @@ c0c35064e4d2bdcf86e6fd83e0de2e599473c12a6599415a9a021bdf382a3589   busybox:lates
 abf8c40b19e353ff1f67e3a26a967c14944b07b8f5aceb752f781ffca285a2a9   10.16.71.105:5000/fedora:latest   /bin/bash                                          22 hours ago        Exit 0                                                               suspicious_pare     77 B
 e1820ef428b51a95c963353cc4ce6b57ea0a20c44537a8336792510713dfe524   10.16.71.105:5000/fedora:latest   /bin/bash                                          22 hours ago        Exit 0                                                               thirsty_mccarthy    77 B
 """,
-                        stderr='',
-                        exit_status=0,
-                        duration=42)
+                         stderr='',
+                         exit_status=0,
+                         duration=42)
 
 # Mock module and mock function run in one line
 setattr(mock('autotest.client.utils'), 'run', run)
@@ -148,9 +150,10 @@ setattr(mock('autotest.client.shared.error'), 'TestError', Exception)
 setattr(mock('autotest.client.shared.error'), 'TestNAError', Exception)
 setattr(mock('autotest.client.shared.error'), 'AutotestError', Exception)
 setattr(mock('autotest.client.shared.version'), 'get_version',
-                                               lambda :version.AUTOTESTVERSION)
+        lambda: version.AUTOTESTVERSION)
 
 import version
+
 
 class DockerContainersTestBase(ContainersTestBase):
 
@@ -175,8 +178,8 @@ class DockerContainersTestBase(ContainersTestBase):
 
     def _setup_defaults(self):
         self.config.DEFAULTSFILE = self._setup_inifile('DEFAULTS',
-                                   self.config.CONFIGDEFAULT,
-                                   self.defaults)
+                                                       self.config.CONFIGDEFAULT,
+                                                       self.defaults)
 
     def _setup_customs(self):
         self._setup_inifile(self.config_section,

--- a/dockertest/docker_daemon.py
+++ b/dockertest/docker_daemon.py
@@ -109,6 +109,7 @@ class SocketClient(ClientBase):
 
 # Group of utils for managing docker daemon service.
 
+
 def start(docker_path, docker_args):
     """
     Start new docker daemon with special args.
@@ -125,6 +126,7 @@ def start(docker_path, docker_args):
     daemon_process = utils.AsyncJob(" ".join(cmd), close_fds=True)
     return daemon_process
 
+
 def output_match(daemon_process,
                  timeout=120,
                  regex=r"-job acceptconnections\(\) = OK \(0\)"):
@@ -138,6 +140,7 @@ def output_match(daemon_process,
     return wait_for_output(daemon_process.get_stderr,
                            regex,
                            timeout=timeout)
+
 
 def restart_service(daemon_process=None):
     """

--- a/dockertest/docker_daemon_unittests.py
+++ b/dockertest/docker_daemon_unittests.py
@@ -55,13 +55,15 @@ class DDTest(DDTestBase):
 
     def test_client_subclass(self):
         class c(self.dd.ClientBase):
+
             def get(self, resource):
                 return (self.uri, resource)
+
             @staticmethod
             def value_to_json(value):
                 return json.loads('[{"%s":"%s"}]' % value)
         i = c('foo')
-        self.assertEqual(i.get_json('bar'), [{u'foo':u'bar'}])
+        self.assertEqual(i.get_json('bar'), [{u'foo': u'bar'}])
         self.assertEqual(i.interface, None)
 
 if __name__ == '__main__':

--- a/dockertest/dockercmd.py
+++ b/dockertest/dockercmd.py
@@ -78,7 +78,6 @@ class DockerCmdBase(object):
 
     @property
     def details(self):
-
         """
         Returns substitution dictionary for __str__ and logging.
         """
@@ -105,7 +104,6 @@ class DockerCmdBase(object):
         return dct
 
     def __str__(self):
-
         """
         Return string representation of instance w/ details if verbose=True
         """
@@ -126,7 +124,6 @@ class DockerCmdBase(object):
         return fmt % self.details
 
     def execute(self, stdin):  # pylint: disable=R0201
-
         """
         Execute docker subcommand
 
@@ -144,7 +141,6 @@ class DockerCmdBase(object):
 
     # Impl. specific stubb, can't be a function
     def execute_calls(self):  # pylint: disable=R0201
-
         """
         Returns the number of times ``execute()`` has been called
 
@@ -155,7 +151,6 @@ class DockerCmdBase(object):
 
     @property
     def docker_options(self):
-
         """
         String of docker args
         """
@@ -165,7 +160,6 @@ class DockerCmdBase(object):
 
     @property
     def docker_command(self):
-
         """
         String of docker command path
         """
@@ -175,7 +169,6 @@ class DockerCmdBase(object):
 
     @property
     def command(self):
-
         """
         String representation of command + subcommand + args
         """
@@ -192,7 +185,6 @@ class DockerCmdBase(object):
 
     @property
     def stdout(self):
-
         """
         Represent string of stdout
 
@@ -206,7 +198,6 @@ class DockerCmdBase(object):
 
     @property
     def stderr(self):
-
         """
         Represent string of stderr
 
@@ -220,7 +211,6 @@ class DockerCmdBase(object):
 
     @property
     def exit_status(self):
-
         """
         Represent exit code
 
@@ -235,7 +225,6 @@ class DockerCmdBase(object):
 
     @property
     def duration(self):
-
         """
         Represent the duration / elapsed time of command
 
@@ -252,7 +241,6 @@ class DockerCmdBase(object):
 
     @property
     def cmdresult(self):
-
         """
         Represent fresh CmdResult value (not reference)
         """
@@ -263,7 +251,6 @@ class DockerCmdBase(object):
 
     @cmdresult.setter
     def cmdresult(self, value):
-
         """
         Allow subclasses ability to update the private cache attribute
 
@@ -277,6 +264,7 @@ class DockerCmdBase(object):
                                           duration=value.duration)
         return self.cmdresult
 
+
 class DockerCmd(DockerCmdBase):
 
     """
@@ -285,7 +273,6 @@ class DockerCmd(DockerCmdBase):
     """
 
     def execute(self, stdin=None):
-
         """
         Run docker command, ignore any non-zero exit code
         """
@@ -311,13 +298,13 @@ class DockerCmd(DockerCmdBase):
 
 
 class NoFailDockerCmd(DockerCmd):
+
     """
     Setup a call docker subcommand as if by CLI w/ subtest config integration
     Execute docker subcommand with arguments and a timeout.
     """
 
     def execute(self, stdin=None):
-
         """
         Execute docker command, raising DockerCommandError if non-zero exit
         """
@@ -336,7 +323,6 @@ class MustFailDockerCmd(DockerCmd):
     """
 
     def execute(self, stdin=None):
-
         """
         Execute docker command, raise DockerExecError if **zero** exit code
         """
@@ -358,7 +344,6 @@ class AsyncDockerCmd(DockerCmdBase):
     _async_job = None
 
     def execute(self, stdin=None):
-
         """
         Start execution of asynchronous docker command
         """
@@ -377,7 +362,6 @@ class AsyncDockerCmd(DockerCmdBase):
         return self.cmdresult
 
     def wait(self, timeout=None):
-
         """
         Return CmdResult after waiting for process to end or timeout
 
@@ -398,7 +382,6 @@ class AsyncDockerCmd(DockerCmdBase):
         return self.cmdresult
 
     def update_result(self):
-
         """
         Deprecated, do not use
 
@@ -409,7 +392,6 @@ class AsyncDockerCmd(DockerCmdBase):
 
     @property
     def done(self):
-
         """
         Return True if processes has ended
 
@@ -423,7 +405,6 @@ class AsyncDockerCmd(DockerCmdBase):
 
     @property
     def process_id(self):
-
         """
         Return the process id of the command
 

--- a/dockertest/dockercmd_unittests.py
+++ b/dockertest/dockercmd_unittests.py
@@ -35,35 +35,47 @@ def mock(mod_path):
             sys.modules[mod_path] = child_mod
         return sys.modules[mod_path]
 
+
 class FakePopen(object):
+
     """needed for testing AsyncDockerCmd"""
     pid = -1
+
     def poll(self):
         return True
 
+
 class FakeCmdResult(object):    # pylint: disable=R0903
+
     """ Just pack whatever args received into attributes """
     duration = 123
     stdout = None
     stderr = None
     exit_status = 0
+
     def __init__(self, *args, **dargs):
         self.sp = FakePopen()
         for key, val in dargs.items():
             setattr(self, key, val)
+
     def __str__(self):
         return self.command
     # needed for testing AsyncDockerCmd
+
     def get_stdout(self):
         return "STDOUT"
+
     def get_stderr(self):
         return "STDERR"
+
     def wait_for(self, timeout):
         self.duration = timeout
         return self
+
     @property
     def result(self):
         return self
+
 
 def run(command, *args, **dargs):
     """ Don't actually run anything! """
@@ -94,13 +106,14 @@ setattr(mock('autotest.client.shared.error'), 'TestError', Exception)
 setattr(mock('autotest.client.shared.error'), 'TestNAError', Exception)
 setattr(mock('autotest.client.shared.error'), 'AutotestError', Exception)
 setattr(mock('autotest.client.shared.version'), 'get_version',
-                                               lambda :version.AUTOTESTVERSION)
+        lambda: version.AUTOTESTVERSION)
 # Need all three for Subtest class
 mock('autotest.client.shared.base_job')
 mock('autotest.client.shared.job')
 mock('autotest.client.job')
 
 import version
+
 
 class DockerCmdTestBase(unittest.TestCase):
 
@@ -124,8 +137,8 @@ class DockerCmdTestBase(unittest.TestCase):
 
     def _setup_defaults(self):
         self.config.DEFAULTSFILE = self._setup_inifile('DEFAULTS',
-                                   self.config.CONFIGDEFAULT,
-                                   self.defaults)
+                                                       self.config.CONFIGDEFAULT,
+                                                       self.defaults)
 
     def _setup_customs(self):
         self._setup_inifile(self.config_section,
@@ -134,6 +147,7 @@ class DockerCmdTestBase(unittest.TestCase):
 
     def _make_fake_subtest(self):
         class FakeSubtestException(Exception):
+
             def __init__(fake_self, *_args, **_dargs):  # pylint: disable=E0213
                 super(FakeSubtestException, self).__init__()
 
@@ -210,7 +224,7 @@ class DockerCmdTestBasic(DockerCmdTestBase):
         docker_command.timeout = 24
         self.assertEqual(docker_command.timeout, 24)
         self.assertRaises(NotImplementedError, docker_command.execute,
-                           'not stdin')
+                          'not stdin')
 
         self.assertRaises(self.dockercmd.DockerTestError,
                           self.dockercmd.DockerCmdBase, "ThisIsNotSubtest",
@@ -285,7 +299,6 @@ class AsyncDockerCmd(DockerCmdTestBase):
         for prop in ('done', 'process_id'):
             self.assertRaises(self.dockercmd.DockerTestError,
                               getattr, docker_cmd, prop)
-
 
         cmdresult = docker_cmd.execute()
         self.assertTrue(isinstance(cmdresult, FakeCmdResult))

--- a/dockertest/images_unittests.py
+++ b/dockertest/images_unittests.py
@@ -10,6 +10,7 @@ import tempfile
 import types
 import unittest
 
+
 def mock(mod_path):
     name_list = mod_path.split('.')
     child_name = name_list.pop()
@@ -30,6 +31,7 @@ def mock(mod_path):
 
 
 class FakeCmdResult(object):
+
     def __init__(self, **dargs):
         for key, val in dargs.items():
             setattr(self, key, val)
@@ -62,13 +64,14 @@ setattr(mock('autotest.client.shared.error'), 'TestError', Exception)
 setattr(mock('autotest.client.shared.error'), 'TestNAError', Exception)
 setattr(mock('autotest.client.shared.error'), 'AutotestError', Exception)
 setattr(mock('autotest.client.shared.version'), 'get_version',
-                                               lambda :version.AUTOTESTVERSION)
+        lambda: version.AUTOTESTVERSION)
 mock('autotest.client.shared.base_job')
 mock('autotest.client.shared.job')
 mock('autotest.client.shared.utils')
 mock('autotest.client.job')
 
 import version
+
 
 class ImageTestBase(unittest.TestCase):
 
@@ -92,8 +95,8 @@ class ImageTestBase(unittest.TestCase):
 
     def _setup_defaults(self):
         self.config.DEFAULTSFILE = self._setup_inifile('DEFAULTS',
-                                   self.config.CONFIGDEFAULT,
-                                   self.defaults)
+                                                       self.config.CONFIGDEFAULT,
+                                                       self.defaults)
 
     def _setup_customs(self):
         self._setup_inifile(self.config_section,
@@ -204,7 +207,7 @@ class DockerImageTestBasic(ImageTestBase):
         self.assertEqual(str(act), exp)
 
         images = str(d.list_imgs_with_full_name_components(repo_addr="192.168.122.245:5000",
-                                                                 tag="32"))
+                                                           tag="32"))
         self.assertEqual(images,
                          "[DockerImage(full_name:192.168.122.245:5000/fedora:32 LONG_ID:0d20aec6529d5d396b195182c0eaa82bfe014c3e82ab390203ed56a774d2c404 CREATED:5 weeks ago SIZE:387 MB)]")
 
@@ -238,7 +241,7 @@ class DockerImageTestBasic(ImageTestBase):
 
         full_name = "fedora_addr/user_user/fedora_repo:last_tag"
         (repo, tag, repo_addr, user) = self.images.DockerImage.split_to_component(
-                                             full_name)
+            full_name)
         self.assertRaises(self.images.DockerFullNameFormatError,
                           self.images.DockerImage.split_to_component, ["dd/"])
         self.assertRaises(self.images.DockerFullNameFormatError,
@@ -253,7 +256,7 @@ class DockerImageTestBasic(ImageTestBase):
                           ["<none>:<none>"])
 
         self.assertEqual(self.images.DockerImage.full_name_from_component(
-                                    repo, tag, repo_addr, user), full_name)
+            repo, tag, repo_addr, user), full_name)
 
         self.assertEqual((repo, tag, repo_addr, user),
                          ("fedora_repo", "last_tag", "fedora_addr",
@@ -270,7 +273,7 @@ class DockerImageTestBasic(ImageTestBase):
         self.assertFalse(di_ref == di_dif)
 
         self.assertTrue(self.images.DockerImage(
-                                         "fedora_addr:44/user_user/"
+            "fedora_addr:44/user_user/"
                                          "fedora_repo:last_tag", None,
                                          "0d20aec6529d5d396b195182c0eaa82bfe0"
                                          "14c3e82ab390203ed56a774d2c404",
@@ -278,9 +281,9 @@ class DockerImageTestBasic(ImageTestBase):
                                          "50 MB",
                                          None,
                                          None).cmp_full_name_with_component("fedora_repo",
-                                                             "last_tag",
-                                                             "fedora_addr:44",
-                                                             "user_user"))
+                                                                            "last_tag",
+                                                                            "fedora_addr:44",
+                                                                            "user_user"))
 
         self.assertTrue(di_ref.cmp_id(di_ref2.short_id))
         self.assertTrue(di_ref.cmp_id(di_ref2.long_id))

--- a/dockertest/networking_unittests.py
+++ b/dockertest/networking_unittests.py
@@ -65,7 +65,7 @@ class ContainerPortTest(NetworkingTestBase):
         self.assertTrue(cp.cmp_portstr_with_component(4321, 1234,
                                                       "1.2.3.4", "foobar"))
         self.assertFalse(cp.cmp_portstr_with_component(4321, 1234,
-                                                      "1.2.3.4"))
+                                                       "1.2.3.4"))
 
     def test_split_to_component(self):
         # host_ip:host_port->container_port/protocol

--- a/dockertest/output_unittests.py
+++ b/dockertest/output_unittests.py
@@ -272,11 +272,9 @@ class WaitForOutput(unittest.TestCase):
         self.output = output
         self.gtime = self.timegen()
 
-
     def tearDown(self):
         setattr(mock('time'), 'time', self.old_time)
         setattr(mock('time'), 'sleep', self.old_sleep)
-
 
     def test_wait_for_output(self):
         pattern = r"exp_out"
@@ -293,7 +291,6 @@ class WaitForOutput(unittest.TestCase):
         e = time.time()
         self.assertGreater(t + 7, e,
                            "Waiting for output takes longer time")
-
 
     @staticmethod
     def outgenerator(raise_time, expected_out):
@@ -312,7 +309,6 @@ class WaitForOutput(unittest.TestCase):
                 out += chr(random.randint(32, 100))
             yield out
 
-
     @staticmethod
     def timegen():
         t = 0
@@ -320,10 +316,8 @@ class WaitForOutput(unittest.TestCase):
             t += 1
             yield t
 
-
     def get_time(self):
         return self.gtime.next()
-
 
     @staticmethod
     def sleep(_):

--- a/dockertest/subtest.py
+++ b/dockertest/subtest.py
@@ -28,7 +28,9 @@ from xceptions import DockerTestNAError
 from xceptions import DockerTestError
 from xceptions import DockerSubSubtestNAError
 
+
 class SubBase(object):
+
     """
     Methods/attributes common to Subtest & SubSubtest classes
 
@@ -52,7 +54,6 @@ class SubBase(object):
     n_tabs = 1     # one-level
 
     def initialize(self):
-
         """
         Called every time the test is run.
         """
@@ -60,7 +61,6 @@ class SubBase(object):
         self.loginfo("initialize()")
 
     def run_once(self):
-
         """
         Called once only to exercise subject of sub-subtest
         """
@@ -68,7 +68,6 @@ class SubBase(object):
         self.loginfo("run_once()")
 
     def postprocess(self):
-
         """
         Called to process results of subject
         """
@@ -76,7 +75,6 @@ class SubBase(object):
         self.loginfo("postprocess()")
 
     def cleanup(self):
-
         """
         Always called, before any exceptions thrown are re-raised.
         """
@@ -85,7 +83,6 @@ class SubBase(object):
 
     @staticmethod
     def failif(condition, reason=None):
-
         """
         Convenience method for subtests to avoid importing TestFail exception
 
@@ -101,7 +98,6 @@ class SubBase(object):
 
     @classmethod
     def log_x(cls, lvl, msg, *args):
-
         """
         Send msg & args through to logging module function with name lvl
         """
@@ -112,7 +108,6 @@ class SubBase(object):
 
     @classmethod
     def log_xn(cls, lvl, msg, *args):
-
         """
         Multiline-split and send msg & args through to logging module
 
@@ -305,6 +300,7 @@ class Subtest(SubBase, test.test):
         """
         self.loginfo("postprocess_iteration() #%d of #%d",
                      self.iteration, self.iterations)
+
 
 class SubSubtest(SubBase):
 

--- a/dockertest/version_unittests.py
+++ b/dockertest/version_unittests.py
@@ -32,11 +32,13 @@ def mock(mod_path):
 
 
 class DockerVersionError(IOError):
+
     """ Dummy exception """
     pass
 
 
 class DockerValueError(IOError):
+
     """ Dummy exception """
     pass
 

--- a/envchecks/non-default-images.py
+++ b/envchecks/non-default-images.py
@@ -4,6 +4,7 @@ import os
 import sys
 from subprocess import Popen, PIPE, STDOUT
 
+
 def get_envcheck_ignore_iids():
     csv = os.environ.get('envcheck_ignore_iids')
     if csv is not None:
@@ -11,12 +12,14 @@ def get_envcheck_ignore_iids():
     else:
         return []
 
+
 def get_envcheck_ignore_fqin():
     csv = os.environ.get('envcheck_ignore_fqin')
     if csv is not None:
         return csv.strip().split(',')
     else:
         return []
+
 
 def get_docker_path():
     docker_path = os.environ.get('docker_path')

--- a/subtests/docker_cli/attach/attach.py
+++ b/subtests/docker_cli/attach/attach.py
@@ -14,6 +14,7 @@ from dockertest.output import OutputGood
 from dockertest.dockercmd import AsyncDockerCmd, DockerCmd
 from dockertest import subtest
 
+
 class attach(subtest.SubSubtestCaller):
     config_section = 'docker_cli/attach'
 
@@ -57,7 +58,7 @@ class attach_base(SubSubtest):
                     self.logdebug("Removing image %s", image)
                     di.remove_image_by_full_name(image)
                     self.logdebug("Successfully removed test image: %s",
-                                 image)
+                                  image)
                 except error.CmdError, e:
                     error_text = "tagged in multiple repositories"
                     if not error_text in e.result_obj.stderr:
@@ -95,7 +96,6 @@ class simple_base(attach_base):
 
         self.failif(cid == [],
                     "Unable to search container with name %s" % (c_name))
-
 
     def run_once(self):
         super(simple_base, self).run_once()
@@ -160,7 +160,6 @@ class simple_base(attach_base):
 
         in_output = self.sub_stuff['cmd_attach'].stdout
         self.failif_not_contain(check_for, in_output, details)
-
 
     def postprocess(self):
         super(simple_base, self).postprocess()  # Prints out basic info

--- a/subtests/docker_cli/attach/no_stdin.py
+++ b/subtests/docker_cli/attach/no_stdin.py
@@ -11,6 +11,7 @@ Test attach
 
 from attach import simple_base
 
+
 class no_stdin(simple_base):
 
     def verify_output(self):

--- a/subtests/docker_cli/attach/sig_proxy_off.py
+++ b/subtests/docker_cli/attach/sig_proxy_off.py
@@ -10,5 +10,6 @@ Test attach
 
 from attach import sig_proxy_off_base
 
+
 class sig_proxy_off(sig_proxy_off_base):
     pass

--- a/subtests/docker_cli/attach/sig_proxy_on.py
+++ b/subtests/docker_cli/attach/sig_proxy_on.py
@@ -9,6 +9,7 @@ Test attach
 """
 from attach import sig_proxy_off_base
 
+
 class sig_proxy_on(sig_proxy_off_base):
 
     def check_containers(self, containers):

--- a/subtests/docker_cli/build/build.py
+++ b/subtests/docker_cli/build/build.py
@@ -8,7 +8,10 @@ Test run of docker build command
 5. Optionally remove built image
 """
 
-import os, os.path, shutil, time
+import os
+import os.path
+import shutil
+import time
 from urllib2 import urlopen
 from dockertest import subtest
 from dockertest.images import DockerImages
@@ -18,7 +21,9 @@ from dockertest.dockercmd import AsyncDockerCmd
 from dockertest.dockercmd import DockerCmd
 from dockertest.dockercmd import NoFailDockerCmd
 
+
 class NotSeenString(object):
+
     """
     Represent the next line of a string not already returned previously
     """
@@ -80,7 +85,7 @@ class NotSeenString(object):
             del lines[0:self.end]
             self.end += 1
         else:
-            return None # no new lines
+            return None  # no new lines
         result = lines[0]
         stripped = result.strip()
         if len(stripped) > 0:
@@ -88,6 +93,7 @@ class NotSeenString(object):
             return True
         else:
             return False  # skip blank line
+
 
 class build(subtest.Subtest):
     config_section = 'docker_cli/build'

--- a/subtests/docker_cli/build_paths/build_paths.py
+++ b/subtests/docker_cli/build_paths/build_paths.py
@@ -15,6 +15,7 @@ import os.path
 import re
 import shutil
 
+
 class build_paths(Subtest):
 
     def _init_build_paths(self):
@@ -91,7 +92,7 @@ class build_paths(Subtest):
         self.stuff['passed'] = [False for _ in xrange(self.iterations)]
 
         self._init_build_args()
-        #stuff needed later
+        # stuff needed later
         self.stuff['names'] = []
         self.stuff['cmdresults'] = []
 

--- a/subtests/docker_cli/commit/check_default_cmd.py
+++ b/subtests/docker_cli/commit/check_default_cmd.py
@@ -17,6 +17,7 @@ from dockertest.output import OutputGood
 from dockertest.dockercmd import DockerCmd
 from dockertest.containers import DockerContainers
 
+
 class check_default_cmd(commit_base):
     config_section = 'docker_cli/commit/check_default_cmd'
 
@@ -51,8 +52,8 @@ class check_default_cmd(commit_base):
                 dc = DockerCmd(self.parent_subtest, "rm", ["-f", cont.long_id])
                 rm_results = dc.execute()
                 self.failif(rm_results.exit_status != 0,
-                    "Non-zero commit exit status: %s"
-                    % rm_results)
+                            "Non-zero commit exit status: %s"
+                            % rm_results)
 
         self.failif(results.exit_status != 0,
                     "Non-zero commit exit status: %s"

--- a/subtests/docker_cli/commit/commit.py
+++ b/subtests/docker_cli/commit/commit.py
@@ -25,6 +25,7 @@ from dockertest import subtest
 from dockertest import config
 from dockertest import xceptions
 
+
 class commit(subtest.SubSubtestCaller):
     config_section = 'docker_cli/commit'
 
@@ -158,5 +159,5 @@ class commit_base(SubSubtest):
                             "Data read from image do not match"
                             " data written to container during"
                             " test initialization: %s != %s" %
-                           (results.stdout.strip(),
-                            self.sub_stuff["rand_data"]))
+                            (results.stdout.strip(),
+                             self.sub_stuff["rand_data"]))

--- a/subtests/docker_cli/commit/good.py
+++ b/subtests/docker_cli/commit/good.py
@@ -10,5 +10,6 @@ docker commit full_name
 
 from commit import commit_base
 
+
 class good(commit_base):
     config_section = 'docker_cli/commit/good'

--- a/subtests/docker_cli/cp/cp.py
+++ b/subtests/docker_cli/cp/cp.py
@@ -13,6 +13,7 @@ from dockertest.dockercmd import DockerCmd
 from dockertest.images import DockerImage
 import hashlib
 
+
 class cp(subtest.Subtest):
     config_section = 'docker_cli/cp'
 
@@ -36,14 +37,14 @@ class cp(subtest.Subtest):
 
     def run_once(self):
         super(cp, self).run_once()
-        #build arg list and execute command
+        # build arg list and execute command
         subargs = [self.stuff['container_name'] + ":" + self.stuff['cpfile']]
         subargs.append(self.tmpdir)
         nfdc = NoFailDockerCmd(self, "cp", subargs,
                                timeout=self.config['docker_timeout'])
         nfdc.execute()
         copied_path = "%s/%s" % (self.tmpdir,
-                                   self.stuff['cpfile'].split('/')[-1])
+                                 self.stuff['cpfile'].split('/')[-1])
         self.stuff['copied_path'] = copied_path
 
     def postprocess(self):

--- a/subtests/docker_cli/diff/diff.py
+++ b/subtests/docker_cli/diff/diff.py
@@ -13,10 +13,13 @@ from dockertest.containers import DockerContainers
 from dockertest.subtest import SubSubtest
 from dockertest.subtest import SubSubtestCaller
 
+
 class diff(SubSubtestCaller):
     pass
 
+
 class diff_base(SubSubtest):
+
     @staticmethod
     def parse_diff_output(output):
         xsplit = [x.split() for x in output.split('\n') if x]
@@ -65,11 +68,14 @@ class diff_base(SubSubtest):
                                [self.sub_stuff['name']])
             dkrcmd.execute()
 
+
 class diff_add(diff_base):
-    pass #only change in configuration
+    pass  # only change in configuration
+
 
 class diff_change(diff_base):
-    pass #only change in configuration
+    pass  # only change in configuration
+
 
 class diff_delete(diff_base):
-    pass #only change in configuration
+    pass  # only change in configuration

--- a/subtests/docker_cli/dockerhelp/dockerhelp.py
+++ b/subtests/docker_cli/dockerhelp/dockerhelp.py
@@ -11,11 +11,13 @@ from dockertest.output import OutputGood
 from dockertest.dockercmd import DockerCmd, NoFailDockerCmd
 
 # 'help()' is reserved in python
+
+
 class dockerhelp(subtest.Subtest):
     config_section = 'docker_cli/dockerhelp'
 
     def initialize(self):
-        super(dockerhelp, self).initialize() # Prints out basic info
+        super(dockerhelp, self).initialize()  # Prints out basic info
         # Names are too long to put on one line
         sol = 'success_option_list'
         fol = 'failure_option_list'
@@ -29,7 +31,7 @@ class dockerhelp(subtest.Subtest):
             self.stuff[fol] = self.config[fol].split(',')
 
     def run_once(self):
-        super(dockerhelp, self).run_once() # Prints out basic info
+        super(dockerhelp, self).run_once()  # Prints out basic info
         for option in self.stuff['success_option_list']:
             # No successful command should throw an exception
             dkrcmd = NoFailDockerCmd(self, option)

--- a/subtests/docker_cli/dockerimport/dockerimport.py
+++ b/subtests/docker_cli/dockerimport/dockerimport.py
@@ -4,5 +4,6 @@ Based on config['test_subsection_postfixes'] load module, call function.
 
 from dockertest.subtest import SubSubtestCallerSimultaneous
 
+
 class dockerimport(SubSubtestCallerSimultaneous):
     pass

--- a/subtests/docker_cli/dockerimport/empty.py
+++ b/subtests/docker_cli/dockerimport/empty.py
@@ -13,6 +13,7 @@ from dockertest.subtest import SubSubtest
 from dockertest.dockercmd import DockerCmd
 from dockertest.images import DockerImages, DockerImage
 
+
 class empty(SubSubtest):
 
     def initialize(self):

--- a/subtests/docker_cli/dockerimport/truncated.py
+++ b/subtests/docker_cli/dockerimport/truncated.py
@@ -8,18 +8,22 @@ Sub-subtest module used by dockerimport test
 """
 
 from autotest.client import utils
-import tempfile, os, os.path, shutil
+import tempfile
+import os
+import os.path
+import shutil
 from empty import empty
 from dockertest.dockercmd import MustFailDockerCmd
 from dockertest import output
+
 
 class truncated(empty):
 
     def cleanup(self):
         # Call empty parent's cleanup, not empty's.
-        super(empty, self).cleanup() # pylint: disable=E1003
+        super(empty, self).cleanup()  # pylint: disable=E1003
         # Fail test if **successful**
-        image_name = self.sub_stuff['image_name']  #  assume id lookup failed
+        image_name = self.sub_stuff['image_name']  # assume id lookup failed
         if self.parent_subtest.config['try_remove_after_test']:
             dkrcmd = MustFailDockerCmd(self, 'rmi', [image_name])
             dkrcmd.execute()
@@ -41,7 +45,7 @@ class truncated(empty):
         # instance-specific namespace
         self.loginfo("Expected to fail: %s", command)
         self.sub_stuff['cmdresult'] = utils.run(command, ignore_status=True,
-                                             verbose=False)
+                                                verbose=False)
 
     def check_output(self):
         outputgood = output.OutputGood(self.sub_stuff['cmdresult'],

--- a/subtests/docker_cli/dockerinspect/dockerinspect.py
+++ b/subtests/docker_cli/dockerinspect/dockerinspect.py
@@ -17,9 +17,11 @@ from dockertest.xceptions import DockerTestError
 import json
 import os
 
+
 class dockerinspect(SubSubtestCaller):
 
     config_section = 'docker_cli/dockerinspect'
+
 
 class inspect_base(SubSubtest):
 
@@ -123,6 +125,7 @@ class inspect_base(SubSubtest):
                                self.sub_stuff['containers'])
             dkrcmd.execute()
 
+
 class inspect_container_simple(inspect_base):
 
     def initialize(self):
@@ -142,4 +145,3 @@ class inspect_container_simple(inspect_base):
         for field in check_fields:
             self.failif(field not in cli_output[0],
                         "Field: '%s' not found in output." % (field))
-

--- a/subtests/docker_cli/dockerinspect/inspect_all.py
+++ b/subtests/docker_cli/dockerinspect/inspect_all.py
@@ -10,6 +10,7 @@ Test output of docker inspect command
 from dockertest.dockercmd import NoFailDockerCmd
 from dockerinspect import inspect_base
 
+
 class inspect_all(inspect_base):
 
     def initialize(self):
@@ -28,10 +29,9 @@ class inspect_all(inspect_base):
         cli_output = self.parse_cli_output(self.sub_stuff['cmdresult'].stdout)
         cid = self.get_cid_from_name(self, self.sub_stuff['name'])
         config_map = self.get_config_maps([cid])
-        #https://bugzilla.redhat.com/show_bug.cgi?id=1092781
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1092781
         ifields = self.config['ignore_fields'].split(',')
         self.verify_same_configs(self,
                                  config_map,
                                  cli_output,
                                  ignore_fields=ifields)
-

--- a/subtests/docker_cli/dockerinspect/inspect_keys.py
+++ b/subtests/docker_cli/dockerinspect/inspect_keys.py
@@ -13,11 +13,12 @@ from dockertest.images import DockerImage
 from dockertest.xceptions import DockerTestError
 import re
 
+
 class inspect_keys(inspect_base):
 
     def initialize(self):
         super(inspect_keys, self).initialize()
-        #make a container to check
+        # make a container to check
         self.create_simple_container(self)
         image = DockerImage.full_name_from_defaults(self.config)
         self.sub_stuff['image'] = image
@@ -29,11 +30,11 @@ class inspect_keys(inspect_base):
 
     def run_once(self):
         super(inspect_keys, self).run_once()
-        #inspect a container
+        # inspect a container
         subargs = self.sub_stuff['containers']
         self.sub_stuff['container_config'] = self.inspect_and_parse(subargs)
 
-        #inspect an image
+        # inspect an image
         subargs = [self.sub_stuff['image']]
         self.sub_stuff['image_config'] = self.inspect_and_parse(subargs)
 
@@ -73,7 +74,7 @@ class inspect_keys(inspect_base):
         if self.config['key_regex']:
             self.assert_regex(keys, name)
 
-        #verify container keys
+        # verify container keys
         name = "container: %s" % (self.sub_stuff['containers'][0])
         keys = self.get_keys(self.sub_sutff['container_config'])
         if self.config['container_keys']:

--- a/subtests/docker_cli/events/events.py
+++ b/subtests/docker_cli/events/events.py
@@ -20,15 +20,16 @@ from dockertest.xceptions import DockerValueError
 
 # TODO: Turn this into a general module?
 cid_regex = re.compile(r'\s+([a-z0-9]{64})\:\s+')
-dt_regex = re.compile(r'\[(\d{4}-\d{2}-\d{2})\s+' # date part
-                      r'(\d{2}:\d{2}:\d{2})\s+' # time part
+dt_regex = re.compile(r'\[(\d{4}-\d{2}-\d{2})\s+'  # date part
+                      r'(\d{2}:\d{2}:\d{2})\s+'  # time part
                       r'([+-]?\d{4})\s+'  # UTC offset part
-                      r'([a-zA-Z]+)\]\s+') # Timezone part
+                      r'([a-zA-Z]+)\]\s+')  # Timezone part
 ymd_regex = re.compile(r'(\d{4})-(\d{2})-(\d{2})')
 hms_regex = re.compile(r'(\d{2})\:(\d{2})\:(\d{2})')
 source_regex = re.compile(r'\s+\(from\s+%s\)\s+'
                           % DockerImage.repo_split_p.pattern)
 operation_regex = re.compile(r'\s+(\w+)$')  # final word chars
+
 
 def event_dt(line):
     try:
@@ -47,12 +48,14 @@ def event_dt(line):
     except (AttributeError, TypeError, ValueError):  # regex.search() failed
         return None
 
+
 def event_cid(line):
     mobj = cid_regex.search(line)
     if mobj is not None:
         return mobj.group(1)
     else:
         return None
+
 
 def event_source(line):
     mobj = source_regex.search(line)
@@ -64,6 +67,7 @@ def event_source(line):
     else:
         return None
 
+
 def event_operation(line):
     mobj = operation_regex.search(line)
     if mobj is not None:
@@ -71,23 +75,25 @@ def event_operation(line):
     else:
         return None
 
+
 def event_details(line):
     # TODO: An event class object?
-    return {'datetime':event_dt(line),
-            'source':event_source(line),
-            'operation':event_operation(line)}
+    return {'datetime': event_dt(line),
+            'source': event_source(line),
+            'operation': event_operation(line)}
+
 
 def is_dupe_event(needle, haystack):
     for event in haystack:
         # Fastest comparison order
         if (needle['datetime'] == event['datetime'] and
             needle['source'] == event['source'] and
-            needle['operation'] == event['operation']):
+                needle['operation'] == event['operation']):
             return True
     return False
 
-def parse_event(line):
 
+def parse_event(line):
     """
     Return tuple(CID, {DETAILS}) from parsing line
 
@@ -101,8 +107,8 @@ def parse_event(line):
     else:
         return (cid, details)
 
-def parse_events(lines, slop=None):
 
+def parse_events(lines, slop=None):
     """
     Return list of tuples for valid lines returned by parse_events()
 
@@ -132,6 +138,7 @@ def parse_events(lines, slop=None):
                                        % (slop, n_lines, n_lines - n_slop,
                                           sloppy))
     return result
+
 
 def events_by_cid(events_list, previous=None):
     """
@@ -166,7 +173,7 @@ class events(Subtest):
         fullname = dc.get_unique_name(prefix=self.config['name_prefix'])
         fqin = DockerImage.full_name_from_defaults(self.config)
         # generic args have spots for some value substitution
-        mapping = {'NAME':fullname, 'IMAGE':fqin}
+        mapping = {'NAME': fullname, 'IMAGE': fqin}
         subargs = []
         for arg in self.config['run_args'].strip().split(','):
             tmpl = Template(arg)

--- a/subtests/docker_cli/history/history.py
+++ b/subtests/docker_cli/history/history.py
@@ -14,6 +14,7 @@ from dockertest import subtest
 from dockertest import config
 from dockertest import xceptions
 
+
 class history(subtest.SubSubtestCaller):
     config_section = 'docker_cli/history'
 
@@ -37,7 +38,7 @@ class history_base(SubSubtest):
         self.sub_stuff["new_image_name"] = new_img_name
 
         new_img_name2 = "%s_%s" % (name_prefix,
-                                  utils.generate_random_string(8).lower())
+                                   utils.generate_random_string(8).lower())
         self.sub_stuff["new_image_name2"] = new_img_name2
 
         self.sub_stuff['rand_data'] = utils.generate_random_string(8)
@@ -45,10 +46,10 @@ class history_base(SubSubtest):
                          % self.sub_stuff['rand_data'])
 
         fqin = DockerImage.full_name_from_defaults(self.config)
-        #create new image in history
+        # create new image in history
         self.create_image(fqin, new_img_name, cmd_with_rand)
         self.sub_stuff["images"].append(new_img_name)
-        #create new image in history
+        # create new image in history
         self.create_image(new_img_name, new_img_name2, cmd_with_rand)
         self.sub_stuff["images"].append(new_img_name2)
 
@@ -87,19 +88,18 @@ class history_base(SubSubtest):
 
             self.failif(base_img_name in self.sub_stuff['cmdresult'].stdout,
                         "Unable find image name %s in image history: %s" %
-                         (base_img_name,
-                          self.sub_stuff['cmdresult'].stdout))
+                        (base_img_name,
+                         self.sub_stuff['cmdresult'].stdout))
 
             self.failif(new_img_name in self.sub_stuff['cmdresult'].stdout,
                         "Unable find image name %s in image history: %s" %
-                         (new_img_name,
-                          self.sub_stuff['cmdresult'].stdout))
+                        (new_img_name,
+                         self.sub_stuff['cmdresult'].stdout))
 
             self.failif(new_img_name2 in self.sub_stuff['cmdresult'].stdout,
                         "Unable find image name %s in image history: %s" %
-                         (new_img_name2,
-                          self.sub_stuff['cmdresult'].stdout))
-
+                        (new_img_name2,
+                         self.sub_stuff['cmdresult'].stdout))
 
     def cleanup(self):
         super(history_base, self).cleanup()
@@ -120,7 +120,7 @@ class history_base(SubSubtest):
                     self.logdebug("Removing image %s", image)
                     di.remove_image_by_full_name(image)
                     self.logdebug("Successfully removed test image: %s",
-                                 image)
+                                  image)
                 except error.CmdError, e:
                     error_text = "tagged in multiple repositories"
                     if not error_text in e.result_obj.stderr:

--- a/subtests/docker_cli/history/simple.py
+++ b/subtests/docker_cli/history/simple.py
@@ -16,5 +16,6 @@ clean
 
 from history import history_base
 
+
 class simple(history_base):
     config_section = 'docker_cli/history/simple'

--- a/subtests/docker_cli/images/images.py
+++ b/subtests/docker_cli/images/images.py
@@ -8,6 +8,7 @@ Test output of docker Images command
 from dockertest import subtest
 from dockertest.images import DockerImages
 
+
 class images(subtest.Subtest):
     config_section = 'docker_cli/images'
 

--- a/subtests/docker_cli/import_export/import_export.py
+++ b/subtests/docker_cli/import_export/import_export.py
@@ -12,6 +12,7 @@ from dockertest.dockercmd import NoFailDockerCmd
 from dockertest import xceptions
 from dockertest import subtest
 
+
 class import_export(subtest.SubSubtestCaller):
     config_section = 'docker_cli/import_export'
 
@@ -27,11 +28,11 @@ class import_export_base(SubSubtest):
         cmdresult = dkrcmd.execute()
         if cmdresult.exit_status != 0:
             xceptions.DockerTestNAError("Unable to prepare env for test: %s" %
-                                       (cmdresult))
+                                        (cmdresult))
         cid = self.sub_stuff["cont"].list_containers_with_name(name)
         self.failif(cid == [],
                     "Unable to search container with name %s: details :%s" %
-                   (name, cmdresult))
+                    (name, cmdresult))
 
     def init_ei_dockercmd(self, export_arg_csv, import_arg_csv):
         # Never execute()'d, just used for command property
@@ -81,6 +82,7 @@ class import_export_base(SubSubtest):
                         raise
                 except xceptions.DockerTestError:
                     pass  # best effort removal, maybe image wasn't there
+
 
 class simple(import_export_base):
 

--- a/subtests/docker_cli/info/info.py
+++ b/subtests/docker_cli/info/info.py
@@ -12,6 +12,7 @@ from dockertest.output import OutputGood
 from dockertest.dockercmd import NoFailDockerCmd
 import os
 
+
 class info(subtest.Subtest):
 
     def run_once(self):
@@ -32,27 +33,27 @@ class info(subtest.Subtest):
         # Raise exception on Go Panic or usage help message
         outputgood = OutputGood(self.stuff['cmdresult'])
         info_map = self._build_table(outputgood.stdout_strip)
-        #verify each element
+        # verify each element
         self.verify_pool_name(info_map['Pool Name'])
         self.verify_sizes(info_map['Data file'],
-                         info_map['Data Space Used'],
-                         info_map['Data Space Total'],
-                         info_map['Metadata file'],
-                         info_map['Metadata Space Used'],
-                         info_map['Metadata Space Total'])
+                          info_map['Data Space Used'],
+                          info_map['Data Space Total'],
+                          info_map['Metadata file'],
+                          info_map['Metadata Space Used'],
+                          info_map['Metadata Space Total'])
 
     def verify_pool_name(self, docker_pool_name):
         read_pool_names = utils.run("dmsetup ls | grep 'docker.*pool'")
         raw_pools = read_pool_names.stdout.strip()
         pool_names = [x.split()[0] for x in raw_pools.split('\n')]
 
-        #make sure there is only one pool
+        # make sure there is only one pool
         self.failif(len(pool_names) != 1,
                     "There is more than one docker pool.")
         self.logdebug("One docker pool found.")
 
         read_pool_name = pool_names[0]
-        #verify pool names
+        # verify pool names
         self.logdebug("Read Pool Name: %s , Docker Pool Name: %s",
                       read_pool_name, docker_pool_name)
         self.failif(docker_pool_name != read_pool_name,
@@ -61,7 +62,7 @@ class info(subtest.Subtest):
 
     @staticmethod
     def _sizeof_fmt_mb(num, input_unit='b'):
-        conv = float(1024*1024)
+        conv = float(1024 * 1024)
         if input_unit == 'Kb':
             conv = float(1024)
         fmt_num = num / conv
@@ -69,47 +70,47 @@ class info(subtest.Subtest):
 
     def verify_sizes(self, data_file, data_used, data_total,
                      meta_file, meta_used, meta_total):
-        #read sizes of the data and meta files
+        # read sizes of the data and meta files
         read_size = lambda x: float(
-                                utils.run("du %s | cut -f1" % x
-                                            ).stdout.strip())
+            utils.run("du %s | cut -f1" % x
+                      ).stdout.strip())
         read_data_size = read_size(data_file)
         read_meta_size = read_size(meta_file)
-        #read apparent sizes of data and meta files
+        # read apparent sizes of data and meta files
         data_asize = os.stat(data_file).st_size
         meta_asize = os.stat(meta_file).st_size
-        #format sizes to compare them to docker output
+        # format sizes to compare them to docker output
         read_data_size_mb = self._sizeof_fmt_mb(read_data_size, 'Kb')
         read_meta_size_mb = self._sizeof_fmt_mb(read_meta_size, 'Kb')
         read_data_asize_mb = self._sizeof_fmt_mb(data_asize)
         read_meta_asize_mb = self._sizeof_fmt_mb(meta_asize)
 
-        #compare actual file sizes
+        # compare actual file sizes
         self.logdebug("Read metadata file size total: %s, Docker metadata file "
-                     "total size: %s", read_meta_asize_mb, meta_total)
+                      "total size: %s", read_meta_asize_mb, meta_total)
         self.failif(meta_total != read_meta_asize_mb,
                     "Docker reported metadata file size total does not match "
                     "read file size total.")
         self.logdebug("Docker reported metadata file size total matches read "
-                     "file size total.")
+                      "file size total.")
         self.logdebug("Read data file size total: %s, Docker data file total "
-                     "size: %s", read_data_asize_mb, data_total)
+                      "size: %s", read_data_asize_mb, data_total)
         self.failif(data_total != read_data_asize_mb,
                     "Docker reported data file size total does not match read "
                     "file size total.")
         self.logdebug("Docker reported data file size total matches read file "
-                     "size total.")
+                      "size total.")
 
-        #compare real used file sizes
+        # compare real used file sizes
         self.logdebug("Read metadata file size: %s, Docker metadata file size: "
-                     "%s", read_meta_size_mb, meta_used)
+                      "%s", read_meta_size_mb, meta_used)
         self.failif(meta_used != read_meta_size_mb,
                     "Docker reported metadata file size does not match read "
                     "file size.")
         self.logdebug("Docker reported metadata file size matches read file "
-                     "size.")
+                      "size.")
         self.logdebug("Read data file size: %s, Docker data file size: %s",
-                     read_data_size_mb, data_used)
+                      read_data_size_mb, data_used)
         self.failif(data_used != read_data_size_mb,
                     "Docker reported data file size does not match read file "
                     "size.")

--- a/subtests/docker_cli/insert/insert.py
+++ b/subtests/docker_cli/insert/insert.py
@@ -16,17 +16,18 @@ from dockertest.xceptions import DockerTestNAError
 import hashlib
 import urllib2
 
+
 class insert(subtest.Subtest):
     config_section = 'docker_cli/insert'
 
     def initialize(self):
         super(insert, self).initialize()
         self.stuff['cntr_objs'] = []
-        #check for a valid url for the test
+        # check for a valid url for the test
         file_url = self.config['file_url']
         if not file_url or len(file_url) < 4:
             raise DockerTestNAError("'file_url' in insert.ini not set.")
-        #pull down file at url for use later
+        # pull down file at url for use later
         response = urllib2.urlopen(file_url)
         contents = response.read()
         self.stuff['contents'] = contents

--- a/subtests/docker_cli/invalid/arg.py
+++ b/subtests/docker_cli/invalid/arg.py
@@ -10,6 +10,6 @@ subtest-arg: the invalid charactor occurs in [ARG...]
 
 from invalid import invalid_base
 
+
 class arg(invalid_base):
     config_section = 'docker_cli/invalid/arg'
-

--- a/subtests/docker_cli/invalid/command.py
+++ b/subtests/docker_cli/invalid/command.py
@@ -10,6 +10,6 @@ subtest-command:the invalid charactor occurs in [COMMAND]
 
 from invalid import invalid_base
 
+
 class command(invalid_base):
     config_section = 'docker_cli/invalid/command'
-

--- a/subtests/docker_cli/invalid/image.py
+++ b/subtests/docker_cli/invalid/image.py
@@ -11,6 +11,6 @@ subtest-image:  the invalid charactor occurs in IMAGE
 
 from invalid import invalid_base
 
+
 class image(invalid_base):
     config_section = 'docker_cli/invalid/image'
-

--- a/subtests/docker_cli/invalid/option.py
+++ b/subtests/docker_cli/invalid/option.py
@@ -13,6 +13,6 @@ subtest-option: the invalid charactor occurs in [OPTIONS]
 
 from invalid import invalid_base
 
+
 class option(invalid_base):
     config_section = 'docker_cli/invalid/option'
-

--- a/subtests/docker_cli/iptable/iptable.py
+++ b/subtests/docker_cli/iptable/iptable.py
@@ -13,6 +13,7 @@ from dockertest.subtest import SubSubtestCallerSimultaneous
 from autotest.client import utils
 import re
 
+
 class iptable(SubSubtestCallerSimultaneous):
 
     pass
@@ -100,17 +101,19 @@ class iptable_base(SubSubtest):
         super(iptable_base, self).cleanup()
         if self.config['remove_after_test']:
             dcmd = DockerCmd(self.parent_subtest,
-                                 'rm',
-                                 ['--force',
-                                  '--volumes',
+                             'rm',
+                             ['--force',
+                              '--volumes',
                                  self.sub_stuff['name']])
             dcmd.execute()
 
 
 class iptable_remove(iptable_base):
+
     """
     Test if container iptable rules are removed after stopped
     """
+
     def run_once(self):
         super(iptable_remove, self).run_once()
         before_net = set(self.sub_stuff['net_device_list'])
@@ -129,7 +132,7 @@ class iptable_remove(iptable_base):
         added_rules = utils.wait_for(container_rules, 10, step=0.1)
         self.failif(not added_rules, "No rules added when container started.")
         self.loginfo("Container %s\niptable rule list %s:" %
-                      (self.sub_stuff['name'], added_rules))
+                     (self.sub_stuff['name'], added_rules))
 
         NoFailDockerCmd(self.parent_subtest,
                         'stop',

--- a/subtests/docker_cli/psa/psa.py
+++ b/subtests/docker_cli/psa/psa.py
@@ -5,7 +5,10 @@ Test output of docker ps -a command
 2. Fail if table-format changes or is not parseable
 """
 
-import time, signal, os.path, os
+import time
+import signal
+import os.path
+import os
 from autotest.client import utils
 from dockertest import subtest
 from dockertest import images
@@ -14,6 +17,7 @@ from dockertest.dockercmd import AsyncDockerCmd
 from dockertest.dockercmd import NoFailDockerCmd
 from dockertest.containers import DockerContainers
 from dockertest.xceptions import DockerTestFail
+
 
 class psa(subtest.Subtest):
     config_section = 'docker_cli/psa'
@@ -37,7 +41,7 @@ class psa(subtest.Subtest):
                    "echo 'foobar' > stop && "
                    "rm -f stop && trap '/usr/bin/date +%%s> stop' USR1 && "
                    "while ! [ -f stop ]; do /usr/bin/sleep 0.1s; done"
-                    "\"")
+                   "\"")
         subargs.append(command)
         self.stuff['cl0'] = dc.list_containers()
         dkrcmd = AsyncDockerCmd(self, 'run', subargs)
@@ -85,7 +89,7 @@ class psa(subtest.Subtest):
         self.loginfo("Waiting up to %d seconds for exit",
                      self.config['wait_stop'])
         self.stuff['cmdresult'] = self.stuff['dkrcmd'].wait(
-                                                    self.config['wait_stop'])
+            self.config['wait_stop'])
         self.stuff['cl2'] = dc.list_containers()
 
     def postprocess(self):
@@ -95,8 +99,8 @@ class psa(subtest.Subtest):
         cnts = dc.list_containers_with_name(self.stuff['container_name'])
         self.failif(len(cnts) < 1, "Test container not found in list")
         cnt = cnts[0]
-        estat1 = str(cnt.status).startswith("Exit 0") # pre docker 0.9.1
-        estat2 = str(cnt.status).startswith("Exited (0)") # docker 0.9.1 & later
+        estat1 = str(cnt.status).startswith("Exit 0")  # pre docker 0.9.1
+        estat2 = str(cnt.status).startswith("Exited (0)")  # docker 0.9.1 & later
         self.failif(not (estat1 or estat2), "Exit status mismatch: %s does not"
                                             "start with %s or %s"
                                             % (str(cnt), "Exit 0",

--- a/subtests/docker_cli/pull/good.py
+++ b/subtests/docker_cli/pull/good.py
@@ -10,6 +10,7 @@ docker pull full_name
 
 from pull import pull_base, check_registry
 
+
 class good(pull_base):
     config_section = 'docker_cli/pull/good'
 

--- a/subtests/docker_cli/pull/good_extra_tag.py
+++ b/subtests/docker_cli/pull/good_extra_tag.py
@@ -10,6 +10,7 @@ docker pull --tag=xxx full_name
 from pull import pull_base, check_registry
 from dockertest.images import DockerImage
 
+
 class good_extra_tag(pull_base):
     config_section = 'docker_cli/pull/good_extra_tag'
 

--- a/subtests/docker_cli/pull/pull.py
+++ b/subtests/docker_cli/pull/pull.py
@@ -18,6 +18,7 @@ from dockertest.dockercmd import AsyncDockerCmd
 from dockertest import subtest
 from dockertest import config
 
+
 class pull(subtest.SubSubtestCaller):
     config_section = 'docker_cli/pull'
 

--- a/subtests/docker_cli/pull/wrong_registry_addr.py
+++ b/subtests/docker_cli/pull/wrong_registry_addr.py
@@ -10,6 +10,7 @@ docker pull wrong_full_name
 from dockertest import output
 from pull import pull_base
 
+
 class wrong_registry_addr(pull_base):
     config_section = 'docker_cli/pull/wrong_registry_addr'
 

--- a/subtests/docker_cli/pull/wrong_tag.py
+++ b/subtests/docker_cli/pull/wrong_tag.py
@@ -8,6 +8,7 @@ docker pull full_name_wrong_tag
 """
 from pull import pull_base, check_registry
 
+
 class wrong_tag(pull_base):
     config_section = 'docker_cli/pull/wrong_tag'
 

--- a/subtests/docker_cli/restart/restart.py
+++ b/subtests/docker_cli/restart/restart.py
@@ -20,6 +20,7 @@ from dockertest.images import DockerImage
 from dockertest.subtest import SubSubtest
 from dockertest.dockercmd import NoFailDockerCmd
 
+
 class restart(subtest.SubSubtestCaller):
 
     """ Subtest caller """
@@ -29,6 +30,7 @@ class restart(subtest.SubSubtestCaller):
 class restart_base(SubSubtest):
 
     """ Base class """
+
     def initialize(self):
         super(restart_base, self).initialize()
         config.none_if_empty(self.config)

--- a/subtests/docker_cli/rm/rm.py
+++ b/subtests/docker_cli/rm/rm.py
@@ -21,6 +21,7 @@ from dockertest.images import DockerImage
 from dockertest.output import OutputGood
 from dockertest import environment
 
+
 class rm(SubSubtestCaller):
     config_section = 'docker_cli/rm'
 
@@ -30,11 +31,10 @@ class rm(SubSubtestCaller):
         for cntr in dc.list_containers():
             self.failif('exit' not in cntr.status.lower(),
                         "Container %s found running before test!"
-                         % cntr.container_name)
+                        % cntr.container_name)
         super(rm, self).initialize()
         # Static data for subtests to use
         self.stuff['init_time'] = int(time.time())
-
 
     def postprocess(self):
         super(rm, self).postprocess()
@@ -50,6 +50,7 @@ class rm(SubSubtestCaller):
             self.logwarning("Removing leftover container: %s", cnt)
             dc.remove_by_obj(cnt)
 
+
 class rm_sub_base(SubSubtest):
 
     def rm_container(self, what):
@@ -60,7 +61,7 @@ class rm_sub_base(SubSubtest):
         self.sub_stuff['rm_cmdresult'] = rm_cmd.execute()
         wait_rm = self.config['wait_rm']
         self.loginfo("Sleeping %d seconds after rm",
-                      wait_rm)
+                     wait_rm)
         time.sleep(wait_rm)
 
     def signal_container(self, name):
@@ -128,7 +129,7 @@ class rm_sub_base(SubSubtest):
                    "echo 'foobar' > stop && "
                    "rm -f stop && trap '/usr/bin/date +%%s> stop' %s && "
                    "while ! [ -f stop ]; do /usr/bin/sleep 0.1s; done"
-                    "\""
+                   "\""
                    % self.config['listen_signal'])
         subargs.append(command)
 
@@ -181,7 +182,7 @@ class rm_sub_base(SubSubtest):
         self.wait_start()
         wait_start = self.config['wait_start']
         self.loginfo("Sleeping %d seconds after container start",
-                      wait_start)
+                     wait_start)
         time.sleep(wait_start)
         dkrcmd = self.sub_stuff['dkrcmd']
         dkrcmd.update_result()
@@ -195,7 +196,7 @@ class rm_sub_base(SubSubtest):
         self.failif(cmdresult.exit_status != 0, "Expected zero exit: %s"
                                                 % cmdresult)
         self.failif(rm_cmdresult.exit_status != 0, "Expected zero exit: %s"
-                                                % rm_cmdresult)
+                    % rm_cmdresult)
         OutputGood(cmdresult)
         OutputGood(rm_cmdresult)
 
@@ -236,7 +237,9 @@ class rm_sub_base(SubSubtest):
         self.verify_start()
         self.verify_stop()
 
+
 class finished(rm_sub_base):
+
     """
     Signal to update timestamp, exit bash, verify container exit(0), call rm
     """
@@ -247,6 +250,7 @@ class finished(rm_sub_base):
         self.signal_container(cntr_name)
         self.wait_container()
         self.rm_container(cntr_name)
+
 
 class forced(rm_sub_base):
 
@@ -262,7 +266,7 @@ class forced(rm_sub_base):
         self.failif(cmdresult.exit_status == 0, "Expected non-zero exit: %s"
                                                 % cmdresult)
         self.failif(rm_cmdresult.exit_status != 0, "Expected zero exit: %s"
-                                                % rm_cmdresult)
+                    % rm_cmdresult)
         OutputGood(cmdresult)
         OutputGood(rm_cmdresult)
 

--- a/subtests/docker_cli/rmi/delete_wrong_name.py
+++ b/subtests/docker_cli/rmi/delete_wrong_name.py
@@ -11,6 +11,7 @@ from autotest.client import utils
 from rmi import rmi_base
 from dockertest.output import OutputGood
 
+
 class delete_wrong_name(rmi_base):
     config_section = 'docker_cli/rmi/delete_wrong_name'
 

--- a/subtests/docker_cli/rmi/only_tag.py
+++ b/subtests/docker_cli/rmi/only_tag.py
@@ -13,6 +13,7 @@ from rmi import rmi_base
 from dockertest.dockercmd import DockerCmd
 from dockertest.xceptions import DockerTestNAError
 
+
 class only_tag(rmi_base):
     config_section = 'docker_cli/rmi/only_tag'
 

--- a/subtests/docker_cli/rmi/rmi.py
+++ b/subtests/docker_cli/rmi/rmi.py
@@ -20,6 +20,7 @@ from dockertest.dockercmd import NoFailDockerCmd
 from dockertest.xceptions import DockerCommandError
 from dockertest.xceptions import DockerTestNAError
 
+
 class rmi(subtest.SubSubtestCaller):
     config_section = 'docker_cli/rmi'
 
@@ -27,6 +28,7 @@ class rmi(subtest.SubSubtestCaller):
         super(rmi, self).initialize()
         base_image = images.DockerImage.full_name_from_defaults(self.config)
         self.stuff['base_image'] = base_image
+
 
 class rmi_base(SubSubtest):
 
@@ -85,7 +87,7 @@ class rmi_base(SubSubtest):
             im = self.check_image_exists(self.sub_stuff["image_name"])
             self.sub_stuff['image_list'] = im
             self.failif(im != [], "Deleted image still exits: %s" %
-                                                self.sub_stuff["image_name"])
+                        self.sub_stuff["image_name"])
 
         elif self.config["docker_expected_result"] == "FAIL":
             self.failif(self.sub_stuff['cmdresult'].exit_status == 0,
@@ -101,7 +103,7 @@ class rmi_base(SubSubtest):
         di = DockerImages(self.parent_subtest)
         # Auto-converts "yes/no" to a boolean
         if (self.config['remove_after_test'] and
-            'image_list' in self.sub_stuff):
+                'image_list' in self.sub_stuff):
             for cont in self.sub_stuff["containers"]:
                 clean_cont = NoFailDockerCmd(self, "rm",
                                              ['--force', cont],
@@ -125,6 +127,7 @@ class rmi_base(SubSubtest):
 
 
 class with_blocking_container_by_tag(rmi_base):
+
     """
     Test output of docker rmi command
 
@@ -159,7 +162,7 @@ class with_blocking_container_by_tag(rmi_base):
 
         results = prep_changes.execute()
         dnamsg = ("Problems during initialization of"
-                                    " test: %s", results)
+                  " test: %s", results)
         if results.exit_status:
             raise DockerTestNAError(dnamsg)
         else:
@@ -219,7 +222,6 @@ class with_blocking_container_by_tag(rmi_base):
                     "Zero rmi exit status: Command should fail due to"
                     " wrong image name.")
 
-
     def postprocess(self):
         self._common_post()
         im = self.check_image_exists(self.sub_stuff["image_name"])
@@ -227,7 +229,9 @@ class with_blocking_container_by_tag(rmi_base):
                               " %s is still used by container." %
                     self.sub_stuff["image_name"])
 
+
 class with_blocking_container_by_id(with_blocking_container_by_tag):
+
     """
     Test output of docker Pull command
 

--- a/subtests/docker_cli/run/run_attach_stdout.py
+++ b/subtests/docker_cli/run/run_attach_stdout.py
@@ -55,8 +55,8 @@ class run_attach_stdout(run_base):
 
         self.logdebug("Starting attach command")
         attachcmd = AsyncDockerCmd(self.parent_subtest, 'attach',
-                                  self.sub_stuff['attach_options'],
-                                  timeout=self.config['docker_timeout'])
+                                   self.sub_stuff['attach_options'],
+                                   timeout=self.config['docker_timeout'])
         self.logdebug("Attach Command: %s", runcmd.command)
         attachcmd.execute()
         self.loginfo("Waiting for %s seconds for attach",
@@ -89,5 +89,5 @@ class run_attach_stdout(run_base):
         try:
             dc.kill_container_by_name(name)
         except ValueError:
-            pass  #  death was the goal
+            pass  # death was the goal
         dc.remove_by_name(self.sub_stuff["rand_name"])

--- a/subtests/docker_cli/run/run_interactive.py
+++ b/subtests/docker_cli/run/run_interactive.py
@@ -59,6 +59,6 @@ class run_interactive(run_base):
         self.failif(not str_in_output in cmd_stdout,
                     "Command %s output must contain %s but doesn't."
                     " Detail:%s" %
-                   (self.config["interactive_cmd"],
-                    str_in_output,
-                    cmdresult))
+                    (self.config["interactive_cmd"],
+                     str_in_output,
+                     cmdresult))

--- a/subtests/docker_cli/run/run_interactive_disconnect.py
+++ b/subtests/docker_cli/run/run_interactive_disconnect.py
@@ -88,9 +88,9 @@ class run_interactive_disconnect(run_base):
         self.failif(not str_in_output in cmd_stdout_attach,
                     "Command %s output must contain %s but doesn't."
                     " Detail:%s" %
-                   (self.config["bash_cmd"],
-                    str_in_output,
-                    self.sub_stuff['dkrcmd_attach'].cmdresult))
+                    (self.config["bash_cmd"],
+                     str_in_output,
+                     self.sub_stuff['dkrcmd_attach'].cmdresult))
 
     def cleanup(self):
         c_name = self.sub_stuff["rand_name"]

--- a/subtests/docker_cli/run/run_signal.py
+++ b/subtests/docker_cli/run/run_signal.py
@@ -18,7 +18,7 @@ class run_signal(run_base):
                                 self.sub_stuff['subargs'],
                                 timeout=self.config['docker_timeout'])
         self.logdebug("Starting background docker command, timeout %s seconds: "
-                     "%s", self.config['docker_timeout'], dkrcmd.command)
+                      "%s", self.config['docker_timeout'], dkrcmd.command)
         dkrcmd.verbose = True
         # Runs in background
         self.sub_stuff['dkrcmd'] = dkrcmd

--- a/subtests/docker_cli/run_memory/run_memory.py
+++ b/subtests/docker_cli/run_memory/run_memory.py
@@ -26,9 +26,11 @@ from dockertest.images import DockerImage
 from dockertest.subtest import SubSubtest
 from dockertest.subtest import SubSubtestCallerSimultaneous
 
+
 class run_memory(SubSubtestCallerSimultaneous):
 
     """subtest Caller"""
+
 
 class run_memory_base(SubSubtest):
 
@@ -57,27 +59,27 @@ class run_memory_base(SubSubtest):
 
         if container_memory == 0:
             if cgroup_memory == 0:
-                result = {'PASS':"container_memory is %s, "
-                             "unit %s, cgroup_memory is %s"
-                             % (container_memory, unit, cgroup_memory)}
+                result = {'PASS': "container_memory is %s, "
+                          "unit %s, cgroup_memory is %s"
+                          % (container_memory, unit, cgroup_memory)}
 
                 return result
             else:
-                result = {'FAIL':"container_memory is %s, "
-                             "unit %s, cgroup_memory is %s, status Unknown"
-                             % (container_memory, unit, cgroup_memory)}
+                result = {'FAIL': "container_memory is %s, "
+                          "unit %s, cgroup_memory is %s, status Unknown"
+                          % (container_memory, unit, cgroup_memory)}
 
                 return result
 
         if container_memory != cgroup_memory:
-            result = {'FAIL':"container_memory is %s "
-                             ",unit %s, cgroup_memory is %s"
-                             % (container_memory, unit, cgroup_memory)}
+            result = {'FAIL': "container_memory is %s "
+                      ",unit %s, cgroup_memory is %s"
+                      % (container_memory, unit, cgroup_memory)}
             return result
         else:
-            result = {'PASS':"container_memory is %s, "
-                             "unit %s, cgroup_memory is %s"
-                             % (container_memory, unit, cgroup_memory)}
+            result = {'PASS': "container_memory is %s, "
+                      "unit %s, cgroup_memory is %s"
+                      % (container_memory, unit, cgroup_memory)}
             return result
 
     @staticmethod
@@ -187,8 +189,8 @@ class run_memory_base(SubSubtest):
         inspect_id_args = ['--format={{.%s}}' % content]
         inspect_id_args.append(name)
         container_json = NoFailDockerCmd(self.parent_subtest,
-                                           'inspect',
-                                            inspect_id_args)
+                                         'inspect',
+                                         inspect_id_args)
         content_value = container_json.execute().stdout.strip()
 
         return content_value
@@ -234,23 +236,23 @@ class run_memory_base(SubSubtest):
         for subargs in self.sub_stuff['subargs']:
             if self.config['expect_success'] == "PASS":
                 memory_container = NoFailDockerCmd(self.parent_subtest,
-                                                'run -d -t',
-                                                subargs).execute()
+                                                   'run -d -t',
+                                                   subargs).execute()
                 long_id = self.container_json(str(subargs[0]).split('=')[1],
                                               'ID')
                 memory_arg = self.get_value_from_arg(
-                                    self.get_arg_from_arglist(subargs, '-m'),
+                    self.get_arg_from_arglist(subargs, '-m'),
                                     ' ', 1)
                 memory = self.split_unit(memory_arg)
                 memory_value = memory[0]
                 memory_unit = memory[1]
 
                 cgroup_exist = self.check_cgroup_exist(long_id,
-                                           self.config['cgroup_path'],
-                                           self.config['cgroup_key_value'])
+                                                       self.config['cgroup_path'],
+                                                       self.config['cgroup_key_value'])
                 if cgroup_exist is True:
                     cgroup_memory = self.read_cgroup(
-                                            long_id,
+                        long_id,
                                             self.config['cgroup_path'],
                                             self.config['cgroup_key_value'])
                 else:
@@ -258,7 +260,7 @@ class run_memory_base(SubSubtest):
                                                 "exist!")
 
                 self.sub_stuff['result'].append(self.check_memory(
-                                                     memory_value,
+                    memory_value,
                                                      cgroup_memory,
                                                      memory_unit))
             else:
@@ -286,7 +288,7 @@ class run_memory_base(SubSubtest):
                     fail_check = True
                 else:
                     raise xceptions.DockerTestNAError(
-                         "%s invalid result %s"
+                        "%s invalid result %s"
                           % (clsname, result.keys()[0]))
             self.failif(fail_check is True,
                         "%s memory check mismatch %s"
@@ -302,11 +304,13 @@ class run_memory_base(SubSubtest):
             for name in self.sub_stuff.get('name', []):
                 self.logdebug("Cleaning up %s", name)
                 dcmd = DockerCmd(self.parent_subtest,
-                                     'rm',
-                                     ['--force', name])
+                                 'rm',
+                                 ['--force', name])
                 dcmd.execute()
 
+
 class memory_positive(run_memory_base):
+
     """
     Test usage of docker 'run -m' command positively.
 
@@ -318,7 +322,9 @@ class memory_positive(run_memory_base):
     """
     pass
 
+
 class memory_no_cgroup(run_memory_base):
+
     """
     Test usage of docker 'run -m' command that sets memory to 0.
 
@@ -328,7 +334,9 @@ class memory_no_cgroup(run_memory_base):
     """
     pass
 
+
 class memory_negative(run_memory_base):
+
     """
     Test usage of docker 'run -m' command negatively
 

--- a/subtests/docker_cli/run_volumes/run_volumes.py
+++ b/subtests/docker_cli/run_volumes/run_volumes.py
@@ -133,6 +133,7 @@ class volumes_base(SubSubtest):
         except IOError:
             subtest.logdebug("Container never ran for %s", cmdresult)
 
+
 class volumes_rw(volumes_base):
 
     def initialize(self):

--- a/subtests/docker_cli/run_volumes/volumes_one_source.py
+++ b/subtests/docker_cli/run_volumes/volumes_one_source.py
@@ -63,10 +63,10 @@ class volumes_one_source(volumes_base):
             file_path = self.tmpdir + "/" + name
             with open(file_path, 'r') as content:
                 data = content.read()
-                #uncommenting these print lines will show that the files are
-                #being written at the same time
-                #print file_path
-                #print data
+                # uncommenting these print lines will show that the files are
+                # being written at the same time
+                # print file_path
+                # print data
             md5 = hashlib.md5(data).hexdigest()
             self.failif(result != md5,
                         "MD5 mismatch for container: %s" % (name))

--- a/subtests/docker_cli/save_load/save_load.py
+++ b/subtests/docker_cli/save_load/save_load.py
@@ -25,6 +25,7 @@ from dockertest.output import OutputGood
 from dockertest.dockercmd import DockerCmd
 from dockertest import subtest
 
+
 class save_load(subtest.SubSubtestCaller):
     config_section = 'docker_cli/save_load'
 
@@ -91,7 +92,7 @@ class simple(save_load_base):
 
         self.failif(cid == [],
                     "Unable to search container with name %s: details :%s" %
-                   (c_name, cmdresult))
+                    (c_name, cmdresult))
 
         dkrcmd = DockerCmd(self.parent_subtest, 'commit',
                            [c_name, c_name], verbose=True)

--- a/subtests/docker_cli/start/long_term_app.py
+++ b/subtests/docker_cli/start/long_term_app.py
@@ -15,6 +15,7 @@ from autotest.client.shared import error
 from start import short_term_app, DockerContainersCLIRunOnly
 from dockertest.dockercmd import DockerCmd
 
+
 class long_term_app(short_term_app):
     config_section = 'docker_cli/start/long_term_app'
 

--- a/subtests/docker_cli/start/rerun_long_term_app.py
+++ b/subtests/docker_cli/start/rerun_long_term_app.py
@@ -11,6 +11,7 @@ docker start full_name
 from start import short_term_app
 from dockertest.output import OutputGood
 
+
 class rerun_long_term_app(short_term_app):
     config_section = 'docker_cli/start/rerun_long_term_app'
 

--- a/subtests/docker_cli/start/start.py
+++ b/subtests/docker_cli/start/start.py
@@ -16,6 +16,7 @@ from dockertest.images import DockerImage
 from dockertest import subtest
 from dockertest import config
 
+
 class DockerContainersCLIWithOutSize(DockerContainersCLI):
 
     """
@@ -101,7 +102,6 @@ class start_base(SubSubtest):
         self.failif(self.sub_stuff['cmdresult'].exit_status != 0,
                     "Non-zero start exit status: %s"
                     % self.sub_stuff['cmdresult'])
-
 
     def cleanup(self):
         super(start_base, self).cleanup()

--- a/subtests/docker_cli/stop/stop.py
+++ b/subtests/docker_cli/stop/stop.py
@@ -18,6 +18,7 @@ from dockertest.images import DockerImage
 from dockertest.output import OutputGood
 from dockertest.subtest import SubSubtest
 
+
 class stop(subtest.SubSubtestCaller):
 
     """ Subtest caller """

--- a/subtests/docker_cli/syslog/syslog.py
+++ b/subtests/docker_cli/syslog/syslog.py
@@ -15,6 +15,7 @@ from dockertest.containers import DockerContainers
 
 
 class syslog(Subtest):
+
     def initialize(self):
         super(syslog, self).initialize()
         dc = DockerContainers(self)

--- a/subtests/docker_cli/tag/change_registry.py
+++ b/subtests/docker_cli/tag/change_registry.py
@@ -18,6 +18,7 @@ from dockertest.images import DockerImage
 import random
 import string
 
+
 class change_registry(change_tag):
     config_section = 'docker_cli/commit/change_registry'
 

--- a/subtests/docker_cli/tag/change_repository.py
+++ b/subtests/docker_cli/tag/change_repository.py
@@ -17,6 +17,7 @@ from tag import change_tag
 from dockertest.images import DockerImage
 from autotest.client import utils
 
+
 class change_repository(change_tag):
     config_section = 'docker_cli/commit/change_repository'
 

--- a/subtests/docker_cli/tag/change_user.py
+++ b/subtests/docker_cli/tag/change_user.py
@@ -17,6 +17,7 @@ from tag import change_tag
 from dockertest.images import DockerImage
 from autotest.client import utils
 
+
 class change_user(change_tag):
     config_section = 'docker_cli/commit/change_repository'
 

--- a/subtests/docker_cli/tag/tag.py
+++ b/subtests/docker_cli/tag/tag.py
@@ -23,6 +23,7 @@ from dockertest import subtest
 from dockertest import config
 from dockertest import xceptions
 
+
 class tag(subtest.SubSubtestCaller):
     config_section = 'docker_cli/tag'
 
@@ -43,7 +44,7 @@ class tag_base(SubSubtest):
         new_img_name = di.get_unique_name(name_prefix)
         while self.check_image_exists(new_img_name):
             new_img_name = "%s_%s" % (name_prefix,
-                                  utils.generate_random_string(8))
+                                      utils.generate_random_string(8))
 
         self.sub_stuff["image"] = new_img_name
         base_image = DockerImage.full_name_from_defaults(self.config)
@@ -61,8 +62,6 @@ class tag_base(SubSubtest):
 
         im = self.check_image_exists(self.sub_stuff["image"])
         self.sub_stuff['image_list'] = im
-
-
 
     def complete_docker_command_line(self):
         force = self.config["tag_force"]
@@ -142,7 +141,6 @@ class change_tag(tag_base):
                                                             registry,
                                                             registry_user)
         return new_img_name
-
 
     def initialize(self):
         super(change_tag, self).initialize()

--- a/subtests/docker_cli/top/top.py
+++ b/subtests/docker_cli/top/top.py
@@ -30,7 +30,7 @@ class top(subtest.Subtest):
 
     """ Subtest caller """
     config_section = 'docker_cli/top'
-    #F,UID,(PID),(PPID),(PRI),(NI),(VSZ),(RSS),(WCHAN),(STAT),(TTY),TIME,CMD
+    # F,UID,(PID),(PPID),(PRI),(NI),(VSZ),(RSS),(WCHAN),(STAT),(TTY),TIME,CMD
     __re_top_all = re.compile(r'\d+\s+\d+\s+(?P<pid>\d+)\s+(?P<ppid>\d+)\s+'
                               r'(?P<pri>\d+)\s+(?P<ni>\d+)\s+(?P<vsz>\d+)\s+'
                               r'(?P<rss>\d+)\s+(?P<wchan>\w+|-|\?)\s+'
@@ -148,7 +148,7 @@ class top(subtest.Subtest):
             os.write(cont_stdin, "while [ -e /test_cmd_lock ]; do :; "
                      "done &\n")
 
-        #time.sleep(3)
+        # time.sleep(3)
 
         last_idx = self._gather_processes(last_idx)
 

--- a/subtests/docker_cli/wait/wait.py
+++ b/subtests/docker_cli/wait/wait.py
@@ -236,6 +236,7 @@ class wait_base(SubSubtest):
 
 
 class no_wait(wait_base):
+
     """
     Test usage of docker 'wait' command (waits only for containers, which
     should already exited. Expected execution duration is 0s)
@@ -255,6 +256,7 @@ class no_wait(wait_base):
 
 
 class wait_first(wait_base):
+
     """
     Test usage of docker 'wait' command (first container exits after 10s,
     others immediately. Expected execution duration is 10s)
@@ -274,6 +276,7 @@ class wait_first(wait_base):
 
 
 class wait_last(wait_base):
+
     """
     Test usage of docker 'wait' command (last container exits after 10s,
     others immediately. Expected execution duration is 10s)
@@ -293,6 +296,7 @@ class wait_last(wait_base):
 
 
 class wait_missing(wait_base):
+
     """
     Test usage of docker 'wait' command (first and last containers doesn't
     exist, second takes 10s to finish and the rest should finish immediately.

--- a/subtests/docker_cli/workdir/workdir.py
+++ b/subtests/docker_cli/workdir/workdir.py
@@ -17,6 +17,7 @@ from dockertest.output import OutputGood
 
 
 class workdir(subtest.Subtest):
+
     def initialize(self):
         super(workdir, self).initialize()
         self.stuff['fin'] = DockerImage.full_name_from_defaults(self.config)

--- a/subtests/docker_daemon/network/icc.py
+++ b/subtests/docker_daemon/network/icc.py
@@ -40,7 +40,7 @@ class icc(network_base):
         args1.append("--name=%s" % (self.sub_stuff["cont1_name"]))
         args1.append(fin)
         self.sub_stuff["bash1"] = self.dkr_cmd.async("run", args1 + ["sh"],
-                                               stdin_r=AsyncDockerCmdSpec.PIPE)
+                                                     stdin_r=AsyncDockerCmdSpec.PIPE)
 
         self.sub_stuff["cont2_name"] = conts.get_unique_name("client")
         self.sub_stuff["containers"].append(self.sub_stuff["cont2_name"])
@@ -48,7 +48,7 @@ class icc(network_base):
         args2.append("--name=%s" % (self.sub_stuff["cont2_name"]))
         args2.append(fin)
         self.sub_stuff["bash2"] = self.dkr_cmd.async("run", args2 + ["sh"],
-                                               stdin_r=AsyncDockerCmdSpec.PIPE)
+                                                     stdin_r=AsyncDockerCmdSpec.PIPE)
 
         ip = self.get_container_ip(self.sub_stuff["cont1_name"])
         if ip is None:
@@ -59,7 +59,6 @@ class icc(network_base):
     def run_cmd(self, bash_stdin, cmd):
         self.logdebug("send command to container:\n%s" % (cmd))
         os.write(bash_stdin, cmd)
-
 
     def run_once(self):
         super(icc, self).run_once()
@@ -77,7 +76,7 @@ class icc(network_base):
                      " print \"Recv:\" + s.recv(100); s.close();'\n" %
                      self.sub_stuff["ip1"])
 
-        #Wait for possible ping passing.
+        # Wait for possible ping passing.
         out_fn = lambda: self.sub_stuff["bash2"].stdout
         wait_for_output(out_fn, "64 bytes", 10)
         if "python: not found" in out_fn():

--- a/subtests/docker_daemon/network/network.py
+++ b/subtests/docker_daemon/network/network.py
@@ -16,7 +16,9 @@ from dockertest import docker_daemon
 from dockertest.config import none_if_empty, get_as_list
 from dockertest.xceptions import DockerTestNAError
 
+
 class AsyncDockerCmdStdIn(AsyncDockerCmd):
+
     r"""
     Setup a call docker subcommand as if by CLI w/ subtest config integration
     Execute docker subcommand with arguments and a timeout.
@@ -42,7 +44,7 @@ class AsyncDockerCmdStdIn(AsyncDockerCmd):
     def __init__(self, subtest, subcmd, subargs=None, timeout=None,
                  verbose=True, stdin_r=None, stdin=None):
         super(AsyncDockerCmdStdIn, self).__init__(subtest, subcmd, subargs,
-                                                 timeout, verbose)
+                                                  timeout, verbose)
 
         self.stdin = stdin
         if stdin_r == self.PIPE:
@@ -62,6 +64,7 @@ class AsyncDockerCmdStdIn(AsyncDockerCmd):
 
 
 class AsyncDockerCmdSpec(AsyncDockerCmdStdIn):
+
     r"""
     Setup a call docker subcommand as if by CLI w/ subtest config integration
     Execute docker subcommand with arguments and a timeout.
@@ -88,6 +91,7 @@ class AsyncDockerCmdSpec(AsyncDockerCmdStdIn):
 
 
 class DkrcmdFactory(object):
+
     r"""
     DockerCmd factory create dockercmd object with specified subtest and more.
     Simplifies DockerCmd because replace blocking calling of docker by
@@ -196,13 +200,12 @@ class network_base(SubSubtest):
         docker_args.append("-H %s" % bind_addr)
         self.loginfo("Starting %s %s", self.config["docker_path"], docker_args)
         dd = docker_daemon.start(self.config["docker_path"],
-                                               docker_args)
+                                 docker_args)
         if not docker_daemon.output_match(dd):
             raise DockerTestNAError("Unable to start docker daemon:"
                                     "\n**STDOUT**:\n%s\n**STDERR**:\n%s" %
                                     (dd.get_stdout(), dd.get_stderr()))
         self.sub_stuff["docker_daemon"] = dd
-
 
     def cleanup(self):
         super(network_base, self).cleanup()
@@ -220,7 +223,7 @@ class network_base(SubSubtest):
 
         if "docker_daemon" in self.sub_stuff:
             docker_daemon.restart_service(
-                                    self.sub_stuff["docker_daemon"])
+                self.sub_stuff["docker_daemon"])
 
     def get_jason(self, cont_name):
         try:

--- a/subtests/example/example.py
+++ b/subtests/example/example.py
@@ -4,6 +4,7 @@ Call superclass during each stage
 
 from dockertest import subtest
 
+
 class example(subtest.Subtest):
     iterations = 3
     config_section = 'example'


### PR DESCRIPTION
Hi @cevich, there are the promissed PEP8 fixes. It's done by `inspekt style` and `inspekt lint`. There are still lots of remaining warnings/errors/info which needs to be fixed manually. It'd be nice to have `inspekt github` running on each pull request similarly to autotest CI to check this for us. Alternatively the one who merges the changes should run `inspekt` manually and include the fix before he hits the green button.

Regards,
Lukáš
