### PR TITLE
subtests.docker_cli.kill: Reflect changes in uncatchable signals

### DIFF
--- a/config_defaults/subtests/docker_cli/kill.ini
+++ b/config_defaults/subtests/docker_cli/kill.ini
@@ -42,8 +42,11 @@ kill_map_signals = true
 # docker kill
 kill_sigproxy = true
 skip_signals = 9
-# 2 - should be OK is here for reference; 19, 27 - golang bug, 20 - SIGCONT
-signals_sequence = 2 19 20 27
+signals_sequence = 17 19 18 27
+stress_cmd_timeout = 3
+#: ``grep`` regexp matching the info in ``docker man run`` about noncatchable
+#: signals
+man_regexp = SIGCHLD.*SIGSTOP.*SIGKILL
 
 [docker_cli/kill/go_lang_bad_signals_ttyoff]
 kill_sigproxy = true


### PR DESCRIPTION
Uncatchable signals are now documented in `man docker run`.
Change `go_lang_bad_signals` test to check man pages and verify that
these signals are not handled (in case golang starts working again)

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
