### PR TITLE
dockertest: Modify {containers,images).get_unique_name()

### DIFF
--- a/config_defaults/subtests/docker_cli/build.ini
+++ b/config_defaults/subtests/docker_cli/build.ini
@@ -5,8 +5,6 @@ docker_build_options = --rm
 # busybox_url = http://www.busybox.net/downloads/binaries/latest/busybox-x86_64
 source_dirs = full,part,bad
 build_timeout_seconds = 120
-image_name_prefix = docker_test
-image_name_postfix = :test
 subsubtests = local_path,https_file,git_path,rm_false,rm_false_nocache,bad,bad_quiet,bad_force_rm
 
 [docker_cli/build/local_path]

--- a/config_defaults/subtests/docker_cli/commit.ini
+++ b/config_defaults/subtests/docker_cli/commit.ini
@@ -10,8 +10,6 @@ subsubtests = good,check_default_cmd
 [docker_cli/commit/good]
 #: expected result
 docker_expected_result = PASS
-#: Name prefix of the created testing image
-commit_repo_name_prefix = test
 #: Author
 commit_author = Author_name
 #: Commit message
@@ -22,8 +20,6 @@ commit_run_params = '{"Cmd": ["ls", "/etc"], "PortSpecs": ["22"]}'
 commit_changed_files = /var/i
 
 [docker_cli/commit/check_default_cmd]
-#: Name prefix of the created testing image
-commit_repo_name_prefix = test
 #: Author
 commit_author = Author_name
 #: Commit message

--- a/config_defaults/subtests/docker_cli/cp.ini
+++ b/config_defaults/subtests/docker_cli/cp.ini
@@ -2,10 +2,8 @@
 subsubtests = simple,every_last
 
 [docker_cli/cp/simple]
-name_prefix = simple_cp
 
 [docker_cli/cp/every_last]
-name_prefix = every_last
 #: **quoted** CSV of directory/file prefixes to skip 
 exclude_paths = "/dev", "/proc", "/sys", "/tmp", "/run/secrets"
 #: copy symlinks

--- a/config_defaults/subtests/docker_cli/dockerimport.ini
+++ b/config_defaults/subtests/docker_cli/dockerimport.ini
@@ -2,8 +2,6 @@
 [docker_cli/dockerimport]
 subsubtests = empty,truncated
 #: value used to automatically generate a unique image name.
-image_name_prefix = docker_test
-#: value used to automatically generate a unique image name.
 image_name_postfix = :test
 #: Full path to tar command on host
 tar_command = /usr/bin/tar

--- a/config_defaults/subtests/docker_cli/events.ini
+++ b/config_defaults/subtests/docker_cli/events.ini
@@ -9,6 +9,5 @@ wait_stop = 5
 rm_after_run = True
 #: CSV of required events for test to pass
 expect_events = create,start,die,destroy
-name_prefix = events
 #: specifies the number of lines with parse errors to allow
 unparseable_allowance = 5

--- a/config_defaults/subtests/docker_cli/history.ini
+++ b/config_defaults/subtests/docker_cli/history.ini
@@ -10,4 +10,3 @@ subsubtests = simple
 [docker_cli/history/simple]
 #: expected results
 docker_expected_result = PASS
-history_repo_name_prefix = test

--- a/config_defaults/subtests/docker_cli/import_url.ini
+++ b/config_defaults/subtests/docker_cli/import_url.ini
@@ -4,8 +4,6 @@ subsubtests = md5sum
 tar_url = https://github.com/autotest/autotest-docker/archive/0.7.6.tar.gz
 
 [docker_cli/import_url/md5sum]
-name_prefix = md5sum
-repo_prefix = md5sum
 #: specifies the full path to a test file
 #: contained within the tarball.
 in_tar_file = /autotest-docker-0.7.6/index.rst

--- a/config_defaults/subtests/docker_cli/iptable.ini
+++ b/config_defaults/subtests/docker_cli/iptable.ini
@@ -1,6 +1,5 @@
 [docker_cli/iptable]
 subsubtests = iptable_remove
-name_prefix = test
 
 [docker_cli/iptable/iptable_remove]
 #: container's shell

--- a/config_defaults/subtests/docker_cli/restart.ini
+++ b/config_defaults/subtests/docker_cli/restart.ini
@@ -4,7 +4,6 @@ docker_timeout = 60
 run_options_csv = --detach
 #: modifies the ``docker restart`` options
 restart_options_csv = --time=10
-restart_name_prefix = test
 #: ``True`` - expected string must not be present in the output
 check_output_inverted = false
 #: executed command

