### PR TITLE
Fix test failure in double_tag subsubtest.

### DIFF
--- a/config_defaults/subtests/docker_cli/tag.ini
+++ b/config_defaults/subtests/docker_cli/tag.ini
@@ -4,8 +4,6 @@ tag_force = false
 #: generate names using lowercase only
 gen_lower_only = True
 subsubtests = change_tag,change_repository,change_user,double_tag,double_tag_force
-#: expected results
-docker_expected_result = PASS
 #: testing repo_name_prefix
 tag_repo_name_prefix = test
 #: Works best with remote registry provided repository
@@ -24,7 +22,5 @@ docker_registry_host =
 [docker_cli/tag/change_user]
 
 [docker_cli/tag/double_tag]
-docker_expected_result = FAIL
 
 [docker_cli/tag/double_tag_force]
-tag_force = true


### PR DESCRIPTION
subtest tag:double_tag was failing. Root cause: too many
to list. I don't think this test could have ever completed
successfully.

Fixes:
 + Principally, reworked the way we check exit status
   when we're expecting the command to fail (i.e.
   two 'docker tag' commands in a row without -f).

Related fixes:
 + moved some logic from the config file to the code:
   1) docker_expected_result (PASS/FAIL): this absolutely
      does not belong in a config file. There is no
      circumstance under which an end user would want
      to say "oh hey let's expect double-tag to pass"
      or "let's expect other-test to fail". This is
      code logic, not configuration logic.
   2) -f flag (in double_tag_force): again, this is
      code logic. It's the whole defining factor of
      the test itself. It is harmful to imply that
      an end user should be able to change this via
      config file.

Unrelated fixes:
 + differentiation of two previously identical debug
   messages, so human debugger can identify which part
   of the code a message is coming from;
 + variable name change, fixing a misleading reuse situation
 + make first docker command in double_tag verbose, making
   test flow clearer in debug log
 + slightly more informative comments
 + minor typo fix

Signed-off-by: Ed Santiago <santiago@redhat.com>