### PR TITLE
Don't check Autotest version by default

### DIFF
--- a/config_defaults/defaults.ini
+++ b/config_defaults/defaults.ini
@@ -9,7 +9,7 @@
 config_version = 0.8.4
 
 #: Autotest version dependency for framework (or override for individual tests)
-autotest_version = 0.16.2
+autotest_version = @!NOVERSIONCHECK!@
 
 ##### docker command options
 


### PR DESCRIPTION
This option is intended for environments where a specific
version MUST be locked in, perhaps due to upstream API/behavior
changes.  Normally however, Docker Autotest should just run with
whatever the latest/greatest autotest version is installed.

Signed-off-by: Chris Evich <cevich@redhat.com>