--- a/config_defaults/subtests/docker_cli/rmi.ini
+++ b/config_defaults/subtests/docker_cli/rmi.ini
@@ -2,7 +2,6 @@
 #: maximal acceptable ``docker rmi`` duration
 docker_rmi_timeout = 30.0
 subsubtests = only_tag,delete_wrong_name,with_blocking_container_by_tag,with_blocking_container_by_id
-rmi_repo_tag_name_prefix = rmi_image
 #: use ``docker rmi --force``
 docker_rmi_force = no
 #: Expected results
@@ -13,8 +12,6 @@ docker_expected_result = PASS
 [docker_cli/rmi/with_blocking_container_by_tag]
 #: Command used to prepare the container
 docker_data_prepare_cmd = /bin/bash -c "echo '%%s' > /var/i"
-#: Name of the created testing image
-commit_repo_tag_name_prefix = test:commit_repo
 #: Author
 commit_author = Author_name
 #: Commit message
@@ -27,8 +24,6 @@ docker_commit_timeout = 60.0
 [docker_cli/rmi/with_blocking_container_by_id]
 #: Command used to prepare the container
 docker_data_prepare_cmd = /bin/bash -c "echo '%%s' > /var/i"
-#: Name of the created testing image
-commit_repo_tag_name_prefix = test:commit_repo
 #: Author
 commit_author = Author_name
 #: Commit message

--- a/config_defaults/subtests/docker_cli/run_cgroups.ini
+++ b/config_defaults/subtests/docker_cli/run_cgroups.ini
@@ -1,5 +1,4 @@
 [docker_cli/run_cgroups]
-name_prefix = memory
 #: subsystem path to the docker's cgroups on host
 cgroup_path = /sys/fs/cgroup/memory/system.slice/docker
 #: which key is used in this test
@@ -28,21 +27,18 @@ memory_invalid = abcd
 expect_success = FAIL
 
 [docker_cli/run_cgroups/cpu_positive]
-name_prefix = cpu_positive
 cgroup_path = /sys/fs/cgroup/cpu/system.slice/docker
 cgroup_key_value = cpu.shares
 #: Set/expected value of the ``cgroup_key_value``
 cpushares_value = 10
 
 [docker_cli/run_cgroups/cpu_zero]
-name_prefix = cpu_zero
 cgroup_path = /sys/fs/cgroup/cpu/system.slice/docker
 cgroup_key_value = cpu.shares
 #: Set/expected value of the ``cgroup_key_value``
 cpushares_value = 0
 
 [docker_cli/run_cgroups/cpu_none]
-name_prefix = cpu_zero
 cgroup_path = /sys/fs/cgroup/cpu/system.slice/docker
 #: Set/expected value of the ``cgroup_key_value``
 cgroup_key_value = cpu.shares

--- a/config_defaults/subtests/docker_cli/start.ini
+++ b/config_defaults/subtests/docker_cli/start.ini
@@ -15,7 +15,6 @@ run_cmd =
 docker_timeout = 60
 #: modifies the running container options
 run_options_csv = --tty=false,--interactive=true
-container_name_prefix = test
 docker_attach = no
 docker_interactive = no
 

--- a/config_defaults/subtests/docker_cli/stop.ini
+++ b/config_defaults/subtests/docker_cli/stop.ini
@@ -6,7 +6,6 @@ wait_start = 3
 run_options_csv = --tty,--rm,--attach=stdout
 #: modifies the docker stop options
 stop_options_csv = --time=10
-stop_name_prefix = test
 #: expected output to be found in stdout (if ``check_output_inverted = False``
 check_stdout =
 #: expect the ``check_stdout`` NOT to be present in the output

--- a/config_defaults/subtests/docker_cli/tag.ini
+++ b/config_defaults/subtests/docker_cli/tag.ini
@@ -1,7 +1,6 @@
 [docker_cli/tag]
 #: whether to use --force option
 tag_force = no
-tag_repo_name_prefix = test
 #: generate names using lowercase only
 gen_lower_only = True
 subsubtests = change_tag,change_repository,change_repository,change_user

--- a/config_defaults/subtests/docker_cli/top.ini
+++ b/config_defaults/subtests/docker_cli/top.ini
@@ -4,7 +4,6 @@ docker_timeout = 60
 #       (when using docker top, processes are displayed correctly)
 #: modifies the running container options
 run_options_csv = --tty=true,--interactive=true,--detach=true
-container_name_prefix = test
 
 
 #: !This test requires an image containing the ``top`` command on

