### PR TITLE
subtests.docker_cli.diff: Avoid RHEL-specific files in test

### DIFF
--- a/config_defaults/subtests/docker_cli/diff.ini
+++ b/config_defaults/subtests/docker_cli/diff.ini
@@ -7,9 +7,9 @@ command = /bin/touch,/root/doesnotexist
 files_changed = A,/root/doesnotexist,C,/root
 
 [docker_cli/diff/diff_change]
-command = /bin/touch,/root/anaconda-ks.cfg
-files_changed = C,/root/anaconda-ks.cfg
+command = /bin/touch,/usr
+files_changed = C,/usr
 
 [docker_cli/diff/diff_delete]
-command = /bin/rm,-f,/root/anaconda-ks.cfg
-files_changed = D,/root/anaconda-ks.cfg,C,/root
+command = /bin/rm,-rf,/usr/bin
+files_changed = D,/usr/bin,C,/usr


### PR DESCRIPTION
Use /usr and /usr/bin for test instead of anaconda's ones. Fixes the https://github.com/autotest/autotest-docker/issues/232 .

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
