### PR TITLE
kill_stress: Fix improper tests

### DIFF
--- a/config_defaults/subtests/docker_cli/kill.ini
+++ b/config_defaults/subtests/docker_cli/kill.ini
@@ -4,9 +4,9 @@ docker_timeout = 60
 wait_start = 3
 #: modifies the ``docker run`` options
 run_options_csv = --attach=stdout
-subsubtests = random_num,random_num_ttyoff,random_name,random_name_ttyoff,go_lang_bad_signals,go_lang_bad_signals_ttyoff,run_sigproxy,run_sigproxy_ttyoff,attach_sigproxy,attach_sigproxy_ttyoff
+subsubtests = random_num_ttyoff,random_name_ttyoff,run_sigproxy_ttyoff,attach_sigproxy_ttyoff
 #: which signals should not be used (uncatchable signals)
-skip_signals = 9 17 19 27
+skip_signals = 9 17 19 27 18 20
 #: checking output produced by signal
 check_stdout = Received %%s, ignoring...
 #: range of used signals
@@ -29,63 +29,18 @@ run_container_attached = false
 #: Additional options to pass when attaching to backgrounded container process
 attach_options_csv =
 
-[docker_cli/kill/random_num]
-# docker kill
-# signals_sequence = L 1 27 4 L 12 19 15 21 L 18 L 5 16 21 19 21 13 2 L 28
-
-[docker_cli/kill/random_name]
-kill_map_signals = true
-# signals_sequence = M 4 M L 11 M 20 M L 21 M 6 M L 30 M 22 M L 25 M L 1 M
-
 [docker_cli/kill/random_name_ttyoff]
 kill_map_signals = true
-
-[docker_cli/kill/go_lang_bad_signals]
-# docker kill
-kill_sigproxy = true
-skip_signals = 9
-signals_sequence = 17 19 18 27
-stress_cmd_timeout = 3
-#: ``grep`` regexp matching the info in ``docker man run`` about noncatchable
-#: signals
-man_regexp = SIGCHLD.*SIGSTOP.*SIGKILL
-
-[docker_cli/kill/go_lang_bad_signals_ttyoff]
-kill_sigproxy = true
-skip_signals = 9
-signals_sequence = 2 19 20 27
-
-[docker_cli/kill/run_sigproxy]
-# --sig-proxy + os.kill() test
-kill_sigproxy = true
-run_options_csv = --attach=stdout,--sig-proxy=true
-# signals_sequence = 1 2 3 4 5 6 7 8 10 11 12 13 14 15 16 17 18 19 18 20 21 22 23 24 25 26 27 28 29 30 31
 
 [docker_cli/kill/run_sigproxy_ttyoff]
 kill_sigproxy = true
 run_options_csv = --attach=stdout,--sig-proxy=true
-
-[docker_cli/kill/attach_sigproxy]
-# --sig-proxy + os.kill() test
-kill_sigproxy = true
-run_container_attached = true
-run_options_csv = --detach=true,--sig-proxy=true
-attach_options_csv = --sig-proxy=true
-# signals_sequence = 1 2 3 4 5 6 7 8 10 11 12 13 14 15 16 17 18 19 18 20 21 22 23 24 25 26 27 28 29 30 31
 
 [docker_cli/kill/attach_sigproxy_ttyoff]
 kill_sigproxy = true
 run_container_attached = true
 run_options_csv = --detach=true,--sig-proxy=true
 attach_options_csv = --sig-proxy=true
-
-[docker_cli/kill/run_sigproxy_stress]
-# --sig-proxy + os.kill() test
-kill_sigproxy = true
-run_container_attached = true
-run_options_csv = --detach=true,--sig-proxy=true
-attach_options_csv = --sig-proxy=true
-# signals_sequence = 1 2 3 4 5 6 7 8 10 11 12 13 14 15 16 17 18 19 18 20 21 22 23 24 25 26 27 28 29 30 31
 
 [docker_cli/kill/run_sigproxy_stress_ttyoff]
 kill_sigproxy = true

--- a/config_defaults/subtests/docker_cli/kill_stopped.ini
+++ b/config_defaults/subtests/docker_cli/kill_stopped.ini
@@ -4,13 +4,15 @@ docker_timeout = 60
 wait_start = 3
 #: modifies the ``docker run`` options
 run_options_csv = --attach=stdout
-subsubtests = sigstop,sigstop_ttyoff,sigstop_sigproxy,sigstop_sigproxy_ttyoff
+subsubtests = sigstop,sigstop_ttyoff,sigstop_sigproxy_ttyoff
 #: which signals should not be used (uncatchable signals)
