### PR TITLE
subtests.docker_cli: Update documentation docstrings

### DIFF
--- a/subtests/docker_cli/images_all/images_all.py
+++ b/subtests/docker_cli/images_all/images_all.py
@@ -8,21 +8,15 @@ checks the difference between ``docker images`` and ``docker images --all``.
 Operational Summary
 ----------------------
 
-#.  Create image test_a
-#.  Create image test_a1 with parent test_a
-#.  Create image test_b
-#.  Create image test_b1 with parent test_b
-#.  Untag test_a
-#.  Untag test_a1 (verify intermediary images were removed too)
-#.  Untag test_b1 (verify test_b was preserved)
+1.  Create image test_a
+2.  Create image test_a1 with parent test_a
+3.  Create image test_b
+4.  Create image test_b1 with parent test_b
+5.  Untag test_a
+6.  Untag test_a1 (verify intermediary images were removed too)
+7.  Untag test_b1 (verify test_b was preserved)
 
 *  Between steps 4-7 verify `docker images` and `docker history`
-
-Prerequisites
----------------
-
-Configuration
----------------
 """
 
 from dockertest import config, xceptions

--- a/subtests/docker_cli/logs_follow/logs_follow.py
+++ b/subtests/docker_cli/logs_follow/logs_follow.py
@@ -6,21 +6,15 @@ This test checks function of `docker logs --follow`
 
 Operational Summary
 ---------------------
-#.  Start container
-#.  Start `docker logs --follow` process
-#.  Execute couple of cmds
-#.  Start `docker logs` (without --follow) process
-#.  Execute couple of cmds (output to stderr)
-#.  Stop container
-#.  Start `docker logs` (without --follow) process
-#.  Check correctness o 2, then compare 2 and 7 (match) and 4 (partial
+1.  Start container
+2.  Start `docker logs --follow` process
+3.  Execute couple of cmds
+4.  Start `docker logs` (without --follow) process
+5.  Execute couple of cmds (output to stderr)
+6.  Stop container
+7.  Start `docker logs` (without --follow) process
+8.  Check correctness o 2, then compare 2 and 7 (match) and 4 (partial
     match). Also check all exit statuses/errors/...
-
-Prerequisites
----------------
-
-Configuration
----------------
 """
 
 import os

--- a/subtests/docker_cli/restart/restart.py
+++ b/subtests/docker_cli/restart/restart.py
@@ -7,18 +7,14 @@ Test usage of docker 'restart' command
 Operational Summary
 ----------------------
 
-#. start container with test command
-#. check container output for start message
-#. execute docker restart
-#. check container output for restart message
-#. execute docker stop
-#. check container output for stop message
-#. analyze results
+1. start container with test command
+2. check container output for start message
+3. execute docker restart
+4. check container output for restart message
+5. execute docker stop
+6. check container output for stop message
+7. analyze results
 
-
-Prerequisites
----------------------------------------------
-*  A remote registry server
 
 Configuration
 --------------------------------------

--- a/subtests/docker_cli/rm/rm.py
+++ b/subtests/docker_cli/rm/rm.py
@@ -7,17 +7,11 @@ Test for docker rm subcommand
 Operational Summary
 ----------------------
 
-#. Remember subtest start time
-#. Write subtest start time into sub-subtest tmpdir file
-#. Share sub-subtest tmpdir to container as volume
-#. Container waits for signal to update file in volume
-#. Run sub-subtests to exercize 'rm' on container and verify volume file
-
-Prerequisites
----------------
-
-Configuration
----------------
+1. Remember subtest start time
+2. Write subtest start time into sub-subtest tmpdir file
+3. Share sub-subtest tmpdir to container as volume
+4. Container waits for signal to update file in volume
+5. Run sub-subtests to exercize 'rm' on container and verify volume file
 """
 
 import os.path

--- a/subtests/docker_cli/run_attach/run_attach.py
+++ b/subtests/docker_cli/run_attach/run_attach.py
@@ -7,17 +7,10 @@ This test checks different ``docker run -a xxx`` variants.
 Operational Summary
 ----------------------
 
-#. Starts `docker run` with defined combination of `-a ...`
-   across 6 variants of tty/non-tty vs stdin/out/err.
-#. Analyze results
-
-Prerequisites
----------------
-
-Configuration
----------------
+1. Starts `docker run` with defined combination of `-a ...`
+   each subtest executes 6 variants of tty/non-tty vs stdin/out/err.
+2. Analyze results (exit_code, input_handling, correct_output)
 """
