### PR TITLE
subtests...build: Provide self-contained and simple

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+# Simple dockerfile needed by some tests
+# to build from a static http/https/git location
+FROM centos:centos7
+RUN echo "Some ECHO line."

--- a/config_defaults/subtests/docker_cli/build.ini
+++ b/config_defaults/subtests/docker_cli/build.ini
@@ -14,12 +14,12 @@ dockerfile_path = /full
 
 [docker_cli/build/https_file]
 # Specify path to http/https based dockerfile (raw) e.g.:
-# dockerfile_path = https://raw.githubusercontent.com/ldoktor/autotest-docker-appliance/master/Dockerfile2
+# dockerfile_path = https://raw.githubusercontent.com/autotest/autotest-docker/Dockerfile
 dockerfile_path =
 
 [docker_cli/build/git_path]
 # Specify path to git based dockerfile e.g.:
-# dockerfile_path = github.com/ldoktor/autotest-docker-appliance
+# dockerfile_path = github.com/autotest/autotest-docker.git
 dockerfile_path =
 
 [docker_cli/build/rm_false]


### PR DESCRIPTION
Build test was failing with default configuration, provide
static links less dependent on external projects.

Signed-off-by: Chris Evich cevich@redhat.com
