### PR TITLE
Docs: Fix conf.py for readthedocs.org

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -296,3 +296,11 @@ setattr(mock('autotest.client.shared.version'), 'get_version', lambda: "0.15.0")
 mock('autotest.client.shared.base_job')
 mock('autotest.client.shared.job')
 mock('autotest.client.job')
+
+# -- Build subtests.rst and defaults.rst ---------------
+
+from dockertest.documentation import DefaultDoc
+from dockertest.documentation import SubtestDocs
+open('defaults.rst', 'w+').write(str(DefaultDoc('config_defaults/defaults.ini')))
+open('subtests.rst', 'w+').write(str(SubtestDocs()))
+


### PR DESCRIPTION
Additional files (subtests.rst and defaults.rst) are produced
for documentation by statically examining other project files.
Normally this would be accomplished by a Sphinx extension, however
for our simple needs, it's easier to use the existing method
employed in the Makefile.

Signed-off-by: Chris Evich cevich@redhat.com
