### PR TITLE
subtests.docker_cli.run_ipc_mem: Add custom-setup variants

### DIFF
--- a/config_defaults/subtests/docker_cli/run_ipc_mem.ini
+++ b/config_defaults/subtests/docker_cli/run_ipc_mem.ini
@@ -4,7 +4,8 @@ run_options_csv = -i
 #: Number of ping-pong iterations
 no_iterations = 128
 auto_subsubtests = host_hcont1,hcont1_host,cont1_c1cont2,hcont1_hcont2,host_cont1,cont1_cont2,hcont1_cont2,cont1_hcont2,host_hconts,host_hcont1_c1cont2,multi_conts_deep
-subsubtests = %(auto_subsubtests)s
+subsubtests = %(auto_subsubtests)s,host_w_hcont1_c1cont2,host_hcont1_w_c1cont2,host_hcont1_w_hcont2,cont1_w_c1cont2_c1cont3,cont1_c1cont2_w_c2cont3
+
 #: Setup string (**ONLY: auto_ipc_base** inherited tests); 
 #: Start workers according to setup. They are chained ``(A->B->C->...->A)``; 
 #: ``obj = host | cont$x | $ref_cont$x``;  
@@ -17,7 +18,7 @@ name_stop =
 #: What error string is expected (None=>None;True=>exit_code!=0;string=>string
 name_err =
 
-# Simple good (TODO: Add setups where the 2nd creates the shm)
+# Simple good
 [docker_cli/run_ipc_mem/host_hcont1]
 setup = host host_cont1
 cont1_stop = 120
@@ -63,7 +64,7 @@ cont1_err = Silent 0th iteration
 cont2_start = 15
 cont2_err = Silent 0th iteration
 
-# Advanced good (TODO: Add setups where 2nd/3rd creates the shm)
+# Advanced good
 [docker_cli/run_ipc_mem/host_hconts]
 setup = host host_cont1 host_cont2 host_cont3 host_cont4
 cont4_stop = 120

--- a/subtests/docker_cli/run_ipc_mem/cont1_c1cont2_w_c2cont3.py
+++ b/subtests/docker_cli/run_ipc_mem/cont1_c1cont2_w_c2cont3.py
@@ -1,0 +1,45 @@
+"""
+1. start cont1
+2. start cont2 --ipc container:$cont1
+3. start cont3 --ipc container:$cont2
+4. start worker on cont3 (cont3 allocates the shm)
+5. start workers on cont1 and cont2
+6. wait until they finish
+"""
+import random
+
+from run_ipc_mem import IpcBase
+
+
+class cont1_c1cont2_w_c2cont3(IpcBase):
+
+    def run_once(self):
+        super(cont1_c1cont2_w_c2cont3, self).run_once()
+        no_iter = self.config.get('no_iterations', 1024)
+        key = self._find_hosts_free_ipc(random.randint(1, 65536))
+        self.sub_stuff['shms'].append(key)
+        str1 = 'a%s' % self._generate_string()
+        str2 = 'b%s' % self._generate_string()
+        str3 = 'c%s' % self._generate_string()
+        # start containers
+        c1_name = self._init_container_stdin('cont1', None)
+        c2_name = self._init_container_stdin('cont2', "container:%s" % c1_name)
+        self._init_container_stdin('cont3', "container:%s" % c2_name)
+        # start worker on 3rd container
+        args = "%s %s %s %s n" % (key, no_iter, str1, str2)
+        self._exec_container_stdin(self.sub_stuff['cmds'][2], args)
+        args = "%s %s %s %s n" % (key, no_iter, str2, str3)
+        self._exec_container_stdin(self.sub_stuff['cmds'][1], args)
+        args = "%s %s %s %s y" % (key, no_iter, str3, str1)
+        self._exec_container_stdin(self.sub_stuff['cmds'][0], args)
+
+    def postprocess(self):
+        super(cont1_c1cont2_w_c2cont3, self).postprocess()
+        timeout = self.parent_subtest.adjust_timeout(120)
+        self.sub_stuff['cmds'][0].wait_check(timeout)
+        timeout = self.parent_subtest.adjust_timeout(15)
+        self.sub_stuff['cmds'][1].wait_check(timeout)
+        timeout = self.parent_subtest.adjust_timeout(15)
+        self.sub_stuff['cmds'][2].wait_check(timeout)
+        self.sub_stuff['cmds'] = []
+        self.sub_stuff['shms'] = []

