### PR TITLE
run_env: Fix several bugs

### DIFF
--- a/config_defaults/defaults.ini
+++ b/config_defaults/defaults.ini
@@ -16,8 +16,11 @@ autotest_version = 0.16.0-master-66-g9aaee
 #: Docker default options (before subcommand)
 docker_path = /usr/bin/docker
 
-#: Global docker command options to use
+#: Global docker client command options to use (CSV)
 docker_options = -D
+
+#: Global docker daemon options to use (CSV)
+daemon_options = -d,--selinux-enabled
 
 #: Max runtime in seconds for any docker command (auto-converts to float)
 docker_timeout = 300.0

--- a/config_defaults/subtests/docker_cli/run_env.ini
+++ b/config_defaults/subtests/docker_cli/run_env.ini
@@ -1,2 +1,9 @@
 [docker_cli/run_env]
 subsubtests = port,rm_link
+docker_timeout = 60
+#: Server container options in addition to --name, --publish, and --env.
+server_options = --interactive
+#: Client container options in addition to --name, --link and --env.
+client_options = -i
+#: Options to pass to python command when starting containers
+python_options = -B,-E,-i,-s,-S,-u


### PR DESCRIPTION
Test was using --tty incorrectly (no pty attached).  Test
was also incorrectly checking stdout vs stderr in some situations.
Test had hard-coded docker daemon options that didn't match current
release options.  Added 'daemon_options' global to defaults, updated
test to use it.

Signed-off-by: Chris Evich <cevich@redhat.com>