### PR TITLE
 subtests.docker_cli.tag: Add double_tag variants and fix couple of bugs

### DIFF
--- a/config_defaults/subtests/docker_cli/tag.ini
+++ b/config_defaults/subtests/docker_cli/tag.ini
@@ -3,7 +3,7 @@
 tag_force = false
 #: generate names using lowercase only
 gen_lower_only = True
-subsubtests = change_tag,change_repository,change_repository,change_user
+subsubtests = change_tag,change_repository,change_repository,change_user,double_tag,double_tag_force
 #: expected results
 docker_expected_result = PASS
 #: testing repo_name_prefix
@@ -16,3 +16,9 @@ tag_repo_name_prefix = test
 [docker_cli/tag/change_repository]
 
 [docker_cli/tag/change_user]
+
+[docker_cli/tag/double_tag]
+docker_expected_result = FAIL
+
+[docker_cli/tag/double_tag_force]
+tag_force = true


### PR DESCRIPTION
This pull request fixes couple of bugs, style errors and last but not least implements 2 new tag subsubtests. See details in each commit.