--- a/subtests/docker_cli/run_ipc_mem/cont1_w_c1cont2_c1cont3.py
+++ b/subtests/docker_cli/run_ipc_mem/cont1_w_c1cont2_c1cont3.py
@@ -1,0 +1,45 @@
+"""
+1. start cont1
+2. start cont2 --ipc container:$cont1
+3. start cont3 --ipc container:$cont2
+4. start worker on cont2 (cont2 allocates the shm)
+5. start workers on cont1 and cont3
+6. wait until they finish
+"""
+import random
+
+from run_ipc_mem import IpcBase
+
+
+class cont1_w_c1cont2_c1cont3(IpcBase):
+
+    def run_once(self):
+        super(cont1_w_c1cont2_c1cont3, self).run_once()
+        no_iter = self.config.get('no_iterations', 1024)
+        key = self._find_hosts_free_ipc(random.randint(1, 65536))
+        self.sub_stuff['shms'].append(key)
+        str1 = 'a%s' % self._generate_string()
+        str2 = 'b%s' % self._generate_string()
+        str3 = 'c%s' % self._generate_string()
+        # start containers
+        c1_name = self._init_container_stdin('cont1', None)
+        c2_name = self._init_container_stdin('cont2', "container:%s" % c1_name)
+        self._init_container_stdin('cont3', "container:%s" % c2_name)
+        # start worker on 3rd container
+        args = "%s %s %s %s n" % (key, no_iter, str1, str2)
+        self._exec_container_stdin(self.sub_stuff['cmds'][1], args)
+        args = "%s %s %s %s n" % (key, no_iter, str2, str3)
+        self._exec_container_stdin(self.sub_stuff['cmds'][2], args)
+        args = "%s %s %s %s y" % (key, no_iter, str3, str1)
+        self._exec_container_stdin(self.sub_stuff['cmds'][0], args)
+
+    def postprocess(self):
+        super(cont1_w_c1cont2_c1cont3, self).postprocess()
+        timeout = self.parent_subtest.adjust_timeout(120)
+        self.sub_stuff['cmds'][0].wait_check(timeout)
+        timeout = self.parent_subtest.adjust_timeout(15)
+        self.sub_stuff['cmds'][2].wait_check(timeout)
+        timeout = self.parent_subtest.adjust_timeout(15)
+        self.sub_stuff['cmds'][1].wait_check(timeout)
+        self.sub_stuff['cmds'] = []
+        self.sub_stuff['shms'] = []

--- a/subtests/docker_cli/run_ipc_mem/host_hcont1_w_c1cont2.py
+++ b/subtests/docker_cli/run_ipc_mem/host_hcont1_w_c1cont2.py
@@ -1,0 +1,43 @@
+"""
+1. start cont1 --ipc host
+2. start cont2 --ipc container:$cont1
+3. start worker on cont2 (cont2 allocates the shm)
+4. start workers on host and cont1
+5. wait until they finish
+"""
+import random
+
+from run_ipc_mem import IpcBase
+
+
+class host_hcont1_w_c1cont2(IpcBase):
+
+    def run_once(self):
+        super(host_hcont1_w_c1cont2, self).run_once()
+        no_iter = self.config.get('no_iterations', 1024)
+        key = self._find_hosts_free_ipc(random.randint(1, 65536))
+        self.sub_stuff['shms'].append(key)
+        str1 = 'a%s' % self._generate_string()
+        str2 = 'b%s' % self._generate_string()
+        str3 = 'c%s' % self._generate_string()
+        # start containers
+        c1_name = self._init_container_stdin('cont1', "host")
+        self._init_container_stdin('cont2', "container:%s" % c1_name)
+        # start worker on 3rd container
+        args = "%s %s %s %s n" % (key, no_iter, str1, str2)
+        self._exec_container_stdin(self.sub_stuff['cmds'][1], args)
+        args = "%s %s %s %s n" % (key, no_iter, str2, str3)
+        self._exec_host('host', args)
+        args = "%s %s %s %s y" % (key, no_iter, str3, str1)
+        self._exec_container_stdin(self.sub_stuff['cmds'][0], args)
+
+    def postprocess(self):
+        super(host_hcont1_w_c1cont2, self).postprocess()
+        timeout = self.parent_subtest.adjust_timeout(120)
+        self.sub_stuff['cmds'][0].wait_check(timeout)
+        timeout = self.parent_subtest.adjust_timeout(15)
+        self.sub_stuff['cmds'][2].wait_check(timeout)
+        timeout = self.parent_subtest.adjust_timeout(15)
+        self.sub_stuff['cmds'][1].wait_check(timeout)
+        self.sub_stuff['cmds'] = []
+        self.sub_stuff['shms'] = []

