### PR TITLE
info subtest: fix verify_pool_name()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
     - pip install Pylint==1.4.5 Pep8==1.6.2 Sphinx==1.2.2
     - pip install Autotest==0.16.2
     - pip install inspektor==0.2.0
+    - pip install unittest2==0.8.0
 
 script:
     - SPHINXOPTS="-W" make

--- a/run_unittests.sh
+++ b/run_unittests.sh
@@ -14,5 +14,13 @@ do
     wait %- &> /dev/null
     RET=$?
 done
+
+# Unit tests for subtests.
+# FIXME: find a way to have nosetests recurse, or move the tests into
+#        a directory structure that nose can handle.
+for unittest in $(find subtests -name 'test_*.py'); do
+    nosetests -v $unittest
+done
+
 echo ""
 echo ""

--- a/subtests/docker_cli/info/test_info.py
+++ b/subtests/docker_cli/info/test_info.py
@@ -1,0 +1,94 @@
+# -*- python -*-
+#
+# Tests for the docker-autotest 'info' subtest
+#
+# As of 2016-02-12 this only includes verify_pool_name(); we'll try to
+# extend coverage as needed.
+#
+# RUNNING:
+#
+#   $ nosetests -v subtests/docker_cli/info
+#
+# This assumes that your autotest-docker is checked out underneath
+# the client/tests subdirectory of a checked-out autotest repo,
+# *and* that the autotest repo is called "autotest" (e.g. not "my-autotest").
+# Also: you can't just run nosetests and hope it'll recurse. It won't.
+#
+# Yeah. Sorry. There's indubitably a better way. Please fix if you know how.
+#
+from unittest2 import TestCase, main
+from mock import Mock, patch
+
+import sys
+sys.path.append('../../../..')
+
+import info
+
+class TestVerifyPoolName(TestCase):
+    # Standard docker pool name to expect
+    docker_pool = 'rhel-docker--pool'
+
+    # Typical output from 'dmsetup ls'. Note that order is arbitrary.
+    dmsetup_ls = [ 'rhel-docker--pool	(253:4)',
+                   'rhel-swap	(253:1)',
+                   'rhel-root	(253:0)',
+                   'rhel-docker--pool_tdata	(253:3)',
+                   'rhel-docker--pool_tmeta	(253:2)',
+                 ]
+
+    def failif(self, cond, msg):
+        if cond:
+            raise ValueError(msg)
+
+    def _run_one_test(self, pool_name, dmsetup_output, expected_exception):
+        """
+        Helper for running an individual test. Creates a set of mocks
+        that mimic the behavior we test for but are otherwise NOPs.
+        """
+        mockinfo = Mock(spec=info.info)
+        mockinfo.failif = self.failif
+        mockrun = Mock()
+        mockrun.stdout = ''.join([line + "\n" for line in dmsetup_output])
+
+        raised = False
+        with patch('autotest.client.utils.run', Mock(return_value=mockrun)):
+            try:
+                info.info.verify_pool_name(mockinfo, pool_name)
+            except Exception, e:
+                if expected_exception:
+                    self.assertEqual(e.message, expected_exception)
+                    raised = True
+                else:
+                    self.fail("Unexpected exception %s" % e.message)
+        if expected_exception and not raised:
+            self.fail("Test did not raise expected exception")
+
+    def test_standard_order(self):
+        """Expected pool name is the first line of output"""
+        self._run_one_test(self.docker_pool, self.dmsetup_ls, None)
+
+    def test_reverse_order(self):
+        """Expected pool name is the last line of output"""
+        self._run_one_test(self.docker_pool,
+                            reversed(self.dmsetup_ls), None)
+
+    def test_empty_dmsetup(self):
+        """dmsetup ls produces no output"""
+        self._run_one_test(self.docker_pool, [],
+                           "'dmsetup ls' reports no docker pools.")
+
+    def test_dmsetup_with_no_pools(self):
+        """dmsetup ls contains no lines with the string 'pool'."""
+        incomplete = [x for x in self.dmsetup_ls if x.find("pool") < 0]
+        self._run_one_test(self.docker_pool, incomplete,
+                           "'dmsetup ls' reports no docker pools.")
+
+    def test_pool_missing(self):
+        """dmsetup ls contains many lines, but not our desired pool name."""
+        incomplete = [x for x in self.dmsetup_ls
+                       if not x.startswith(self.docker_pool + "\t")]
+        self._run_one_test(self.docker_pool, incomplete,
+                           "Docker info pool name 'rhel-docker--pool'"
+                           " (from docker info) not found in dmsetup ls"
+                           " list '['rhel-docker--pool_tdata',"
+                           " 'rhel-docker--pool_tmeta']'")

