### PR TITLE
subtests.docker_cli: Add run_user test

### DIFF
--- a/config_defaults/subtests/docker_cli/run_user.ini
+++ b/config_defaults/subtests/docker_cli/run_user.ini
@@ -1,0 +1,4 @@
+[docker_cli/run_user]
+docker_timeout = 60
+subsubtests = default,named_user,bad_user,bad_number,too_high_number
+exec_cmd = 'echo UIDCHECK: $UID:$GID; echo WHOAMICHECK: `whoami`'

--- a/index.rst
+++ b/index.rst
@@ -929,6 +929,18 @@ it was inserted successfully.
 
 Verify that could not run a container which is already running.
 
+``docker_cli/run_user`` Sub-test
+=================================
+
+This test checks correctness of docker run -u ...
+
+#.  get container's /etc/passwd
+#.  generate uid which suits the test needs (nonexisting, existing name, uid..)
+#.  execute docker run -u ... echo $UID:$GID; whoami
+#.  check results (pass/fail/details)
+
+subsubtests = default,named_user,bad_user,bad_number,too_high_number
+
 ``docker_cli/diff`` Sub-test
 ============================
 

--- a/subtests/docker_cli/run_user/run_user.py
+++ b/subtests/docker_cli/run_user/run_user.py
@@ -1,0 +1,299 @@
+"""
+This test checks correctness of docker run -u ...
+1) get container's /etc/passwd
+2) generate uid which suits the test needs (nonexisting, existing name, ..)
+3) execute docker run -u ... echo $UID:$GID; whoami
+4) check results (pass/fail/details)
+"""
+from autotest.client import utils
+from dockertest import config, xceptions, subtest
+from dockertest.containers import DockerContainers
+from dockertest.dockercmd import DockerCmd
+from dockertest.images import DockerImage
+from dockertest.output import OutputGood
+
+
+class run_user(subtest.SubSubtestCaller):
+
+    """ Subtest caller """
+
+    def _get_passwd_from_container(self):
+        """
+        Get /etc/passwd from container (it's used to generate correct uids)
+        """
+        name = self.stuff['dc'].get_unique_name("initialization", length=4)
+        self.stuff['container'] = name
+        subargs = ['--rm', '--interactive']
+        subargs.append("--name %s" % name)
+        fin = DockerImage.full_name_from_defaults(self.config)
+        subargs.append(fin)
+        subargs.append("cat /etc/passwd")
+        cmd = DockerCmd(self, 'run', subargs, verbose=False)
+        # FIXME: Remove '\n' when BZ1113085 is resolved
+        result = cmd.execute('\n')
+        self.failif(result.exit_status != 0,
+                    "Failed to get container's /etc/passwd. Exit status is !0"
+                    "\n%s" % result)
+        OutputGood(result)
+        return result.stdout
+
+    def initialize(self):
+        super(run_user, self).initialize()
+        self.stuff['dc'] = DockerContainers(self)
+        self.stuff['passwd'] = self._get_passwd_from_container()
+
+    def cleanup(self):
+        """
+        Cleanup the container
+        """
+        super(run_user, self).cleanup()
+        name = self.stuff['container']
+        conts = self.stuff['dc'].list_containers_with_name(name)
+        if conts == []:
+            return  # Docker was already removed
+        elif len(conts) > 1:
+            msg = ("Multiple containers match name '%s', not removing any"
+                   " of them...", name)
+            raise xceptions.DockerTestError(msg)
+        DockerCmd(self, 'rm', ['--force', '--volumes', name],
+                  verbose=False).execute()
+
+
+class run_user_base(subtest.SubSubtest):
+
+    """ Base class """
+
+    def _init_container(self, prefix, subargs, cmd):
+        """
+        Starts container
+        """
+        name = self.sub_stuff['dc'].get_unique_name(prefix, length=4)
+        self.sub_stuff['container'] = name
+        subargs.append("--name %s" % name)
+        fin = DockerImage.full_name_from_defaults(self.config)
+        subargs.append(fin)
+        subargs.append("bash")
+        subargs.append("-c")
+        subargs.append(cmd)
+        self.sub_stuff['cmd'] = DockerCmd(self, 'run', subargs, verbose=False)
+
+    def _init_test_depenent(self):
+        """
+        Override this with your desired test setup.
+        """
+        self.sub_stuff['execution_failure'] = None
+        self.sub_stuff['uid_check'] = None
+        self.sub_stuff['whoami_check'] = None
+        self.sub_stuff['subargs'] = None
+        raise NotImplementedError("Override this methodin your test!")
+
+    def initialize(self):
+        """
+        Runs one container
+        """
+        super(run_user_base, self).initialize()
+        # Prepare a container
+        config.none_if_empty(self.config)
+        self.sub_stuff['dc'] = DockerContainers(self.parent_subtest)
+        self._init_test_depenent()
+        self._init_container("test", self.sub_stuff['subargs'],
+                             self.config['exec_cmd'])
+
+    def run_once(self):
+        """
+        Execute docker and store the results
+        """
+        super(run_user_base, self).run_once()
+        # FIXME: Remove '\n' when BZ1113085 is resolved
+        self.sub_stuff['result'] = self.sub_stuff['cmd'].execute('\n')
+
+    def postprocess(self):
+        super(run_user_base, self).postprocess()
+        # Exit status
+        if self.sub_stuff['execution_failure']:
+            self._postprocess_bad()
+        else:
+            self._postprocess_good()
+
+    def _postprocess_bad(self):
+        """
+        Check that container execution failed with correct message
+        """
+        result = self.sub_stuff['result']
+        self.failif(result.exit_status == 0, "Container's exit status is "
+                    "0, although it should failed:\n0%s"
+                    % result)
+        output = (str(result.stdout) + str(result.stderr))
+        self.failif((self.sub_stuff['execution_failure']
+                     not in output),
+                    "Expected failure message '%s' is not in the "
+                    "container's output:\n%s"
+                    % (self.sub_stuff['execution_failure'], output))
+
+    def _postprocess_good(self):
+        """
+        Check that container executed correctly and that output is as expected
+        """
+        result = self.sub_stuff['result']
+        OutputGood(result)
+        self.failif(result.exit_status != 0,
+                    "Container's exit status is !0 although it should pass"
+                    ":\n%s" % result)
+        output = (str(result.stdout) + str(result.stderr))
+        self.failif(self.sub_stuff['uid_check'] not in output, "UID "
+                    "check line '%s' not present in the container output:\n%s"
+                    % (self.sub_stuff['uid_check'], result))
+        self.failif(self.sub_stuff['whoami_check'] not in output,
+                    "whoami check line '%s' not present in the container "
+                    "output:\n%s" % (self.sub_stuff['whoami_check'], result))
+
+    def _cleanup_container(self):
+        """
+        Cleanup the container
+        """
+        name = self.sub_stuff['container']
+        conts = self.sub_stuff['dc'].list_containers_with_name(name)
+        if conts == []:
+            return  # Docker was already removed
+        elif len(conts) > 1:
+            msg = ("Multiple containers match name '%s', not removing any"
+                   " of them...", name)
+            raise xceptions.DockerTestError(msg)
+        DockerCmd(self, 'rm', ['--force', '--volumes', name],
+                  verbose=False).execute()
+
+    def cleanup(self):
+        super(run_user_base, self).cleanup()
+        self._cleanup_container()
+
+
+class default(run_user_base):
+
+    """
+    Doesn't use "-u" and expects the default user to be root::0
+    """
+
+    def _init_test_depenent(self):
+        self.sub_stuff['execution_failure'] = False
+        self.sub_stuff['uid_check'] = "UIDCHECK: 0:"
+        self.sub_stuff['whoami_check'] = "WHOAMICHECK: root"
+        self.sub_stuff['subargs'] = ['--rm', '--interactive']
+
+
+class named_user(run_user_base):
+
+    """
+    Finds any user but root existing on container and uses it by name
+    """
+
+    def _init_test_depenent(self):
+        user = None
+        for line in self.parent_subtest.stuff['passwd'].splitlines():
+            line = line.strip()
+            if not line or line.startswith('root') or line.startswith('#'):
+                continue
+            user, _, uid, _ = line.split(':', 3)
+            break
+        if not user:
+            msg = ("This container's image doesn't contain passwd with "
+                   "multiple users, unable to execute this test\n%s"
+                   % self.parent_subtest.stuff['passwd'])
+            raise xceptions.DockerTestNAError(msg)
+        self.sub_stuff['execution_failure'] = False
+        self.sub_stuff['uid_check'] = "UIDCHECK: %s:" % uid
+        self.sub_stuff['whoami_check'] = "WHOAMICHECK: %s" % user
+        self.sub_stuff['subargs'] = ['--rm', '--interactive',
+                                     '--user=%s' % user]
+
+
+class num_user(run_user_base):
+
+    """
+    Finds any user but root existing on container and uses it by uid
+    """
+
+    def _init_test_depenent(self):
+        user = None
+        for line in self.parent_subtest.stuff['passwd'].splitlines():
+            line = line.strip()
+            if not line or line.startswith('root') or line.startswith('#'):
+                continue
+            user, _, uid, _ = line.split(':', 3)
+            break
+        if not user:
+            msg = ("This container's image doesn't contain passwd with "
+                   "multiple users, unable to execute this test\n%s"
+                   % self.parent_subtest.stuff['passwd'])
+            raise xceptions.DockerTestNAError(msg)
+        self.sub_stuff['execution_failure'] = False
+        self.sub_stuff['uid_check'] = "UIDCHECK: %s:" % uid
+        self.sub_stuff['whoami_check'] = "WHOAMICHECK: %s" % user
+        self.sub_stuff['subargs'] = ['--rm', '--interactive',
+                                     '--user=%s' % uid]
+
+
+class bad_user(run_user_base):
+
+    """
+    Generates user name which doesn't exist in containers passwd
+    """
+
+    def _init_test_depenent(self):
+        users = []
+        for line in self.parent_subtest.stuff['passwd'].splitlines():
+            line = line.strip()
+            try:
+                users.append(line.split(':', 1)[0])
+            except IndexError:
+                pass
+        user = utils.get_unique_name(lambda name: name not in users, "user",
+                                     length=6)
+        self.sub_stuff['execution_failure'] = "Unable to find user %s" % user
+        self.sub_stuff['subargs'] = ['--rm', '--interactive',
+                                     '--user=%s' % user]
+
+
+class bad_number(run_user_base):
+
+    """
+    Generates user id which doesn't exist in containers passwd
+    (it should start, print correct uid, but whoami should fail)
+    """
+
+    def _init_test_depenent(self):
+        uid = False
+        uids = []
+        for line in self.parent_subtest.stuff['passwd'].splitlines():
+            line = line.strip()
+            try:
+                uids.append(int(line.split(':', 3)[2]))
+            except (IndexError, TypeError):
+                pass
+        for i in xrange(1, 2147483647):
+            if i not in uids:
+                uid = i
+                break
+        if uid is False:
+            msg = ("This container's image passwd occupies all uids. Unable to"
+                   " execute this test\n%s"
+                   % self.parent_subtest.stuff['passwd'])
+            raise xceptions.DockerTestNAError(msg)
+        self.sub_stuff['execution_failure'] = False
+        self.sub_stuff['uid_check'] = "UIDCHECK: %s:" % uid
+        self.sub_stuff['whoami_check'] = ("whoami: cannot find name for user "
+                                          "ID %s" % uid)
+        self.sub_stuff['subargs'] = ['--rm', '--interactive',
+                                     '--user=%s' % uid]
+
+
+class too_high_number(run_user_base):
+
+    """
+    Uses incorrectly large uid number (2147483648)
+    """
+
+    def _init_test_depenent(self):
+        self.sub_stuff['execution_failure'] = ("Uids and gids must be in "
+                                               "range 0-2147483647")
+        self.sub_stuff['subargs'] = ['--rm', '--interactive',
+                                     '--user=2147483648']


### PR DESCRIPTION
this test changes --user and verifies it works correctly.

I encounter the problem with non-exiting containers unless stdin/stdout is used. I solved it by writing `\n` to stdin to avoid test hang and add FIXME note there. Probably we should put higher priority to this bug...

This patch fixes the https://github.com/autotest/autotest-docker/issues/209
