### PR TITLE
subtests.docker_cli.build: Add two new subtests

### DIFF
--- a/config_defaults/subtests/docker_cli/build.ini
+++ b/config_defaults/subtests/docker_cli/build.ini
@@ -7,7 +7,13 @@ source_files = basic_tree.tar,basic_devices.tar,Dockerfile
 build_timeout_seconds = 120
 image_name_prefix = docker_test_
 image_name_postfix = :test
-subsubtests = local_path
+subsubtests = local_path,https_file,git_path
 
 [docker_cli/build/local_path]
 # By default 'dockerfile_path = self.srcdir'
+
+[docker_cli/build/https_file]
+dockerfile_path = https://raw.githubusercontent.com/ldoktor/autotest-docker-appliance/master/Dockerfile2
+
+[docker_cli/build/git_path]
+dockerfile_path = github.com/ldoktor/autotest-docker-appliance

--- a/index.rst
+++ b/index.rst
@@ -430,6 +430,11 @@ Simple test that checks the output of the ``docker version`` command.
 Tests the ``docker build`` command operation with a set of options
 and pre-defined build-content.
 
+``subsubtests = local_path,https_file,git_path``
+
+(``*_path`` means directory, which contains Dockerfile and required files,
+ ``*_file`` means direct path to the Dockerfile without other dependencies)
+
 ``docker_cli/build`` Prerequisites
 ------------------------------------------
 
@@ -450,6 +455,8 @@ and pre-defined build-content.
    exactly like the `docker_cli/dockerimport sub-test`_ test.
 *  The location of the statically linked ``busybox`` executable
    is specified by the ``busybox_url`` option.
+*  Source path of Dockerfile or directory containing Dockerfile is defined
+   by ``dockerfile_path``
 
 ``docker_cli/build_paths`` Sub-test
 ======================================

--- a/subtests/docker_cli/build/build.py
+++ b/subtests/docker_cli/build/build.py
@@ -205,3 +205,15 @@ class local_path(build_base):
     Path to a local directory within the Dockerfile and other files are present
     """
     pass
+
+
+class https_file(build_base):
+
+    """ https path to a Dockerfile """
+    pass
+
+
+class git_path(build_base):
+
+    """ path to a git reporistory which contains Dokerfile and othe files """
+    pass


### PR DESCRIPTION
This pull request fixes issue https://github.com/autotest/autotest-docker/issues/230. For now I used path to my special git repo hosted on github. It could stay like that or we can create this repo within the autotest namespace. The only requirement for this repo is that the docker files are stored in root.

These subtests use https and git repository as source path for
docker build.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