--- a/subtests/docker_cli/info/test_info.py
+++ b/subtests/docker_cli/info/test_info.py
@@ -34,8 +34,7 @@ class TestVerifyPoolName(TestCase):
                   'rhel-swap	(253:1)',
                   'rhel-root	(253:0)',
                   'rhel-docker--pool_tdata	(253:3)',
-                  'rhel-docker--pool_tmeta	(253:2)',
-                 ]
+                  'rhel-docker--pool_tmeta	(253:2)']
 
     @staticmethod
     def failif(cond, msg):

--- a/subtests/docker_cli/info/test_info.py
+++ b/subtests/docker_cli/info/test_info.py
@@ -16,7 +16,7 @@
 #
 # Yeah. Sorry. There's indubitably a better way. Please fix if you know how.
 #
-from unittest2 import TestCase, main
+from unittest2 import TestCase, main        # pylint: disable=unused-import
 from mock import Mock, patch
 
 import sys
@@ -24,19 +24,21 @@ sys.path.append('../../../..')
 
 import info
 
+
 class TestVerifyPoolName(TestCase):
     # Standard docker pool name to expect
     docker_pool = 'rhel-docker--pool'
 
     # Typical output from 'dmsetup ls'. Note that order is arbitrary.
-    dmsetup_ls = [ 'rhel-docker--pool	(253:4)',
-                   'rhel-swap	(253:1)',
-                   'rhel-root	(253:0)',
-                   'rhel-docker--pool_tdata	(253:3)',
-                   'rhel-docker--pool_tmeta	(253:2)',
+    dmsetup_ls = ['rhel-docker--pool	(253:4)',
+                  'rhel-swap	(253:1)',
+                  'rhel-root	(253:0)',
+                  'rhel-docker--pool_tdata	(253:3)',
+                  'rhel-docker--pool_tmeta	(253:2)',
                  ]
 
-    def failif(self, cond, msg):
+    @staticmethod
+    def failif(cond, msg):
         if cond:
             raise ValueError(msg)
 
@@ -54,8 +56,9 @@ class TestVerifyPoolName(TestCase):
         with patch('autotest.client.utils.run', Mock(return_value=mockrun)):
             try:
                 info.info.verify_pool_name(mockinfo, pool_name)
-            except Exception, e:
+            except Exception, e:          # pylint: disable=broad-except
                 if expected_exception:
+                    # exception message is a more specific check than type
                     self.assertEqual(e.message, expected_exception)
                     raised = True
                 else:
@@ -70,7 +73,7 @@ class TestVerifyPoolName(TestCase):
     def test_reverse_order(self):
         """Expected pool name is the last line of output"""
         self._run_one_test(self.docker_pool,
-                            reversed(self.dmsetup_ls), None)
+                           reversed(self.dmsetup_ls), None)
 
     def test_empty_dmsetup(self):
         """dmsetup ls produces no output"""
@@ -86,7 +89,7 @@ class TestVerifyPoolName(TestCase):
     def test_pool_missing(self):
         """dmsetup ls contains many lines, but not our desired pool name."""
         incomplete = [x for x in self.dmsetup_ls
-                       if not x.startswith(self.docker_pool + "\t")]
+                      if not x.startswith(self.docker_pool + "\t")]
         self._run_one_test(self.docker_pool, incomplete,
                            "Docker info pool name 'rhel-docker--pool'"
                            " (from docker info) not found in dmsetup ls"


### PR DESCRIPTION
verify_pool_name() checks that the Docker Pool Name listed
by 'docker info' is present in the output of 'dmsetup ls'.
We cannot rely on the output order of the latter: on one
RHEL7 system it outputs the desired pool name first, on
another system last. So let's just test for the presence
of the desired pool name anywhere in the output.

Also, create a unit test for the new code. Invocation is
ugly but that should be fixable by someone more python-
proficient than I. Fixes welcome.

Unit test requires python-nose and python-unittest2, both
of which are available on RHEL7.

Signed-off-by: Ed Santiago <santiago@redhat.com>