### PR TITLE
docker_cli/diff: change diff_change default option

### DIFF
--- a/config_defaults/subtests/docker_cli/diff.ini
+++ b/config_defaults/subtests/docker_cli/diff.ini
@@ -14,8 +14,8 @@ command = /bin/touch,/root/doesnotexist
 files_changed = A,/root/doesnotexist,C,/root
 
 [docker_cli/diff/diff_change]
-command = /bin/touch,/usr
-files_changed = C,/usr
+command = /bin/chmod,777,/home
+files_changed = C,/home
 
 [docker_cli/diff/diff_delete]
 command = /bin/rm,-rf,/usr/bin


### PR DESCRIPTION
*The `touch /usr` will not be effect if `/usr` has already existed.
 Use `chmod 777 /home` to replace

