### PR TITLE
Symlink support

### DIFF
--- a/control
+++ b/control
@@ -304,7 +304,8 @@ class ControlINI(ConfigParser.SafeConfigParser, Singleton):
         subtest_path = os.path.join(self.control_path, subdir)
         subtests = []
         # All subtest packages located beneath dir holding this control file
-        for dirpath, dirnames, filenames in os.walk(subtest_path):
+        for dirpath, dirnames, filenames in os.walk(subtest_path,
+                                            followlinks=True):
             del dirnames  #  Not used
             # Skip top-level
             if dirpath == subtest_path:

--- a/dockertest/config.py
+++ b/dockertest/config.py
@@ -455,11 +455,13 @@ class Config(dict):
         if self.__class__.configs_ is None:
             self.__class__.configs_ = {'DEFAULTS': self.defaults}
             # Overwrite section-by-section from customs after loading defaults
-            for dirpath, dirnames, filenames in os.walk(CONFIGDEFAULT):
+            for dirpath, dirnames, filenames in os.walk(CONFIGDEFAULT,
+                                                        followlinks=True):
                 del dirnames  # not needed
                 self.load_config_dir(dirpath, filenames,
                                      self.__class__.configs_, self.defaults)
-            for dirpath, dirnames, filenames in os.walk(CONFIGCUSTOMS):
+            for dirpath, dirnames, filenames in os.walk(CONFIGCUSTOMS,
+                                                        followlinks=True):
                 del dirnames  # not needed
                 self.load_config_dir(dirpath, filenames,
                                      self.__class__.configs_, self.defaults)

--- a/dockertest/subtest.py
+++ b/dockertest/subtest.py
@@ -344,10 +344,14 @@ class SubSubtestCaller(Subtest):
         self.step_log_msgs['postprocess'] = ("Postprocess sub-subtest "
                                              "results...")
         # Private to this instance, outside of __init__
-        if self.config.get('subsubtests') is None:
+        if (self.config.get('subsubtests') is None and
+                len(self.subsubtest_names) == 0):
             raise DockerTestNAError("Missing|empty 'subsubtests' in config.")
-        sst_names = self.config['subsubtests']
-        self.subsubtest_names = config.get_as_list(sst_names)
+        if len(self.subsubtest_names) == 0:
+            sst_names = self.config['subsubtests']
+            self.subsubtest_names = config.get_as_list(sst_names)
+        else:
+            sst_names = self.subsubtest_names
         if self.control_config is not None:
             subthings = set(
                 config.get_as_list(self.control_config['subthings'],


### PR DESCRIPTION
* Follow directory symlinks when searching subtests and configs
* Fix SubSubtestCaller.initialize()