### PR TITLE
Convert timeout from float to int, no string. Otherwise tests fails.

### DIFF
--- a/control
+++ b/control
@@ -527,7 +527,7 @@ class Step(collections.Callable):
         except StopIteration:
             pass  # all done, current step is the last
         self._mangle_syspath()
-        job.run_test(url=self.uri, tag=self.tag, timeout=str(self.timeout))
+        job.run_test(url=self.uri, tag=self.tag, timeout=int(self.timeout))
         self._unmangle_syspath()
 
     @property


### PR DESCRIPTION
Convert timeout from float to int, no string. Otherwise tests fails with:

10:31:25 ERROR| Traceback (most recent call last):
10:31:25 ERROR|   File "/usr/lib64/python2.7/logging/__init__.py", line 859, in emit
10:31:25 ERROR|     msg = self.format(record)
10:31:25 ERROR|   File "/usr/lib64/python2.7/logging/__init__.py", line 732, in format
10:31:25 ERROR|     return fmt.format(record)
10:31:25 ERROR|   File "/usr/lib64/python2.7/logging/__init__.py", line 471, in format
10:31:25 ERROR|     record.message = record.getMessage()
10:31:25 ERROR|   File "/usr/lib64/python2.7/logging/__init__.py", line 335, in getMessage
10:31:25 ERROR|     msg = msg % self.args
10:31:25 ERROR| TypeError: %d format: a number is required, not str