--- a/dockertest/containers.py
+++ b/dockertest/containers.py
@@ -316,6 +316,10 @@ class DockerContainersBase(object):
         :return: Container name guaranteed to not be in-use.
         """
         assert length > 1
+        if prefix:
+            prefix = "%s-%s" % (self.subtest.__class__.__name__, prefix)
+        else:
+            prefix = self.subtest.__class__.__name__
         all_containers = [_.container_name for _ in self.list_containers()]
         check = lambda name: name not in all_containers
         return utils.get_unique_name(check, prefix, suffix, length)

--- a/dockertest/images.py
+++ b/dockertest/images.py
@@ -326,8 +326,13 @@ class DockerImagesBase(object):
         """
 
         assert length > 1
+        if prefix:
+            _name = "%s_%s_%%s" % (self.subtest.__class__.__name__, prefix)
+        else:
+            _name = "%s_%%s" % self.subtest.__class__.__name__
         all_images = self.list_imgs_full_name()
-        _name = "_".join([_ for _ in (prefix, '%s', suffix) if _])
+        if suffix:
+            _name += suffix
         for _ in xrange(1000):
             name = _name % utils.generate_random_string(length)
             if self.gen_lower_only:

--- a/subtests/docker_cli/build/build.py
+++ b/subtests/docker_cli/build/build.py
@@ -115,8 +115,7 @@ class build_base(subtest.SubSubtest):
         self.sub_stuff['existing_containers'] = dcont.list_container_ids()
         self.sub_stuff['di'] = dimg = DockerImages(self)
         self.sub_stuff['existing_images'] = dimg.list_imgs_ids()
-        img_name = dimg.get_unique_name(self.config['image_name_prefix'],
-                                        self.config['image_name_postfix'])
+        img_name = dimg.get_unique_name()
         # Build definition:
         # build['image_name'] - name
         # build['dockerfile_path'] - path to docker file

--- a/subtests/docker_cli/commit/commit.py
+++ b/subtests/docker_cli/commit/commit.py
@@ -42,8 +42,7 @@ class commit_base(SubSubtest):
         super(commit_base, self).initialize()
         config.none_if_empty(self.config)
         di = DockerImages(self.parent_subtest)
-        name_prefix = self.config["commit_repo_name_prefix"]
-        new_img_name = di.get_unique_name(name_prefix)
+        new_img_name = di.get_unique_name()
         self.sub_stuff["new_image_name"] = new_img_name
 
         self.sub_stuff['rand_data'] = utils.generate_random_string(8)

--- a/subtests/docker_cli/cp/cp.py
+++ b/subtests/docker_cli/cp/cp.py
@@ -58,7 +58,7 @@ class CpBase(SubSubtest):
         set_selinux_context(self.tmpdir)
         dc = self.sub_stuff['dc'] = DockerContainers(self, "cli")
         self.sub_stuff['di'] = DockerImages(self, "cli")
-        container_name = dc.get_unique_name(self.config['name_prefix'])
+        container_name = dc.get_unique_name()
         self.sub_stuff['container_name'] = container_name
         fqin = DockerImage.full_name_from_defaults(self.config)
         self.sub_stuff['fqin'] = fqin

--- a/subtests/docker_cli/diff/diff.py
+++ b/subtests/docker_cli/diff/diff.py
@@ -51,8 +51,7 @@ class diff_base(SubSubtest):
     def initialize(self):
         super(diff_base, self).initialize()
         dc = DockerContainers(self.parent_subtest)
-        scn = self.__class__.__name__
-        name = self.sub_stuff['name'] = dc.get_unique_name(prefix=scn)
+        name = self.sub_stuff['name'] = dc.get_unique_name()
         fin = DockerImage.full_name_from_defaults(self.config)
         subargs = ['--name=%s' % (name), fin]
         subargs = subargs + self.config['command'].split(',')

--- a/subtests/docker_cli/dockerimport/empty.py
+++ b/subtests/docker_cli/dockerimport/empty.py
@@ -19,8 +19,8 @@ class empty(SubSubtest):
     def initialize(self):
         super(empty, self).initialize()
         di = DockerImages(self.parent_subtest)
-        image_name_tag = di.get_unique_name(self.config['image_name_prefix'],
-                                            self.config['image_name_postfix'])
+        suffix = self.config.get('image_name_postfix')
+        image_name_tag = di.get_unique_name(suffix=suffix)
         image_name, image_tag = image_name_tag.split(':', 1)
         self.sub_stuff['image_name_tag'] = image_name_tag
         self.sub_stuff['image_name'] = image_name

--- a/subtests/docker_cli/events/events.py
+++ b/subtests/docker_cli/events/events.py
@@ -199,7 +199,7 @@ class events(Subtest):
     def initialize(self):
         super(events, self).initialize()
         dc = self.stuff['dc'] = DockerContainers(self)
