### PR TITLE
subtests.docker_cli.dockerinspect: Check CamelCase

### DIFF
--- a/subtests/docker_cli/dockerinspect/inspect_all.py
+++ b/subtests/docker_cli/dockerinspect/inspect_all.py
@@ -3,15 +3,20 @@ Test output of docker inspect command
 
 1. Create some docker containers
 2. Run docker inspect command on them
-3. Check output
-4. Compare output with values obtained in the container's config
+3. Check that all keys are CamelCase
+4. Check output
+5. Compare output with values obtained in the container's config
 """
 
-from dockertest.dockercmd import NoFailDockerCmd
+import re
+
 from dockerinspect import inspect_base
+from dockertest.dockercmd import NoFailDockerCmd
 
 
 class inspect_all(inspect_base):
+
+    re_camel_case = re.compile(r'^[A-Z][a-zA-Z]*$')
 
     def initialize(self):
         super(inspect_all, self).initialize()
@@ -27,6 +32,7 @@ class inspect_all(inspect_base):
     def postprocess(self):
         super(inspect_all, self).postprocess()
         cli_output = self.parse_cli_output(self.sub_stuff['cmdresult'].stdout)
+        self.check_camel_case(cli_output)
         cid = self.get_cid_from_name(self, self.sub_stuff['name'])
         config_map = self.get_config_maps([cid])
         # https://bugzilla.redhat.com/show_bug.cgi?id=1092781
@@ -35,3 +41,20 @@ class inspect_all(inspect_base):
                                  config_map,
                                  cli_output,
                                  ignore_fields=ifields)
+
+    def check_camel_case(self, info):
+        try:
+            self._check_camel_case(info)
+            self.loginfo("CamelCase test PASSED")
+        except ValueError, details:
+            self.failif(True, "%s\n%s" % (details, info))
+
+    def _check_camel_case(self, info):
+        if isinstance(info, list):
+            for item in info:
+                self._check_camel_case(item)
+        elif isinstance(info, dict):
+            for key, value in info.iteritems():
+                if not self.re_camel_case.match(key):
+                    raise ValueError("Key '%s' is not CamelCase" % key)
+                self._check_camel_case(value)


### PR DESCRIPTION
Fixes: https://github.com/autotest/autotest-docker/issues/260

This patch adds the CamelCase keys check into the
docker_cli/dockerinspect/inspect_all test.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
