### PR TITLE
docker_cli/logs use utc instead of LC_ALL

### DIFF
--- a/config_defaults/subtests/docker_cli/logs.ini
+++ b/config_defaults/subtests/docker_cli/logs.ini
@@ -2,6 +2,6 @@
 subsubtests = basic
 #: CSV additional create command arguments besides
 #: ``--name <name>``, the FQIN, and subtest specified command+args.
-extra_create_args = --interactive=false,--tty=false,--env,LC_ALL=C
+extra_create_args = --interactive=false,--tty=false
 #: CSV additional start command arguments besides the container name
 extra_start_args = --attach=true,--interactive=true

--- a/subtests/docker_cli/logs/basic.py
+++ b/subtests/docker_cli/logs/basic.py
@@ -27,18 +27,18 @@ class basic(Base):
 
     def run_once(self):
         super(basic, self).run_once()
-        cntnr = self.create_cntnr('date', '"+foobar: %H"')
+        cntnr = self.create_cntnr('date -u', '"+foobar: %H"')
         name = self.scrape_name(cntnr.subargs)
 
         logs_cmd = self.sub_stuff['logs_cmd']
         logs_cmd['before_start'] = self.logs_cmd(name)
 
         cntnr = self.start_cntnr(name)  # blocking on exit
-        now = datetime.now()
+        now = datetime.utcnow()
         # Most likely failure at hour-increment
         if now.second > 58:  # allow 2 second window for docker start
             sleep(3)
-            now = datetime.now()
+            now = datetime.utcnow()
         #  minute-level accuracy: only hour is important
         magic = 'foobar:'
         if now.hour < 10:

--- a/subtests/docker_cli/logs/logs.py
+++ b/subtests/docker_cli/logs/logs.py
@@ -97,7 +97,7 @@ class Base(SubSubtest):
         :return: A new DockerCmd instance
         """
         subargs = get_as_list(self.config['extra_start_args']) + [name]
-        dockercmd = cls(self, 'start', subargs, verbose=False)
+        dockercmd = cls(self, 'start', subargs, verbose=True)
         dockercmd.quiet = True
         if execute:
             dockercmd.execute()


### PR DESCRIPTION
The LC_ALL method still fails in my machine, then i have a idea that
use utc instead of config the LC_ALL env.

*Use utc as timestamp thus we can ignore the effect of LC_*