--- a/subtests/docker_cli/run_ipc_mem/host_hcont1_w_hcont2.py
+++ b/subtests/docker_cli/run_ipc_mem/host_hcont1_w_hcont2.py
@@ -1,0 +1,44 @@
+"""
+1. start cont1 --ipc host
+2. start cont2 --ipc container:$cont1
+3. start cont3 --ipc container:$cont2
+4. start worker on cont2 (cont2 allocates the shm)
+5. start workers on cont1 and cont3
+6. wait until they finish
+"""
+import random
+
+from run_ipc_mem import IpcBase
+
+
+class host_hcont1_w_hcont2(IpcBase):
+
+    def run_once(self):
+        super(host_hcont1_w_hcont2, self).run_once()
+        no_iter = self.config.get('no_iterations', 1024)
+        key = self._find_hosts_free_ipc(random.randint(1, 65536))
+        self.sub_stuff['shms'].append(key)
+        str1 = 'a%s' % self._generate_string()
+        str2 = 'b%s' % self._generate_string()
+        str3 = 'c%s' % self._generate_string()
+        # start containers
+        c1_name = self._init_container_stdin('cont1', "host")
+        self._init_container_stdin('cont2', "container:%s" % c1_name)
+        # start worker on 3rd container
+        args = "%s %s %s %s n" % (key, no_iter, str1, str2)
+        self._exec_container_stdin(self.sub_stuff['cmds'][1], args)
+        args = "%s %s %s %s n" % (key, no_iter, str2, str3)
+        self._exec_container_stdin(self.sub_stuff['cmds'][0], args)
+        args = "%s %s %s %s y" % (key, no_iter, str3, str1)
+        self._exec_host('host', args)
+
+    def postprocess(self):
+        super(host_hcont1_w_hcont2, self).postprocess()
+        timeout = self.parent_subtest.adjust_timeout(120)
+        self.sub_stuff['cmds'][2].wait_check(timeout)
+        timeout = self.parent_subtest.adjust_timeout(15)
+        self.sub_stuff['cmds'][0].wait_check(timeout)
+        timeout = self.parent_subtest.adjust_timeout(15)
+        self.sub_stuff['cmds'][1].wait_check(timeout)
+        self.sub_stuff['cmds'] = []
+        self.sub_stuff['shms'] = []

--- a/subtests/docker_cli/run_ipc_mem/host_w_hcont1_c1cont2.py
+++ b/subtests/docker_cli/run_ipc_mem/host_w_hcont1_c1cont2.py
@@ -1,0 +1,42 @@
+"""
+1. start cont1 --ipc host and worker (cont1 allocates the shm)
+2. start cont2 --ipc container:$cont1
+3. start workers on host and cont2
+4. wait until they finish
+"""
+import random
+
+from run_ipc_mem import IpcBase
+
+
+class host_w_hcont1_c1cont2(IpcBase):
+
+    def run_once(self):
+        super(host_w_hcont1_c1cont2, self).run_once()
+        no_iter = self.config.get('no_iterations', 1024)
+        key = self._find_hosts_free_ipc(random.randint(1, 65536))
+        self.sub_stuff['shms'].append(key)
+        str1 = 'a%s' % self._generate_string()
+        str2 = 'b%s' % self._generate_string()
+        str3 = 'c%s' % self._generate_string()
+        # start containers
+        c1_name = self._init_container_stdin('cont1', "host")
+        self._init_container_stdin('cont2', "container:%s" % c1_name)
+        # start worker on 3rd container
+        args = "%s %s %s %s n" % (key, no_iter, str1, str2)
+        self._exec_container_stdin(self.sub_stuff['cmds'][0], args)
+        args = "%s %s %s %s n" % (key, no_iter, str2, str3)
+        self._exec_host('host', args)
+        args = "%s %s %s %s y" % (key, no_iter, str3, str1)
+        self._exec_container_stdin(self.sub_stuff['cmds'][1], args)
+
+    def postprocess(self):
+        super(host_w_hcont1_c1cont2, self).postprocess()
+        timeout = self.parent_subtest.adjust_timeout(120)
+        self.sub_stuff['cmds'][1].wait_check(timeout)
+        timeout = self.parent_subtest.adjust_timeout(15)
+        self.sub_stuff['cmds'][2].wait_check(timeout)
+        timeout = self.parent_subtest.adjust_timeout(15)
+        self.sub_stuff['cmds'][0].wait_check(timeout)
+        self.sub_stuff['cmds'] = []
+        self.sub_stuff['shms'] = []


### PR DESCRIPTION
This patch adds 5 new subsubtests, very similar to the previous one
only the memory is allocated in different place/container.

Signed-off-by: Lukáš Doktor ldoktor@redhat.com