-
 from autotest.client import utils
 from dockertest import config, xceptions, subtest
 from dockertest.containers import DockerContainers

--- a/subtests/docker_cli/run_sigproxy/run_sigproxy.py
+++ b/subtests/docker_cli/run_sigproxy/run_sigproxy.py
@@ -2,18 +2,14 @@ r"""
 Summary
 ----------
 
-Test usage of docker run/attach with/without '--sig-proxy'.
+Test the difference of running docker run/attach with/without '--sig-proxy'.
 
 Operational Summary
 ----------------------
 
-#. start VM with test command
-#. kill $SIGNAL $test_process
-#. analyze results
-
-Prerequisites
-------------------
-*  A remote registry server
+1. start VM with test command
+2. kill $SIGNAL $test_process
+3. analyze results
 
 Configuration
 -------------------------------------------
@@ -21,7 +17,6 @@ Configuration
 *  The ``wait_start`` is duration of container init
 *  The ``kill_signals`` space separated list of signals used in test
 """
-
 import time
 from autotest.client import utils
 from dockertest import config, subtest

--- a/subtests/docker_cli/run_user/run_user.py
+++ b/subtests/docker_cli/run_user/run_user.py
@@ -7,16 +7,10 @@ This test checks correctness of docker run -u ...
 Operational Summary
 --------------------
 
-#.  get container's /etc/passwd
-#.  generate uid which suits the test needs (nonexisting, existing name, uid..)
-#.  execute docker run -u ... echo $UID:$GID; whoami
-#.  check results (pass/fail/details)
-
-Prerequisites
----------------
-
-Configuration
----------------
+1.  get container's /etc/passwd
+2.  generate uid which suits the test needs (nonexisting, existing name, uid..)
+3.  execute docker run -u ... echo $UID:$GID; whoami
+4.  check results (pass/fail/details)
 """
 from autotest.client import utils
 from dockertest import config, xceptions, subtest

--- a/subtests/docker_cli/stop/stop.py
+++ b/subtests/docker_cli/stop/stop.py
@@ -7,13 +7,9 @@ Test usage of docker 'stop' command
 Operational Summary
 ----------------------
 
-#. start VM with test command
-#. execute docker stop
-#. analyze results
-
-Prerequisites
----------------------------------------------
-*  A remote registry server
+1. start VM with test command
+2. execute docker stop
+3. analyze results (duration, exit_code)
 
 Configuration
 --------------------------------------

--- a/subtests/docker_cli/top/top.py
+++ b/subtests/docker_cli/top/top.py
@@ -7,19 +7,18 @@ Test usage of docker 'top' command
 Operational Summary
 ----------------------
 
-#. start container with bash
-#. execute docker top and container ps
-#. in container execute couple of processes
-#. execute docker top and container ps
-#. stop container
-#. execute docker top
-#. analyze results
+1. start container with bash
+2. execute docker top and container ps
+3. in container execute couple of processes
+4. execute docker top and container ps
+5. stop container
+6. execute docker top
+7. analyze results
 
 Prerequisites
 ---------------------------------------------
 
-*  A remote registry server
-*  A docker image capable of executing the ``ps`` command
+*  A docker image capable of executing the ``top`` command
 
 Configuration
 --------------------------------------


### PR DESCRIPTION
Hi @cevich, for each test I checked the prerequisites and removed the `A remote registry server` as this one is true for every test...

Note that I did not remove the configuration sections when they were filled as it will be easier to move them to INI file when the grabber is accepted. Although I have not create it when it was missing as it will be easier to do that in INI file later.

Couple of times I updated the description, but usually it was sufficient. I have not add any SubSubtest-related descriptions as those test's SubSubtests differed only in variables, not in steps. With the INI parser we'll have the `subsubtests = ...` list as first description in the `configuration` section so it will be easy to see which SubSubtests are there.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
