### PR TITLE
dockertest.images & containers: Only check SubBase

### DIFF
--- a/dockertest/images.py
+++ b/dockertest/images.py
@@ -31,7 +31,7 @@ from autotest.client import utils
 from output import OutputGood
 # FIXME: from output import TextTable
 # FIXME: parse output table with TextTable
-from subtest import Subtest
+from subtest import SubBase
 from xceptions import DockerFullNameFormatError
 from xceptions import DockerCommandError
 
@@ -299,8 +299,7 @@ class DockerImagesBase(object):
         """
         Initialize subclass operational instance.
 
-        :param subtest: A subtest.Subtest (**NOT** a SubSubtest) subclass
-                        instance
+        :param subtest: A subtest.SubBase subclass instance
         :param timeout: An opaque non-default timeout value to use on instance
         :param verbose: A boolean non-default verbose value to use on instance
         """
@@ -615,16 +614,16 @@ class DockerImages(object):
         """
         Execute docker subcommand with arguments and a timeout.
 
-        :param subtest: A subtest.Subtest subclass instance
+        :param subtest: A subtest.SubBase subclass instance
         :param interface_name: Class-defined string representing a
                                DockerImagesBase subclass
         :param timeout: Operational timeout override specific to interface
         :param verbose: Operational verbose override specific to interface
         """
         # Prevent accidental test.test instance passing
-        if not isinstance(subtest, Subtest):
-            raise TypeError("Instance %s is not a Subtest instance or "
-                            "subclass." % str(subtest))
+        if not isinstance(subtest, SubBase):
+            raise TypeError("Instance %s is not a SubBase or "
+                            "subclass instance." % str(subtest))
         _dic = self.interfaces[interface_name]
         super(DockerImages, self).__setattr__('_interface',
                                               _dic(subtest, timeout, verbose))


### PR DESCRIPTION
Similar to change made for DockerCmd, to allow instances
implementing the common aspects of Subtest and SubSubtest
to be used interchangably.

Signed-off-by: Chris Evich cevich@redhat.com
