### PR TITLE
Update control.ini comments + BZ searching

### DIFF
--- a/config_defaults/control.ini
+++ b/config_defaults/control.ini
@@ -53,23 +53,28 @@ password =
 
 # This will automatically be populated
 # with names of subtests/sub-subtests excluded
-# in results reference control.ini.
+# in results reference control.ini.  Though you may add
+# items here but they will have the same effect as if they
+# were added in 'exclude' (above)
 excluded =
 
-# What field name encodes the subtest/sub-subtest name in
-# the format '<key_match>:<subthing>'
-# e.g. 'whiteboard'
+# Bugzilla bug field name that encodes the subtest/sub-subtest
+# name to exclude.  The format searched for is '<key_match>:<subthing>'
+# where key_match is defined below.  e.g. 'whiteboard' will look for
+# <key_match>:<subthing> in the 'whiteboard' bug field.
 key_field = status_whiteboard
 
-# Value that must match inside key_field for query(below)
+# Value that must match inside key_field for query (below), this allows
+# differientiation between different jobs/configurations matching
+# their own set of bugs.  It's used along with the key_field (above)
 key_match = docker-autotest
 
 [Query]
 
 # All keys/values defined here will be passed as arguments to
-# Bugzilla.build_query() in addition to 'fixed_states' and
+# Bugzilla.build_query() in addition to 'status' and
 # 'key_match' above.
 
 product = Red Hat Enterprise Linux 7
-component = docker
+component = docker, docker-distribution, docker-registry, atomic, rhel-server-atomic, rhel-server-docker, rhel-tools-docker, rsyslog-docker, sadc-docker, sssd-docker
 status = NEW, ASSIGNED, POST, MODIFIED, ON_DEV

--- a/control
+++ b/control
@@ -305,7 +305,7 @@ class ControlINI(ConfigParser.SafeConfigParser, Singleton):
         subtests = []
         # All subtest packages located beneath dir holding this control file
         for dirpath, dirnames, filenames in os.walk(subtest_path,
-                                            followlinks=True):
+                                                    followlinks=True):
             del dirnames  #  Not used
             # Skip top-level
             if dirpath == subtest_path:
@@ -353,17 +353,19 @@ class ControlINI(ConfigParser.SafeConfigParser, Singleton):
         key_field = self.get('Bugzilla', 'key_field').strip()
         for bug in bugs:
             field_value = getattr(bug, key_field)
-            mobj = regex.search(field_value)
-            if mobj is None:
-                continue
-            version, subthing = mobj.groups()
-            # Version is optional (and not currently used) but
-            # contains a trailing ':' that needs pruning
-            version = version[:-1]
-            # Multiple bugs may be associated with a subthing
-            bzs = result.get(subthing, [])
-            bzs.append(bug.bug_id)
-            result[subthing] = bzs
+            for groups in regex.findall(field_value):
+                if groups is None:
+                    continue
+                version, subthing = groups[0:2]
+                # Version is optional (and not currently used) but
+                # contains a trailing ':' that needs pruning
+                if version[-1] == ':':
+                    version = version[:-1]
+                # Multiple bugs may be associated with a subthing
+                bzs = result.get(subthing, [])
+                # TODO: Actually check version against something?
+                bzs.append(bug.bug_id)
+                result[subthing] = bzs
         return result
 
     def bugged_subthings(self, subthings, subtest_modules):


### PR DESCRIPTION
Matching bugs containing multiple subthing names should now be possible.

Signed-off-by: Chris Evich <cevich@redhat.com>