### PR TITLE
Monkey fix and avoid empy subtest throwing error

### DIFF
--- a/control
+++ b/control
@@ -87,9 +87,10 @@ def get_bzobj(bzopts):
         logging.warning("Bugzilla status exclusion filter configured "
                         "but bugzilla python module unavailable.")
         return None
-    # We were never here, you didn't see or hear anything.
-    if os.path.dirname(job.control) == sys.path[0]:
-        del sys.path[0]
+    finally:
+        # We were never here, you didn't see or hear anything.
+        if os.path.dirname(job.control) == sys.path[0]:
+            del sys.path[0]
     quiet_bz()  # the bugzilla module is very noisy
     bz = bugzilla.Bugzilla(url=url)
     if username is not '' and password is not '':

--- a/dockertest/subtest.py
+++ b/dockertest/subtest.py
@@ -458,11 +458,12 @@ class SubSubtestCaller(Subtest):
         (instance attribute) to determine overall subtest success/failure.
         """
         super(SubSubtestCaller, self).run_once()
-        for name in self.subsubtest_names:
-            self.run_all_stages(name, self.new_subsubtest(name))
-        if len(self.start_subsubtests) == 0:
-            raise TestError("No sub-subtests configured to run "
+        if not self.subsubtest_names:
+            self.logwarning("No sub-subtests configured to run "
                             "for subtest %s" % self.config_section)
+        else:
+            for name in self.subsubtest_names:
+                self.run_all_stages(name, self.new_subsubtest(name))
 
     def postprocess(self):
         """


### PR DESCRIPTION
This gets around a special case where a subtest has only a single sub-subtest which is excluded (control file cannot inspect sub-subtests, only identify their names).