### PR TITLE
Fix exclusion filter matching prefixed names

### DIFF
--- a/dockertest/config.py
+++ b/dockertest/config.py
@@ -480,13 +480,18 @@ class Config(dict):
         return the_copy
 
 
-def get_as_list(value, sep=","):
+def get_as_list(value, sep=",", omit_empty=False):
     """
     Return config value as list separated by sep.
-    value = "a,b , c, dd"
-    return ["a","b","c","dd"]
+
+    :param value: Some string or string-like iterable to parse
+    :param sep: The character or item to seperate value around
+    :param omit_empty: When true, skip items that evaluate false
+    :return: List of items from value excluding sep
     """
-    return [val.strip() for val in value.split(sep)]
+    return [val.strip()
+            for val in value.split(sep)
+            if bool(val.strip()) or not omit_empty]
 
 
 def none_if_empty(dict_like, key_name=None):

--- a/dockertest/config_unittests.py
+++ b/dockertest/config_unittests.py
@@ -331,5 +331,26 @@ class TestUtilities(ConfigTestBase):
         self.config.none_if_empty(test_dict, 'baz')
         self.assertEqual(test_dict, {'foo': 0, 'bar': None, 'baz': None})
 
+    def test_getaslist_1(self):
+        testvalue = '  one, two \n\n,\nthree'
+        testlist = self.config.get_as_list(testvalue)
+        self.assertEqual(testlist, ['one','two','three'])
+
+    def test_getaslist_2(self):
+        testvalue = ''
+        testlist = self.config.get_as_list(testvalue)
+        self.assertEqual(testlist, [''])
+
+    def test_getaslist_3(self):
+        testvalue = ''
+        testlist = self.config.get_as_list(testvalue, omit_empty=True)
+        self.assertEqual(testlist, [])
+
+    def test_getaslist_4(self):
+        testvalue = 'one,,two,,three,,'
+        testlist = self.config.get_as_list(testvalue, omit_empty=False)
+        self.assertEqual(testlist, ['one', '', 'two', '', 'three', '',''])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
A check for undefined sub-subtests was incorrectly matching
unrelated parent subtests based on one subtest's name being
a prefix to another.

Signed-off-by: Chris Evich <you@forgot.to.edit.gitconfig>