### PR TITLE
signal 48 (SIGRTMIN+14) is now valid

### DIFF
--- a/config_defaults/subtests/docker_cli/kill_bad.ini
+++ b/config_defaults/subtests/docker_cli/kill_bad.ini
@@ -9,4 +9,4 @@ exec_cmd = 'while :; do sleep 0.1; done'
 
 [docker_cli/kill_bad/bad]
 #: csv of bad signals which will be used in test
-bad_signals = 0,-1,-78,48,96,SIGBADSIGNAL,SIG,%%,!,\\,\,"''",'""', ,
+bad_signals = 0,-1,-78,96,SIGBADSIGNAL,SIG,%%,!,\\,\,"''",'""', ,


### PR DESCRIPTION
Found while testing docker 1.9.1-el7: 'kill -s 48' in the kill_bad
subtest now succeeds because 48 is a valid, if unusual, signal.
Looks like change was introduced in August 2015 via
0e50d946a25beb134bce2aaf4a209b5cfcbacf8f

Submitting as a lone PR because this is 1.9-related but technically
not part of the new exit code work.

Signed-off-by: Ed Santiago <santiago@redhat.com>