-        fullname = dc.get_unique_name(prefix=self.config['name_prefix'])
+        fullname = dc.get_unique_name()
         fqin = DockerImage.full_name_from_defaults(self.config)
         # generic args have spots for some value substitution
         mapping = {'NAME': fullname, 'IMAGE': fqin}

--- a/subtests/docker_cli/flag/flag.py
+++ b/subtests/docker_cli/flag/flag.py
@@ -37,7 +37,7 @@ class flag(subtest.Subtest):
         self.stuff["cmdresult"] = []
         docker_containers = DockerContainers(self)
         self.logdebug("Generating ramdom name will take 1 minute")
-        cname = docker_containers.get_unique_name("docker", "test", 4)
+        cname = docker_containers.get_unique_name()
         self.stuff["containter_name"] = cname
 
     def run_once(self):

--- a/subtests/docker_cli/history/history.py
+++ b/subtests/docker_cli/history/history.py
@@ -54,17 +54,15 @@ class history_base(SubSubtest):
     def initialize(self):
         super(history_base, self).initialize()
         config.none_if_empty(self.config)
+        dimgs = DockerImages(self.parent_subtest)
 
         self.sub_stuff["containers"] = []
         self.sub_stuff["images"] = []
 
-        name_prefix = self.config["history_repo_name_prefix"]
-        new_img_name = "%s_%s" % (name_prefix,
-                                  utils.generate_random_string(8).lower())
+        new_img_name = dimgs.get_unique_name('1')
         self.sub_stuff["new_image_name"] = new_img_name
 
-        new_img_name2 = "%s_%s" % (name_prefix,
-                                   utils.generate_random_string(8).lower())
+        new_img_name2 = dimgs.get_unique_name('2')
         self.sub_stuff["new_image_name2"] = new_img_name2
 
         self.sub_stuff['rand_data'] = utils.generate_random_string(8)

--- a/subtests/docker_cli/images_all/images_all.py
+++ b/subtests/docker_cli/images_all/images_all.py
@@ -40,7 +40,7 @@ class images_all_base(SubSubtest):
         """
         if fin is None:
             fin = DockerImage.full_name_from_defaults(self.config)
-        name = self.sub_stuff['dc'].get_unique_name(prefix, length=4)
+        name = self.sub_stuff['dc'].get_unique_name(prefix)
         subargs.append("--name %s" % name)
         self.sub_stuff['containers'].append(name)
         subargs.append(fin)

--- a/subtests/docker_cli/import_export/import_export.py
+++ b/subtests/docker_cli/import_export/import_export.py
@@ -113,7 +113,7 @@ class simple(import_export_base):
         super(simple, self).initialize()
         # Test container setup
         dc = DockerContainers(self.parent_subtest)
-        c_name = dc.get_unique_name(self.__class__.__name__)
+        c_name = dc.get_unique_name()
         self.sub_stuff["containers"].append(c_name)
         self.init_test_container(c_name)
         # export/import command setup

--- a/subtests/docker_cli/import_url/import_url.py
+++ b/subtests/docker_cli/import_url/import_url.py
@@ -71,8 +71,8 @@ class base(SubSubtest):
         super(base, self).initialize()
         dc = self.sub_stuff['dc'] = DockerContainers(self, 'cli')
         di = self.sub_stuff['di'] = DockerImages(self, 'cli')
-        import_repo = di.get_unique_name(self.config['repo_prefix'])
-        run_name = dc.get_unique_name(self.config['name_prefix'])
+        import_repo = di.get_unique_name()
+        run_name = dc.get_unique_name()
         self.sub_stuff['run_name'] = run_name
         self.sub_stuff['import_repo'] = import_repo
         self.sub_stuff['import_cmdresult'] = None

--- a/subtests/docker_cli/iptable/iptable.py
+++ b/subtests/docker_cli/iptable/iptable.py
@@ -61,8 +61,7 @@ class iptable_base(SubSubtest):
         """
         docker_containers = DockerContainers(self.parent_subtest)
         image = DockerImage.full_name_from_defaults(self.config)
