### PR TITLE
Fix garbage_check not preserving image IDs

### DIFF
--- a/dockertest/images_unittests.py
+++ b/dockertest/images_unittests.py
@@ -323,6 +323,24 @@ class DockerImageTestBasic(ImageTestBase):
         di = DI(repo, tag, '0' * 64, None, None, addr, user)
         self.assertEqual(di.full_name, test)
 
+    def test_user_no_addr(self):
+        test = "user/repo:tag"
+        DI = self.images.DockerImage
+        repo, tag, addr, user = DI.split_to_component(test)
+        self.assertEqual(repo, 'repo')
+        self.assertEqual(tag, 'tag')
+        self.assertEqual(user, 'user')
+        self.assertEqual(addr, None)
+
+    def test_addr_no_user(self):
+        test = "address:1234/repo:tag"
+        DI = self.images.DockerImage
+        repo, tag, addr, user = DI.split_to_component(test)
+        self.assertEqual(repo, 'repo')
+        self.assertEqual(tag, 'tag')
+        self.assertEqual(user, None)
+        self.assertEqual(addr, "address:1234")
+
     def test_remove_cli(self):
         d = self.images.DockerImages(self.fake_subtest, 1.0, True)
         self.assertEqual(d.remove_image_by_id('123456789012').command,


### PR DESCRIPTION
* Additional regex magic & processing is needed when a FQIN is specified
without the repo-address component.
* Images module now uses key-words to reference components of FQIN
group matches
* Added new unittests to verify above changes
* Updated garbage_check to be more flexible when comparing against
configured images to preserve.