### PR TITLE
bz1097344 (docker-1.10 exit codes): prep work

### DIFF
--- a/config_defaults/subtests/docker_cli/commit.ini
+++ b/config_defaults/subtests/docker_cli/commit.ini
@@ -9,7 +9,7 @@ subsubtests = good,check_default_cmd
 
 [docker_cli/commit/good]
 #: expected result
-docker_expected_result = PASS
+docker_expected_exit_status = 0
 #: Author
 commit_author = Author_name
 #: Commit message

--- a/config_defaults/subtests/docker_cli/history.ini
+++ b/config_defaults/subtests/docker_cli/history.ini
@@ -9,4 +9,4 @@ subsubtests = simple
 
 [docker_cli/history/simple]
 #: expected results
-docker_expected_result = PASS
+docker_expected_exit_status = 0

--- a/config_defaults/subtests/docker_cli/pull.ini
+++ b/config_defaults/subtests/docker_cli/pull.ini
@@ -3,7 +3,7 @@
 docker_pull_timeout = 120.0
 subsubtests = good,wrong_tag,wrong_registry_addr
 #: Allow test to pass if actual result matches this PASS/FAIL value
-docker_expected_result = PASS
+docker_expected_exit_status = 0
 #: Should be customized to point at relevant 'remote'
 #: registry server and image name
 __example__ = docker_repo_name, docker_repo_tag,
@@ -13,11 +13,11 @@ docker_repo_tag = buildroot-2014.02
 docker_registry_host = docker.io
 
 [docker_cli/pull/wrong_tag]
-docker_expected_result = FAIL
+docker_expected_exit_status = 1
 #: Additional tag flag **must NOT exist**
 docker_repo_tag = tag_does_not_exist
 
 [docker_cli/pull/wrong_registry_addr]
-docker_expected_result = FAIL
+docker_expected_exit_status = 1
 #: Name of an invalid remote registry server and port
 docker_registry_host = registry.does.not.exist.example.com:3

--- a/config_defaults/subtests/docker_cli/rmi.ini
+++ b/config_defaults/subtests/docker_cli/rmi.ini
@@ -5,7 +5,7 @@ subsubtests = only_tag,delete_wrong_name,with_blocking_container_by_tag,with_blo
 #: use ``docker rmi --force``
 docker_rmi_force = no
 #: Expected results
-docker_expected_result = PASS
+docker_expected_exit_status = 0
 
 [docker_cli/rmi/only_tag]
 
@@ -28,10 +28,8 @@ docker_data_prepare_cmd = /bin/bash -c "echo '%%s' > /var/i"
 commit_author = Author_name
 #: Commit message
 commit_message = Message
-#: Changed files
-commit_changed_files = /var/i
 #: ``docker commit`` deadline
 docker_commit_timeout = 60.0
 
 [docker_cli/rmi/delete_wrong_name]
-docker_expected_result = FAIL
+docker_expected_exit_status = 1

--- a/dockertest/dockercmd_unittests.py
+++ b/dockertest/dockercmd_unittests.py
@@ -282,11 +282,11 @@ class DockerCmdTestBasic(DockerCmdTestBase):
         docker_command = self.dockercmd.DockerCmd(self.fake_subtest,
                                                   'fake_subcommand')
         self.assertRaises(self.xceptions.DockerExecError,
-                          self.output.mustfail, docker_command.execute())
+                          self.output.mustfail, docker_command.execute(), 1)
 
         docker_command = self.dockercmd.DockerCmd(self.fake_subtest,
                                                   'unittest_fail')
-        self.assertTrue(self.output.mustfail(docker_command.execute()))
+        self.assertTrue(self.output.mustfail(docker_command.execute(), 1))
 
 
 class AsyncDockerCmd(DockerCmdTestBase):

