### PR TITLE
documentation: Allow nesting newlines and tabs

### DIFF
--- a/config_defaults/subtests/docker_cli/run_volumes.ini
+++ b/config_defaults/subtests/docker_cli/run_volumes.ini
@@ -32,7 +32,7 @@ selinux_context = svirt_sandbox_file_t
 #: where to mount the volume inside the container
 cntr_path = /run-n-volume
 #: the command each container should run.  This
-#: should be an IO command that writes to a file at ${write_path} which will
+#: should be an IO command that writes to a file at ``%%(write_path)s`` which will
 #: be inside the mounted volume.  This command should also take time to
 #: allow for taking place while the other containers are also writing IO.
 exec_command = /bin/bash -c 'for i in $(seq 5); do echo "%%(name)s - $i - $(date)" >> "%%(write_path)s"; sleep 1; done && /usr/bin/md5sum "%%(write_path)s"'

--- a/dockertest/documentation_unittests.py
+++ b/dockertest/documentation_unittests.py
@@ -191,6 +191,30 @@ class TestConfigINIParser(DocumentationTestBase):
         # This also verifies stripping of line continuation, empty first value
         self.assertEqual(test, expt_test)
 
+    def test_newline_sub(self):
+        test = self.CIP.from_string('[foo]\n'
+                                    '#: line1{n}line2\n'
+                                    'option = value')
+        self.assertEqual(len(test), 1)
+        di = test[0]
+        lines = di.desc.splitlines()
+        self.assertEqual(len(lines), 2)
+
+    def test_tab_sub(self):
+        test = self.CIP.from_string('[foo]\n'
+                                    '#: line1{n}\n'
+                                    '#:     {t}line2{n}\n'
+                                    '#:     {t}line3{n}\n'
+                                    '#:{n}\n'
+                                    '#:\n'
+                                    'option = value')
+        self.assertEqual(len(test), 1)
+        di = test[0]
+        lines = di.desc.splitlines()
+        self.assertEqual(len(lines), 3)
+        self.assertEqual(lines[1], '     line2')
+        self.assertEqual(lines[2], '     line3')
+
 
 class TestDocBase(DocumentationTestBase):
 

--- a/index.rst
+++ b/index.rst
@@ -325,6 +325,7 @@ shared element.
 
 Type-conversion
 -----------------------
+
 The config parser will attempt to parse each item in the following order:
 integers, booleans, floats, then strings.
 
@@ -332,6 +333,33 @@ integers, booleans, floats, then strings.
 *  Booleans are in the form 'yes' or 'true', 'no' or 'false' (case insensitive)
 *  Floats are in the form of numbers with decimals eg: "123.456" or "123.0"
 *  All other items will be returned as strings.
+
+Documentation
+----------------------
+
+All configuration options must be documented somewhere at least once.
+Documentated options in ``[DEFAULTS]`` will automatically be documented
+in subtests, no need to re-document.  Similarly, for subtests with
+multiple sub-subtests, options that are overriden by sub-subtests only
+need to be documented in the subtest section.
+
+Configuration options are documented in *ReStructuredText* format
+by prefixing each option with one or more comment lines that begin
+with the special sequence ``#:``.  Regular line comments (beginning
+with just ``#`` are not treated specially).
+
+Documentation comments always and only apply to the next ``option = value``
+sequence encountered and are otherwise ignored.  Further, all lines of
+documentation are concatenated together and stripped of newlines and multiple
+runs of space characters.  This is required to fit every item into a bullet
+list.  Since newlines and indenting is sometimes required
+(for example, a bullet list or table), special substitution sequences may
+be embedded w/in the comment text:
+
+*  Use the [unbroken] sequence ``{n}`` wherever a newline should be inserted.
+*  Use the [unbroken] sequence ``{t}`` wherever a four-space indent should
+   be inserted.
+*  Use the sequence ``{{`` and ``}}`` to escape literal ``{`` and ``}`` characters.
 
 ------------------------
 Autotest Integration


### PR DESCRIPTION
Some config. option descriptions are quite complex,
but previous parsing always stripped out all extra
whitespace.  Introduce new-style string formatting
map to allow substituting special characters in
final description parsing stages.  Update unittests
accordingly.

Signed-off-by: Chris Evich <cevich@redhat.com>