### PR TITLE
Docker: Reset minimum autotest version

### DIFF
--- a/config_defaults/defaults.ini
+++ b/config_defaults/defaults.ini
@@ -9,7 +9,7 @@
 config_version = 0.7.6
 
 # Autotest version dependency for framework (or override for individual tests)
-autotest_version = 0.16.0-master-32-g050cd
+autotest_version = 0.16.0-master-66-g9aaee
 
 # Subtests and SubSubtests names to skip (CSV)
 disable =


### PR DESCRIPTION
Formerly, the version set could not be reached from current
HEAD for whatever reason (non-ff update maybe?).  Reset
the minimum default reference to one currently reachable.

Signed-off-by: Chris Evich cevich@redhat.com