--- a/dockertest/output_unittests.py
+++ b/dockertest/output_unittests.py
@@ -156,7 +156,7 @@ class DockerVersionTest(unittest.TestCase):
         self.assertEqual(docker_version.client, '1.8.2')
         self.assertEqual(docker_version.server, '1.8.2')
 
-    def test_client_new(self):
+    def test_client_info_new(self):
         version_string = (
             "Client:\n"
             " Go version:   go1.4.2\n"

--- a/subtests/docker_cli/attach/attach.py
+++ b/subtests/docker_cli/attach/attach.py
@@ -143,7 +143,7 @@ class simple_base(attach_base):
 
     def failif_contain(self, check_for, in_output, details):
         self.failif(check_for in in_output,
-                    "Command '%s' output must contain '%s' but doesn't."
+                    "Command '%s' output must not contain '%s' but does."
                     " Detail: %s" % (self.config["bash_cmd"],
                                      check_for, details))
         self.logdebug("Output does NOT contain '%s'", check_for)

--- a/subtests/docker_cli/build/build.py
+++ b/subtests/docker_cli/build/build.py
@@ -225,7 +225,8 @@ class postprocessing(object):
             if OutputGood(build_def.dockercmd.cmdresult,
                           ignore_error=True,
                           skip=['error_check']):
-                return build_def.dockercmd.cmdresult.exit_status != 0
+                # FIXME: this is likely to fail in docker-1.10; bz1097344
+                return build_def.dockercmd.cmdresult.exit_status == 1
         else:
             raise DockerTestError("Command error: %s" % command)
 

--- a/subtests/docker_cli/commit/commit.py
+++ b/subtests/docker_cli/commit/commit.py
@@ -92,26 +92,20 @@ class commit_base(SubSubtest):
 
     def postprocess(self):
         super(commit_base, self).postprocess()
-        if self.config["docker_expected_result"] == "PASS":
-            # Raise exception if problems found
-            OutputGood(self.sub_stuff['cmdresult'])
-            self.failif_ne(self.sub_stuff['cmdresult'].exit_status, 0,
-                           "Non-zero commit exit status: %s"
-                           % self.sub_stuff['cmdresult'])
+        # Raise exception if problems found
+        expect = self.config["docker_expected_exit_status"]
+        OutputGood(self.sub_stuff['cmdresult'], ignore_error=(expect != 0))
 
+        self.failif_ne(self.sub_stuff['cmdresult'].exit_status, expect,
+                       "Command exit status")
+
+        if expect == 0:
             im = self.check_image_exists(self.sub_stuff["new_image_name"])
             # Needed for cleanup
             self.sub_stuff['image_list'] = im
             self.failif(len(im) < 1,
                         "Failed to look up committed image ")
             self.check_file_in_image()
-
-        elif self.config["docker_expected_result"] == "FAIL":
-            og = OutputGood(self.sub_stuff['cmdresult'], ignore_error=True)
-            es = self.sub_stuff['cmdresult'].exit_status == 0
-            self.failif(not og or not es,
-                        "Zero commit exit status: Command should fail due to"
-                        " wrong command arguments.")
 
     def cleanup(self):
         super(commit_base, self).cleanup()

--- a/subtests/docker_cli/create/create_signal.py
+++ b/subtests/docker_cli/create/create_signal.py
@@ -29,7 +29,7 @@ class create_signal(create_base):
         sigdkrcmd = DockerCmd(self, 'kill',
                               ['--signal', str(sig),
                                self.get_cid()])
-        sigdkrcmd = mustfail(sigdkrcmd.execute())
+        sigdkrcmd = mustfail(sigdkrcmd.execute(), 1)
         self.sub_stuff['sigdkrcmd'] = sigdkrcmd
 
     def postprocess(self):

--- a/subtests/docker_cli/dockerimport/truncated.py
+++ b/subtests/docker_cli/dockerimport/truncated.py
@@ -26,7 +26,7 @@ class truncated(empty):
         image_name = self.sub_stuff['image_name']  # assume id lookup failed
         if self.parent_subtest.config['remove_after_test']:
             dkrcmd = DockerCmd(self, 'rmi', [image_name])
-            mustfail(dkrcmd.execute())
+            mustfail(dkrcmd.execute(), 1)
 
     def run_tar(self, tar_command, dkr_command):
         tarfile = os.path.join(self.parent_subtest.bindir, self.TARFILENAME)

--- a/subtests/docker_cli/history/history.py
+++ b/subtests/docker_cli/history/history.py
@@ -83,13 +83,13 @@ class history_base(SubSubtest):
 
     def postprocess(self):
         super(history_base, self).postprocess()
-        if self.config["docker_expected_result"] == "PASS":
-            # Raise exception if problems found
-            OutputGood(self.sub_stuff['cmdresult'])
-            self.failif_ne(self.sub_stuff['cmdresult'].exit_status, 0,
-                           "Non-zero history exit status: %s"
-                           % self.sub_stuff['cmdresult'])
+        # Raise exception if problems found
+        expect = self.config["docker_expected_exit_status"]
+        OutputGood(self.sub_stuff['cmdresult'], ignore_error=(expect != 0))
+        self.failif_ne(self.sub_stuff['cmdresult'].exit_status, expect,
+                       "Exit status")
 
+        if expect == 0:
             new_img_name = self.sub_stuff["new_image_name"]
             new_img_name2 = self.sub_stuff["new_image_name2"]
             base_img_name = DockerImage.full_name_from_defaults(self.config)

--- a/subtests/docker_cli/import_url/import_url.py
+++ b/subtests/docker_cli/import_url/import_url.py
@@ -48,7 +48,7 @@ class base(SubSubtest):
         subargs += [self.sub_stuff['import_repo']]
         subargs += ['some', 'dummy', 'command']
         self.logdebug("Next docker command should fail...")
-        mustfail(DockerCmd(self, 'run', subargs).execute())
+        mustfail(DockerCmd(self, 'run', subargs).execute(), 1)
 
     def initialize(self):
         super(base, self).initialize()

--- a/subtests/docker_cli/kill_bad/kill_bad.py
+++ b/subtests/docker_cli/kill_bad/kill_bad.py
@@ -71,14 +71,14 @@ class kill_bad_base(subtest.SubSubtest):
             mustfail(DockerCmd(self, 'kill',
                                ['-s', signal,
                                 self.sub_stuff['container_name']],
-                               verbose=False).execute())
+                               verbose=False).execute(), 125)
             self.failif(self.sub_stuff['container_cmd'].done, "Testing "
                         "container died after using signal %s." % signal)
         dkrcnt = DockerContainers(self)
         nonexisting_name = dkrcnt.get_unique_name()
         self.logdebug("Killing nonexisting containe.")
         mustfail(DockerCmd(self, 'kill', [nonexisting_name],
-                           verbose=False).execute())
+                           verbose=False).execute(), 125)
 
     def postprocess(self):
         """

--- a/subtests/docker_cli/pull/pull.py
+++ b/subtests/docker_cli/pull/pull.py
@@ -8,10 +8,10 @@ Operational Summary
 ----------------------
 
 #. Try to download repository from registry
-#. if docker_expected_result == PASS: fail when command exitcode != 0
+#. Ensure that command exit code == docker_expected_exit_status (usually 0)
+#. if docker_expected_exit_status == 0:
     #. Check if image is in local repository.
     #. Remote image from local repository
-#. If docker_expected_result == FAIL: fail when command exitcode == 0
 
 Prerequisites
 ---------------------------------------------
@@ -99,18 +99,12 @@ class pull_base(SubSubtest):
         OutputGood(self.sub_stuff['dkrcmd'].cmdresult)
 
     def exitcheck(self):
-        exit_status = self.sub_stuff['dkrcmd'].exit_status
-        if self.config["docker_expected_result"] == "PASS":
-            self.failif_ne(exit_status, 0,
-                           "Non-zero pull exit status: %s"
-                           % self.sub_stuff['dkrcmd'])
-        elif self.config["docker_expected_result"] == "FAIL":
-            self.failif(exit_status == 0,
-                        "Zero pull exit status: Command should fail due to"
-                        " wrong command arguments.")
+        self.failif_ne(self.sub_stuff['dkrcmd'].exit_status,
+                       self.config["docker_expected_exit_status"],
+                       "Exit status from pull command")
 
     def existcheck(self):
-        if self.config["docker_expected_result"] == "PASS":
+        if self.config["docker_expected_exit_status"] == 0:
             di = self.sub_stuff['di']
             image_fn = di.full_name_from_defaults()
             image_list = self.sub_stuff['image_list']

--- a/subtests/docker_cli/rm/rm.py
+++ b/subtests/docker_cli/rm/rm.py
@@ -249,8 +249,8 @@ class forced(rm_sub_base):
         rm_cmdresult = self.sub_stuff['rm_cmdresult']
         self.failif(cmdresult.exit_status == 0, ("Expected non-zero exit: %s"
                                                  % cmdresult))
-        self.failif_ne(rm_cmdresult.exit_statusm, 0, ("Expected zero exit: %s"
-                                                      % rm_cmdresult))
+        self.failif_ne(rm_cmdresult.exit_status, 0, ("Expected zero exit: %s"
+                                                     % rm_cmdresult))
         OutputGood(cmdresult)
         OutputGood(rm_cmdresult)
 

--- a/subtests/docker_cli/rmi/delete_wrong_name.py
+++ b/subtests/docker_cli/rmi/delete_wrong_name.py
@@ -30,7 +30,6 @@ class delete_wrong_name(rmi_base):
         super(delete_wrong_name, self).postprocess()
         # Raise exception if problems found
         OutputGood(self.sub_stuff['cmdresult'], ignore_error=True)
-        if self.config["docker_expected_result"] == "FAIL":
-            self.failif(self.sub_stuff['cmdresult'].exit_status == 0,
-                        "Zero rmi exit status: Command should fail due to"
-                        " wrong image name.")
+        self.failif_ne(self.sub_stuff['cmdresult'].exit_status,
+                       self.config["docker_expected_exit_status"],
+                       "Docker exit status")

--- a/subtests/docker_cli/rmi/rmi.py
+++ b/subtests/docker_cli/rmi/rmi.py
@@ -81,26 +81,18 @@ class rmi_base(SubSubtest):
 
     def postprocess(self):
         super(rmi_base, self).postprocess()
-        if self.config["docker_expected_result"] == "PASS":
-            # Raise exception if problems found
-            OutputGood(self.sub_stuff['cmdresult'])
-            self.failif_ne(self.sub_stuff['cmdresult'].exit_status, 0,
-                           "Non-zero rmi exit status: %s"
-                           % self.sub_stuff['cmdresult'])
+        # Raise exception if problems found
+        expect = self.config["docker_expected_exit_status"]
+        OutputGood(self.sub_stuff['cmdresult'], ignore_error=(expect != 0))
 
+        self.failif_ne(self.sub_stuff['cmdresult'].exit_status, expect,
+                       "Command exit status")
+
+        if expect == 0:
             im = self.check_image_exists(self.sub_stuff["image_name"])
             self.sub_stuff['image_list'] = im
             self.failif_ne(im, [], "Deleted image still exits: %s" %
                            self.sub_stuff["image_name"])
-
-        elif self.config["docker_expected_result"] == "FAIL":
-            self.failif(self.sub_stuff['cmdresult'].exit_status == 0,
-                        "Zero rmi exit status: Command should fail due to"
-                        " wrong command arguments.")
-        else:
-            self.failif(True, ("Config. option 'docker_expected_result' "
-                               "must be 'PASS' or 'FAIL', not %s"
-                               % self.config["docker_expected_result"]))
 
     def cleanup(self):
         super(rmi_base, self).cleanup()

--- a/subtests/docker_cli/run_cidfile/run_cidfile.py
+++ b/subtests/docker_cli/run_cidfile/run_cidfile.py
@@ -135,14 +135,14 @@ class basic(subtest.SubSubtest):
         self._check_cidfile(long_id, cidfile)
         # cidfile already exists (running container)
         containers.append(self._init_container(subargs, cidfile, 'true',
-                                               mustfail))
+                                               lambda x: mustfail(x, 1)))
         self._check_failure_cidfile_present(containers[-1])
         # cidfile already exists (exited container)
         containers[0].stdin("exit\n")
         containers[0].wait(10)
         containers[0].close()
         containers.append(self._init_container(subargs, cidfile, 'true',
-                                               mustfail))
+                                               lambda x: mustfail(x, 1)))
         self._check_failure_cidfile_present(containers[-1])
         # restart container with cidfile
         mustpass(dockercmd.DockerCmd(self, 'start', [name],

--- a/subtests/docker_cli/run_dns/run_dns.py
+++ b/subtests/docker_cli/run_dns/run_dns.py
@@ -39,7 +39,7 @@ class run_dns(subtest.Subtest):
             for name in search:
                 subargs.insert(0, '--dns-search %s' % name)
         return mustfail(DockerCmd(self, 'run', subargs,
-                                  verbose=False).execute())
+                                  verbose=False).execute(), 125)
 
     def _execute_and_record(self, dns, search, dnss, searches):
         """ Execute and store the new dns/searches """

--- a/subtests/docker_cli/run_exec/run_exec.py
+++ b/subtests/docker_cli/run_exec/run_exec.py
@@ -149,7 +149,7 @@ class exec_false(exec_base):
 
     def postprocess(self):
         dkrcmd_exec = self.sub_stuff['dkrcmd_exec']
-        mustfail(dkrcmd_exec.cmdresult)
+        mustfail(dkrcmd_exec.cmdresult, 1)
         OutputNotBad(dkrcmd_exec.cmdresult)
         super(exec_false, self).postprocess()
 

--- a/subtests/docker_cli/start/simple.py
+++ b/subtests/docker_cli/start/simple.py
@@ -63,7 +63,7 @@ class simple(subtest.SubSubtest):
                    "in the output:\n%s")
         # Nonexisting container
         missing_msg = self.config['missing_msg']
-        result = mustfail(DockerCmd(self, "start", [name]).execute())
+        result = mustfail(DockerCmd(self, "start", [name]).execute(), 125)
         self.failif(missing_msg not in str(result), err_msg
                     % ("non-existing", missing_msg, result))
 


### PR DESCRIPTION
Background: 'docker run' exit codes will be changing in 1.10,
to differentiate between container exit status and errors from
docker itself[1]. This commit prepares for that, by
redefining the use of the docker_expected_status config
setting. Instead of 'PASS' or 'FAIL' (old values), it
is now expected to be an integer: 0 for success, X
for failure. As of this commit X is always 1, but at
some future point that will change. When it does,
the new failif_ne() helper will display the new exit
code, and it will be easy to update .ini files as
necessary.

Additionally, the mustfail() helper now requires the
expected exit status as an argument. These statuses can
actually be hardcoded in the code itself, because
mustfail() tests (once) if the installed docker binary
returns unique exit codes; if it doesn't, it changes
the expectation to 1 (what old-docker always returns).

Also includes two unrelated fixes for minor problems
discovered during this process: removed an unused
config setting, and fixed an incorrect test helper.

 [1] https://github.com/docker/docker/pull/14012/files

Note that the exit codes here are UNTESTED, and will
require tweaking once we actually have docker-1.10
available. That is expected to be minor effort.

Signed-off-by: Ed Santiago <santiago@redhat.com>