-skip_signals = 9 17 19 27
+skip_signals = 9 17 19 27 18 20
 #: checking output produced by signal
 check_stdout = Received %%s, ignoring...
 #: range of used signals
 kill_signals = 1 31
+#: how many iterations
+no_iterations = 1
 #: map signal numbers to names (RANDOM,true,false)
 kill_map_signals = false
 #: maximal acceptable delay caused by stress command
@@ -28,9 +30,6 @@ run_container_attached = false
 [docker_cli/kill_stopped/sigstop]
 
 [docker_cli/kill_stopped/sigstop_ttyoff]
-
-[docker_cli/kill_stopped/sigstop_proxy]
-kill_sigproxy = true
 
 [docker_cli/kill_stopped/sigstop_proxy_ttyoff]
 kill_sigproxy = true

--- a/config_defaults/subtests/docker_cli/kill_stress.ini
+++ b/config_defaults/subtests/docker_cli/kill_stress.ini
@@ -4,9 +4,9 @@ docker_timeout = 60
 wait_start = 3
 #: modifies the ``docker run`` options
 run_options_csv = --attach=stdout
-subsubtests = stress,stress_ttyoff,run_sigproxy_stress,run_sigproxy_stress_ttyoff,attach_sigproxy_stress,attach_sigproxy_stress_ttyoff
+subsubtests = stress_ttyoff,run_sigproxy_stress_ttyoff,attach_sigproxy_stress_ttyoff
 #: which signals should not be used (uncatchable signals)
-skip_signals = 9 17 19 27
+skip_signals = 9 17 19 27 18 20
 #: checking output produced by signal
 check_stdout = Received %%s, ignoring...
 #: range of used signals
@@ -29,32 +29,13 @@ run_container_attached = false
 #: Extra arguments to use when re-attaching to test container
 attach_options_csv =
 
-
-[docker_cli/kill_stress/stress]
-# signals_sequence = 21 27 M 30 18 M L 16 M L 8 L 1 M L 14 M L 11 M L 12
-
 [docker_cli/kill_stress/stress_ttyoff]
-
-[docker_cli/kill_stress/run_sigproxy_stress]
-kill_sigproxy = true
-run_container_attached = true
-run_options_csv = --detach=true,--sig-proxy=true
-# Extra arguments to use when re-attaching to test container
-attach_options_csv = --sig-proxy=true
-# signals_sequence = 1 2 3 4 5 6 7 8 10 11 12 13 14 15 16 17 18 19 18 20 21 22 23 24 25 26 27 28 29 30 31
 
 [docker_cli/kill_stress/run_sigproxy_stress_ttyoff]
 kill_sigproxy = true
 run_container_attached = true
 run_options_csv = --detach=true,--sig-proxy=true
 attach_options_csv = --sig-proxy=true
-
-[docker_cli/kill_stress/attach_sigproxy_stress]
-kill_sigproxy = true
-run_container_attached = true
-run_options_csv = --detach=true,--sig-proxy=true
-attach_options_csv = --sig-proxy=true
-# signals_sequence = 1 2 3 4 5 6 7 8 10 11 12 13 14 15 16 17 18 19 18 20 21 22 23 24 25 26 27 28 29 30 31
 
 [docker_cli/kill_stress/attach_sigproxy_stress_ttyoff]
 kill_sigproxy = true

--- a/subtests/docker_cli/kill/kill.py
+++ b/subtests/docker_cli/kill/kill.py
@@ -17,10 +17,8 @@ Operational Summary
 #. execute docker kill no_iteration times
 #. analyze results
 """
-from dockertest import subtest, xceptions
+from dockertest import subtest
 from kill_utils import kill_check_base
-import subprocess
-from autotest.client.shared.utils import wait_for
 
 
 class kill(subtest.SubSubtestCaller):
@@ -64,45 +62,6 @@ class random_name(kill_check_base):
     postprocess:
     5) analyze results
     """