-        prefix = self.config['name_prefix']
-        name = docker_containers.get_unique_name(prefix, length=4)
+        name = docker_containers.get_unique_name()
         self.sub_stuff['name'] = name
         bash_cmd = self.config['bash_cmd']
         args = ["--name=%s" % name,

--- a/subtests/docker_cli/kill/kill.py
+++ b/subtests/docker_cli/kill/kill.py
@@ -155,7 +155,7 @@ class kill_base(subtest.SubSubtest):
         super(kill_base, self).initialize()
         # Prepare a container
         docker_containers = DockerContainers(self.parent_subtest)
-        name = docker_containers.get_unique_name("test", length=4)
+        name = docker_containers.get_unique_name()
         self.sub_stuff['container_name'] = name
         config.none_if_empty(self.config)
         if self.config.get('run_container_attached'):

--- a/subtests/docker_cli/logs_follow/logs_follow.py
+++ b/subtests/docker_cli/logs_follow/logs_follow.py
@@ -118,13 +118,13 @@ class logs_follow_base(SubSubtest):
 
     """ Base class """
 
-    def _init_container(self, prefix, subargs, cmd):
+    def _init_container(self, subargs, cmd):
         """
         Prepares dkrcmd and stores the name in self.sub_stuff['containers']
         and command in self.sub_stuff['async_processes'].
         :return: tuple(dkrcmd, name)
         """
-        name = self.sub_stuff['dc'].get_unique_name(prefix, length=4)
+        name = self.sub_stuff['dc'].get_unique_name()
         subargs.append("--name %s" % name)
         self.sub_stuff['containers'].append(name)
         fin = DockerImage.full_name_from_defaults(self.config)
@@ -242,8 +242,7 @@ class simple_base(logs_follow_base):
         super(simple_base, self).run_once()
         log_us = {}
         # Create container
-        dkrcmd, name = self._init_container('test', self.sub_stuff['subargs'],
-                                            'bash')
+        dkrcmd, name = self._init_container(self.sub_stuff['subargs'], 'bash')
         log_us['container'] = dkrcmd
         dkrcmd.execute()
         self.wait_exists(name)

--- a/subtests/docker_cli/ps_size/ps_size.py
+++ b/subtests/docker_cli/ps_size/ps_size.py
@@ -40,12 +40,12 @@ class ps_size_base(SubSubtest):
 
     """ Base class """
 
-    def _init_container(self, prefix, subargs, cmd):
+    def _init_container(self, subargs, cmd):
         """
         Prepares dkrcmd and stores the name in self.sub_stuff['containers']
         :return: dkrcmd
         """
-        name = self.sub_stuff['dc'].get_unique_name(prefix, length=4)
+        name = self.sub_stuff['dc'].get_unique_name()
         subargs.append("--name %s" % name)
         self.sub_stuff['containers'].append(name)
         fin = DockerImage.full_name_from_defaults(self.config)
@@ -107,7 +107,7 @@ class simple(ps_size_base):
             else:
                 segment = "1M"
                 self.sub_stuff['sizes'].append(size)
-            dkrcmd = self._init_container('test', [], dd_cmd % (segment, size))
+            dkrcmd = self._init_container([], dd_cmd % (segment, size))
             dkrcmd.execute()
 
     def postprocess(self):

--- a/subtests/docker_cli/psa/psa.py
+++ b/subtests/docker_cli/psa/psa.py
@@ -42,7 +42,7 @@ class psa(subtest.Subtest):
         super(psa, self).initialize()
         dc = self.stuff['dc'] = DockerContainers(self)
         dc.verify_output = True  # test subject, do extra checking
-        name = self.stuff['container_name'] = dc.get_unique_name("psa")
+        name = self.stuff['container_name'] = dc.get_unique_name()
         cidfile = os.path.join(self.tmpdir, 'cidfile')
         self.stuff['cidfile'] = cidfile
         subargs = ['--cidfile', cidfile,

--- a/subtests/docker_cli/rm/rm.py
+++ b/subtests/docker_cli/rm/rm.py
@@ -114,7 +114,7 @@ class rm_sub_base(SubSubtest):
 
     def init_subargs(self):
         dc = self.sub_stuff['dc']
-        cntr_name = dc.get_unique_name(self.__class__.__name__)
+        cntr_name = dc.get_unique_name()
         self.sub_stuff['cntr_name'] = cntr_name
         subargs = self.config['run_options_csv'].split(',')
         self.sub_stuff['subargs'] = subargs

--- a/subtests/docker_cli/rmi/delete_wrong_name.py
+++ b/subtests/docker_cli/rmi/delete_wrong_name.py
@@ -8,8 +8,9 @@ docker rmi full_name
 3. Check if rmi command failed
 """
 from autotest.client import utils
-from rmi import rmi_base
+from dockertest.images import DockerImages
 from dockertest.output import OutputGood
+from rmi import rmi_base
 
 
 class delete_wrong_name(rmi_base):
@@ -18,17 +19,9 @@ class delete_wrong_name(rmi_base):
     def initialize(self):
         super(delete_wrong_name, self).initialize()
 
-        name_prefix = self.config["rmi_repo_tag_name_prefix"]
-
         rand_data = utils.generate_random_string(5).lower()
         self.sub_stuff["rand_data"] = rand_data
-        im_name = "%s_%s" % (name_prefix, rand_data)
-        im = self.check_image_exists(im_name)
-        while im != []:
-            rand_data = utils.generate_random_string(5)
-            self.sub_stuff["rand_data"] = rand_data
-            im_name = "%s_%s" % (name_prefix, rand_data)
-            im = self.check_image_exists(im_name)
+        im_name = DockerImages(self.parent_subtest).get_unique_name()
 
         self.sub_stuff["image_name"] = im_name
         # Private to this instance, outside of __init__

--- a/subtests/docker_cli/rmi/only_tag.py
+++ b/subtests/docker_cli/rmi/only_tag.py
@@ -9,9 +9,10 @@ docker rmi full_name
 """
 
 from autotest.client import utils
-from rmi import rmi_base
 from dockertest.dockercmd import DockerCmd
+from dockertest.images import DockerImages
 from dockertest.xceptions import DockerTestNAError
+from rmi import rmi_base
 
 
 class only_tag(rmi_base):
@@ -20,17 +21,9 @@ class only_tag(rmi_base):
     def initialize(self):
         super(only_tag, self).initialize()
 
-        name_prefix = self.config["rmi_repo_tag_name_prefix"]
-
         rand_data = utils.generate_random_string(5).lower()
         self.sub_stuff["rand_data"] = rand_data
-        im_name = "%s_%s" % (name_prefix, rand_data)
-        im = self.check_image_exists(im_name)
-        while im != []:
-            rand_data = utils.generate_random_string(5).lower()
-            self.sub_stuff["rand_data"] = rand_data
-            im_name = "%s_%s" % (name_prefix, rand_data)
-            im = self.check_image_exists(im_name)
+        im_name = DockerImages(self.parent_subtest).get_unique_name()
 
         self.sub_stuff["image_name"] = im_name
         # Private to this instance, outside of __init__

--- a/subtests/docker_cli/rmi/rmi.py
+++ b/subtests/docker_cli/rmi/rmi.py
@@ -190,8 +190,7 @@ class with_blocking_container_by_tag(rmi_base):
         self.sub_stuff["rand_data"] = rand_data
 
         di = DockerImages(self.parent_subtest)
-        name_prefix = self.config["rmi_repo_tag_name_prefix"]
-        self.sub_stuff["image_name"] = di.get_unique_name(name_prefix)
+        self.sub_stuff["image_name"] = di.get_unique_name(":tag")
 
         cmd_with_rand = self.config['docker_data_prepare_cmd'] % (rand_data)
 

--- a/subtests/docker_cli/run/run.py
+++ b/subtests/docker_cli/run/run.py
@@ -111,8 +111,7 @@ class run_names(run_base):
         cont = self.sub_stuff["cont"]
         names = []
         for number in xrange(self.config['names_count']):
-            names.append(cont.get_unique_name(prefix='names',
-                                              suffix=str(number)))
+            names.append(cont.get_unique_name(suffix=str(number)))
         subargs = self.sub_stuff['subargs']
         self.sub_stuff['subargs'] = ["--name %s" % n for n in names] + subargs
         if self.config['last_name_sticks']:

--- a/subtests/docker_cli/run_attach/run_attach.py
+++ b/subtests/docker_cli/run_attach/run_attach.py
@@ -40,11 +40,11 @@ class run_attach_base(subtest.SubSubtest):
     # FIXME: Use stdin=None when BZ1113085 is resolved
     # FIXME: Review the results when BZ1131592 is resolved
 
-    def _init_container(self, prefix, tty, cmd, cmd_input='\n'):
+    def _init_container(self, tty, cmd, cmd_input='\n'):
         """
         Starts container
         """
-        name = self.sub_stuff['dc'].get_unique_name(prefix, length=4)
+        name = self.sub_stuff['dc'].get_unique_name()
         self.sub_stuff['containers'].append(name)
         subargs = self.sub_stuff['subargs'][:]
         if tty:
@@ -143,15 +143,13 @@ class run_attach_base(subtest.SubSubtest):
         self._init_test_depenent()
         for tty in (True, False):   # generate matrix of tested variants
             # interactive container
-            cont = self._init_container("test", tty,
-                                        'bash', 'ls /\nexit\n')
+            cont = self._init_container(tty, 'bash', 'ls /\nexit\n')
             self.sub_stuff['res_stdin_%s' % tty] = cont
             # stdout container
-            cont = self._init_container("test", tty,
-                                        'ls /')
+            cont = self._init_container(tty, 'ls /')
             self.sub_stuff['res_stdout_%s' % tty] = cont
             # stderr container
-            cont = self._init_container("test", tty,
+            cont = self._init_container(tty,
                                         'ls /I/hope/this/does/not/exist/%s'
                                         % utils.generate_random_string(6))
             self.sub_stuff['res_stderr_%s' % tty] = cont

--- a/subtests/docker_cli/run_cgroups/cpushares.py
+++ b/subtests/docker_cli/run_cgroups/cpushares.py
@@ -48,8 +48,7 @@ class cpu_base(cgroups_base):
             subargs = []
         else:
             subargs = ['--cpu-shares=%s' % cpushares_value]
-        name_prefix = self.config['name_prefix']
-        name = self.sub_stuff['name'] = dc.get_unique_name(name_prefix)
+        name = self.sub_stuff['name'] = dc.get_unique_name()
         subargs += ['--name=%s' % name,
                     '--detach',
                     '--tty',

--- a/subtests/docker_cli/run_cgroups/memory.py
+++ b/subtests/docker_cli/run_cgroups/memory.py
@@ -151,8 +151,7 @@ class memory_base(cgroups_base):
             memory_list.append(self.config['memory_invalid'])
 
         for memory in memory_list:
-            name_prefix = self.config['name_prefix']
-            name = docker_containers.get_unique_name(name_prefix)
+            name = docker_containers.get_unique_name()
             if self.config['expect_success'] == "PASS":
                 self.sub_stuff['name'].append(name)
             args.append(self.combine_subargs(name,

--- a/subtests/docker_cli/run_env/run_env.py
+++ b/subtests/docker_cli/run_env/run_env.py
@@ -200,7 +200,7 @@ class run_env_base(SubSubtest):
         Prepares dkrcmd and stores the name in self.sub_stuff['containers']
         :return: tuple(dkrcmd, name)
         """
-        name = self.sub_stuff['dc'].get_unique_name(prefix, length=4)
+        name = self.sub_stuff['dc'].get_unique_name(prefix)
         subargs.append("--name %s" % name)
         self.logdebug("Queuing container %s for removal", name)
         self.sub_stuff['containers'].append(name)

--- a/subtests/docker_cli/run_sigproxy/run_sigproxy.py
+++ b/subtests/docker_cli/run_sigproxy/run_sigproxy.py
@@ -96,7 +96,7 @@ class sigproxy_base(SubSubtest):
         config.none_if_empty(self.config)
         # Prepare a container
         docker_containers = DockerContainers(self.parent_subtest)
-        name = docker_containers.get_unique_name("test", length=4)
+        name = docker_containers.get_unique_name()
         self.sub_stuff['container_name'] = name
         if self.sub_stuff['attached']:
             self._init_container_attached(name)

--- a/subtests/docker_cli/run_user/run_user.py
+++ b/subtests/docker_cli/run_user/run_user.py
@@ -70,11 +70,11 @@ class run_user_base(subtest.SubSubtest):
 
     """ Base class """
 
-    def _init_container(self, prefix, subargs, cmd):
+    def _init_container(self, subargs, cmd):
         """
         Starts container
         """
-        name = self.sub_stuff['dc'].get_unique_name(prefix, length=4)
+        name = self.sub_stuff['dc'].get_unique_name()
         self.sub_stuff['container'] = name
         subargs.append("--name %s" % name)
         fin = DockerImage.full_name_from_defaults(self.config)
@@ -103,7 +103,7 @@ class run_user_base(subtest.SubSubtest):
         config.none_if_empty(self.config)
         self.sub_stuff['dc'] = DockerContainers(self.parent_subtest)
         self._init_test_depenent()
-        self._init_container("test", self.sub_stuff['subargs'],
+        self._init_container(self.sub_stuff['subargs'],
                              self.config['exec_cmd'])
 
     def run_once(self):

--- a/subtests/docker_cli/save_load/save_load.py
+++ b/subtests/docker_cli/save_load/save_load.py
@@ -92,7 +92,7 @@ class save_load_base(SubSubtest):
         else:
             subargs = []
         if name is True:
-            name = self.sub_stuff['cont'].get_unique_name("test", length=4)
+            name = self.sub_stuff['cont'].get_unique_name()
         elif name:
             name = name
         if name:
@@ -409,7 +409,7 @@ class stressed_load(save_load_base):
                         % str_results)
 
             # Execute the loaded image and check the file...
-            cntr = self.sub_stuff['cont'].get_unique_name("test", length=4)
+            cntr = self.sub_stuff['cont'].get_unique_name()
             dkrcmd = DockerCmd(self, "run", ['--rm', "--name %s" % cntr,
                                              name, "cat /test_file"])
             self.sub_stuff['containers'].append(cntr)

--- a/subtests/docker_cli/start/simple.py
+++ b/subtests/docker_cli/start/simple.py
@@ -33,9 +33,8 @@ class simple(subtest.SubSubtest):
         self._init_stuff()
         config.none_if_empty(self.config)
         # Get free name
-        prefix = self.config["container_name_prefix"]
         docker_containers = DockerContainers(self.parent_subtest)
-        name = docker_containers.get_unique_name(prefix, length=4)
+        name = docker_containers.get_unique_name()
         self.sub_stuff['container_name'] = name
 
     def _start_container(self, name):

--- a/subtests/docker_cli/stop/stop.py
+++ b/subtests/docker_cli/stop/stop.py
@@ -50,8 +50,7 @@ class stop_base(SubSubtest):
         super(stop_base, self).initialize()
         # Prepare a container
         docker_containers = DockerContainers(self.parent_subtest)
-        prefix = self.config["stop_name_prefix"]
-        name = docker_containers.get_unique_name(prefix, length=4)
+        name = docker_containers.get_unique_name()
         self.sub_stuff['container_name'] = name
         config.none_if_empty(self.config)
         if self.config.get('run_options_csv'):

--- a/subtests/docker_cli/syslog/syslog.py
+++ b/subtests/docker_cli/syslog/syslog.py
@@ -35,8 +35,7 @@ class syslog(Subtest):
     def initialize(self):
         super(syslog, self).initialize()
         dc = DockerContainers(self)
-        scn = self.__class__.__name__
-        name = self.stuff["container_name"] = dc.get_unique_name(prefix=scn)
+        name = self.stuff["container_name"] = dc.get_unique_name()
         self.stuff['name'] = '--name=%s' % name
         self.stuff['fin'] = DockerImage.full_name_from_defaults(self.config)
         self.stuff['params'] = '-v /dev/log:/dev/log'

--- a/subtests/docker_cli/tag/tag.py
+++ b/subtests/docker_cli/tag/tag.py
@@ -71,15 +71,12 @@ class tag_base(SubSubtest):
 
         di = DockerImages(self.parent_subtest)
         di.gen_lower_only = self.config['gen_lower_only']
-        name_prefix = self.config["tag_repo_name_prefix"]
-        new_img_name = di.get_unique_name(name_prefix)
-        while self.check_image_exists(new_img_name):
-            new_img_name = "%s_%s" % (name_prefix,
-                                      utils.generate_random_string(8))
-        if self.config['gen_lower_only']:
-            new_img_name = new_img_name.lower()
-        else:
-            new_img_name += '_UP'  # guarantee some upper-case
+        new_img_name = di.get_unique_name()
+        # Make sure there are UPPER chars in the name (not gen_lower_only)
+        if (not self.config['gen_lower_only'] and
+                (new_img_name.lower() == new_img_name)):
+            new_img_name = di.get_unique_name("UPPER")
+
         self.sub_stuff["image"] = new_img_name
         base_image = DockerImage.full_name_from_defaults(self.config)
         self.prep_image(base_image)

--- a/subtests/docker_cli/top/top.py
+++ b/subtests/docker_cli/top/top.py
@@ -75,8 +75,7 @@ class top(subtest.Subtest):
                                     "did you set one for this test?")
 
         docker_containers = DockerContainers(self)
-        prefix = self.config["container_name_prefix"]
-        name = docker_containers.get_unique_name(prefix, length=4)
+        name = docker_containers.get_unique_name()
         self.stuff['container_name'] = name
         if self.config.get('run_options_csv'):
             subargs = [arg for arg in

--- a/subtests/docker_daemon/tls/tls.py
+++ b/subtests/docker_daemon/tls/tls.py
@@ -413,12 +413,12 @@ class tls_verify_all_base(tls_base):
         self.sub_stuff["docker_daemon"] = dd
 
         if self.sub_stuff["check_container_name"]:
-            self.sub_stuff["cont1_name"] = self.conts.get_unique_name("test")
+            self.sub_stuff["cont1_name"] = self.conts.get_unique_name()
             self.sub_stuff["containers"].append(self.sub_stuff["cont1_name"])
         else:
             # Try to generate name without check using docker.
             rand = utils.generate_random_string(30)
-            self.sub_stuff["cont1_name"] = "test" + rand
+            self.sub_stuff["cont1_name"] = self.__class__.__name__ + rand
             self.sub_stuff["containers"].append(self.sub_stuff["cont1_name"])
 
         # start docker client command


### PR DESCRIPTION
https://github.com/autotest/autotest-docker/issues/331 Make {containers,images).get_unique_name() always prepend the test name
and remove all unnecessarily prefixes from tests. The sensible ones were
kept (eg. server, client), but still the test name is going to be
prepended automatically.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
