### PR TITLE
import subtest: remove --preserve-order tar option

### DIFF
--- a/config_defaults/subtests/docker_cli/dockerimport.ini
+++ b/config_defaults/subtests/docker_cli/dockerimport.ini
@@ -6,7 +6,7 @@ image_name_postfix = :test
 #: Full path to tar command on host
 tar_command = /usr/bin/tar
 #: Options to pass to tar while inside context directory
-tar_options = --numeric-owner --preserve-permissions --preserve-order --acls --selinux --xattrs --verbose --create .
+tar_options = --numeric-owner --preserve-permissions --acls --selinux --xattrs --verbose --create .
 
 [docker_cli/dockerimport/empty]
 


### PR DESCRIPTION
GNU tar 1.27 [*] allows --preserve-order (aka --same-order)
only with archive reading commands; the import test was
using it with --create, causing test to fail on f22 & f23.

  [*] commit 74ce228