-
-
-class go_lang_bad_signals(kill_check_base):
-
-    """
-    Tests signals, which are not forwarded due of outstanding Golang bug.
-
-    initialize:
-    1) start VM with test command
-    run_once:
-    2) execute specific series of kill signals and checks the output
-    postprocess:
-    3) analyze results
-    """
-
-    def _check_signal(self, container_out, _check, signal, timeout):
-        """
-        Inverse container check for $signal check output presence
-        """
-        _idx = container_out.idx
-        check = _check % signal
-        output_matches = lambda: check in container_out.get(_idx)
-        # Wait until the signal gets logged
-        if wait_for(output_matches, timeout, step=0) is not None:
-            msg = ("Signal %s present inside container althought according to"
-                   " documentation it should not be forwarded/handled."
-                   "Container output:\n  %s"
-                   % (signal, "\n  ".join(container_out.get(_idx))))
-            self.logdebug(msg)
-            raise xceptions.DockerTestFail("Signal documented as non-"
-                                           "forwardable present in the output")
-
-    def postprocess(self):
-        super(go_lang_bad_signals, self).postprocess()
-        self.failif(subprocess.call("man docker run | grep -q '%s'"
-                                    % self.config['man_regexp'], shell=True),
-                    "`man docker run` doesn't contain warning about missing "
-                    "signals defined by expr '%s'"
-                    % (self.config['man_regexp']))
 
 
 class run_sigproxy(kill_check_base):

--- a/subtests/docker_cli/kill_parallel_stress/kill_utils.py
+++ b/subtests/docker_cli/kill_parallel_stress/kill_utils.py
@@ -236,16 +236,6 @@ class kill_base(subtest.SubSubtest):
             self.failif(kill_result.exit_status != 0, "Exit status of the %s "
                         "command was not 0 (%s)"
                         % (kill_result.command, kill_result.exit_status))
-        # FIXME: Return number of container changed:
-        # with tty=on `docker kill` => 0
-        # with tty=off `docker kill` => 255
-        # bash `kill -9 $cont_pid` => 137
-        # if 'container_results' in self.sub_stuff:
-        #     OutputGood(self.sub_stuff['container_results'])
-        #     self.failif((self.sub_stuff['container_results'].exit_status
-        #                  not in (255, -9)), "Exit status of the docker run "
-        #                 "command wasn't 255, nor -9 (%s)"
-        #                 % self.sub_stuff['container_results'].exit_status)
 
     def pre_cleanup(self):
         """
@@ -335,9 +325,6 @@ class kill_check_base(kill_base):
         """
         Checks that all signals from stopped_log are present in container_out
         """
-        # TODO: Signals 20, 21 and 22 are not reported after SIGCONT
-        #       even thought they are reported when docker is not
-        #       stopped.
         if stopped_log:
             endtime = time.time() + timeout
             _idx = container_out.idx

--- a/subtests/docker_cli/kill_stopped/kill_stopped.py
+++ b/subtests/docker_cli/kill_stopped/kill_stopped.py
@@ -13,9 +13,8 @@ Operational Summary
 4. send SIGCONT
 5. check received signals
 """
-import random
 
-from kill_utils import kill_check_base, DockerCmd
+from kill_utils import kill_check_base
 from dockertest import subtest
 
 
@@ -25,46 +24,7 @@ class kill_stopped(subtest.SubSubtestCaller):
 
 
 class sigstop(kill_check_base):
-
-    """
-    Test usage of docker 'kill' command (stopped container)
-
-    initialize:
-    1) start VM with test command
-    2) create sequence of signals in this manner (uses numeric values):
-       [SIGSTOP, 1, 2, 3, .., 8, 10, .., 16, SIGSTOP, 20, .., 31, SIGCONT, 9]
-    run_once:
-    3) execute series of kill signals followed with the output check
-    3b) in case of SIGSTOP it stores following signals until SIGCONT and
-        verifies they were all handled properly
-    4) sends docker kill -9 and verifies docker was killed
-    postprocess:
-    5) analyze results
-    """
-
-    def _populate_kill_cmds(self, extra_subargs):
-        signals_sequence = range(1, 32)
-        signals_sequence.remove(9)
-        signals_sequence.remove(17)
-        signals_sequence.remove(18)
-
-        # TODO: Should these be ignored? They can be caught when not STOPPED
-        # signals_sequence.remove(20)
-        # signals_sequence.remove(21)
-        # signals_sequence.remove(22)
-
-        signals_sequence = [19] + signals_sequence + [18, 9]
-        kill_cmds = []
-        for signal in signals_sequence:
-            subargs = (["%s%s" % (random.choice(('-s ', '--signal=')), signal)]
-                       + extra_subargs)
-            cmd = DockerCmd(self, 'kill', subargs, verbose=False)
-            kill_cmds.append(cmd)
-
-        self.logdebug("kill_command_example: %s", kill_cmds[0])
-        self.logdebug("signals_sequence: %s", signals_sequence)
-        self.sub_stuff['signals_sequence'] = signals_sequence
-        self.sub_stuff['kill_cmds'] = kill_cmds
+    pass
 
 
 class sigstop_ttyoff(sigstop):
