### PR TITLE
docker_cli/run_exec: remove exec --interactive option from config

### DIFF
--- a/config_defaults/subtests/docker_cli/run_exec.ini
+++ b/config_defaults/subtests/docker_cli/run_exec.ini
@@ -5,8 +5,9 @@ docker_timeout = 60
 run_options_csv = --interactive
 #: csv command prefix (docker run ... $bash_cmd)
 bash_cmd = /bin/sh
-#: modifies the execning command in started container)
-exec_options_csv = --interactive
+#: modifies the execning command in started container (Do not
+#: add --interactive as it will not close STDIN and strigger timeout)
+exec_options_csv = 
 #: expected exit status
 exit_status = 0
 subsubtests = exec_true, exec_false, exec_pid_count


### PR DESCRIPTION
 `docker exec --interactive` will trigger utils.run's timeout, so that remove
 it from default configuration file.

