### PR TITLE
control: Don't abort testing on bugzilla exception

### DIFF
--- a/control
+++ b/control
@@ -336,6 +336,7 @@ class ControlINI(ConfigParser.SafeConfigParser, Singleton):
         """
         Return Bugzilla.build_query() keyword dictionary
         """
+        from bugzilla import Fault
         key_field = self.get('Bugzilla', 'key_field').strip()
         key_match = self.get('Bugzilla', 'key_match').strip()
         query = {key_field: key_match}
@@ -375,12 +376,19 @@ class ControlINI(ConfigParser.SafeConfigParser, Singleton):
             return {}
 
         logging.info("Searching for docker-autotest bugs")
-        bugs = bz.query(self.bz_query(bz))
-        namestobzs = self.subthings_to_bugs(bz, bugs)
-        noisy_bz()  # Put it back the way it was
-        del bugs # save some memory
-        del bz
-        del sys.modules['bugzilla']
+        from bugzilla import Fault
+        try:
+            bugs = bz.query(self.bz_query(bz))
+            namestobzs = self.subthings_to_bugs(bz, bugs)
+        except Fault, xcept:
+            logging.warning("Ignoring BZ query exception: %s", xcept)
+            return {}
+        finally:
+            noisy_bz()  # Put it back the way it was
+            del Fault
+            del bz
+            del sys.modules['bugzilla']
+        del bugs
 
         # No need to check same subthing more than once
         subset = set(subthings)


### PR DESCRIPTION
This catches the top-level 'Fault' exception from the bugzilla module.
When thrown, it prints a warning w/ exception info then continues as if
no tests were blocked.

Signed-off-by: Chris Evich <cevich@redhat.com>