@@ -73,12 +33,7 @@ class sigstop_ttyoff(sigstop):
     tty = False
 
 
-class sigstop_sigproxy(sigstop):
-
-    """ Direct kill variant of the sigstop test """
-
-
-class sigstop_sigproxy_ttyoff(sigstop_sigproxy):
+class sigstop_sigproxy_ttyoff(sigstop):
 
     """ Non-tty variant of the sigstop_sigproxy test """
     tty = False

--- a/subtests/docker_cli/kill_stopped/kill_utils.py
+++ b/subtests/docker_cli/kill_stopped/kill_utils.py
@@ -236,16 +236,6 @@ class kill_base(subtest.SubSubtest):
             self.failif(kill_result.exit_status != 0, "Exit status of the %s "
                         "command was not 0 (%s)"
                         % (kill_result.command, kill_result.exit_status))
-        # FIXME: Return number of container changed:
-        # with tty=on `docker kill` => 0
-        # with tty=off `docker kill` => 255
-        # bash `kill -9 $cont_pid` => 137
-        # if 'container_results' in self.sub_stuff:
-        #     OutputGood(self.sub_stuff['container_results'])
-        #     self.failif((self.sub_stuff['container_results'].exit_status
-        #                  not in (255, -9)), "Exit status of the docker run "
-        #                 "command wasn't 255, nor -9 (%s)"
-        #                 % self.sub_stuff['container_results'].exit_status)
 
     def pre_cleanup(self):
         """
@@ -335,9 +325,6 @@ class kill_check_base(kill_base):
         """
         Checks that all signals from stopped_log are present in container_out
         """
-        # TODO: Signals 20, 21 and 22 are not reported after SIGCONT
-        #       even thought they are reported when docker is not
-        #       stopped.
         if stopped_log:
             endtime = time.time() + timeout
             _idx = container_out.idx

--- a/subtests/docker_cli/kill_stress/kill_stress.py
+++ b/subtests/docker_cli/kill_stress/kill_stress.py
@@ -148,23 +148,13 @@ class stress_ttyoff(stress):
     tty = False
 
 
-class run_sigproxy_stress(stress):
-
-    """ direct kill variant of the stress test """
-
-
-class run_sigproxy_stress_ttyoff(run_sigproxy_stress):
+class run_sigproxy_stress_ttyoff(stress):
 
     """ non-tty variant of the run_sigproxy_stress test """
     tty = False
 
 
-class attach_sigproxy_stress(stress):
-
-    """ attached container direct kill variant of the stress test """
-
-
-class attach_sigproxy_stress_ttyoff(attach_sigproxy_stress):
+class attach_sigproxy_stress_ttyoff(stress):
 
     """ non-tty variant of the attach_sigproxy_stress test """
     tty = False

--- a/subtests/docker_cli/kill_stress/kill_utils.py
+++ b/subtests/docker_cli/kill_stress/kill_utils.py
@@ -236,16 +236,6 @@ class kill_base(subtest.SubSubtest):
             self.failif(kill_result.exit_status != 0, "Exit status of the %s "
                         "command was not 0 (%s)"
                         % (kill_result.command, kill_result.exit_status))
-        # FIXME: Return number of container changed:
-        # with tty=on `docker kill` => 0
-        # with tty=off `docker kill` => 255
-        # bash `kill -9 $cont_pid` => 137
-        # if 'container_results' in self.sub_stuff:
-        #     OutputGood(self.sub_stuff['container_results'])
-        #     self.failif((self.sub_stuff['container_results'].exit_status
-        #                  not in (255, -9)), "Exit status of the docker run "
-        #                 "command wasn't 255, nor -9 (%s)"
-        #                 % self.sub_stuff['container_results'].exit_status)
 
     def pre_cleanup(self):
         """
@@ -335,9 +325,6 @@ class kill_check_base(kill_base):
         """
         Checks that all signals from stopped_log are present in container_out
         """
-        # TODO: Signals 20, 21 and 22 are not reported after SIGCONT
-        #       even thought they are reported when docker is not
-        #       stopped.
         if stopped_log:
             endtime = time.time() + timeout
             _idx = container_out.idx


### PR DESCRIPTION
Resolves: #422 

Removed all non-tty enabled sub-subtests as they are now invalid.  Also
added signal 18 to the skip list since it cannot be reliably tested.

Signed-off-by: Chris Evich <cevich@redhat.com>