### PR TITLE
Add sub-subtest to check docker rm --link

### DIFF
--- a/config_defaults/subtests/docker_cli/run_env.ini
+++ b/config_defaults/subtests/docker_cli/run_env.ini
@@ -1,2 +1,2 @@
 [docker_cli/run_env]
-subsubtests = port
+subsubtests = port,rm_link


### PR DESCRIPTION
This addresses #262.
-  Modified run_env test to be more firendly for adding sub-subtests and re-using code.
-  Did some minor reorganization, cleanup, and fixed some minor bugs/omissions.
