### PR TITLE
fix dangling comma in `defaults.ini`

### DIFF
--- a/config_defaults/defaults.ini
+++ b/config_defaults/defaults.ini
@@ -52,7 +52,7 @@ remove_after_test = yes
 #: CSV of possibly existing **full** image names to preserve.
 preserve_fqins = docker.io/stackbrew/centos:7,
                  docker.io/stackbrew/centos:centos7,
-                 docker.io/stackbrew/centos:latest,
+                 docker.io/stackbrew/centos:latest
 
 #: CSV of possibly existing **full** container names to preserve.
 preserve_cnames =


### PR DESCRIPTION
Commit 7f7decaef8c7f76041d56 removed `ATOMIC_SUBSTITUTIONS` value from `config_defaults/defaults.ini`, but it left comma at the end of previous line, so when it is split by commas, it returns one "empty string" value and tests fail.