### PR TITLE
new failif_ne test, for more helpful diagnostics

### DIFF
--- a/dockertest/subtestbase.py
+++ b/dockertest/subtestbase.py
@@ -112,6 +112,33 @@ class SubBase(object):
         if bool(condition):
             raise DockerTestFail(reason)
 
+    @staticmethod
+    def failif_ne(actual, expected, reason=None):
+        """
+        Convenience method for subtests to compare two values and
+        fail if they differ. Failure message will include the expected
+        and actual values for ease of debugging.
+
+        :param actual: value being tested
+        :param expected: value to which we compare.
+        :param reason: Helpful text describing why the test failed
+        :raise DockerTestFail: If actual != expected
+        """
+
+        if actual == expected:
+            return
+        if reason is None:
+            reason = "Failed test condition"
+
+        # By default, quote each value. This is especially helpful when
+        # actual or expected is the empty string or a string with spaces.
+        # But if both are numeric types the quotes distract, so remove them.
+        arg = "'{}'"
+        if all(isinstance(x, (int, long, float)) for x in [actual, expected]):
+            arg = "{}"
+        spec = "{}: expected " + arg + "; got " + arg
+        raise DockerTestFail(spec.format(reason, expected, actual))
+
     @classmethod
     def log_x(cls, lvl, msg, *args):
         """

--- a/subtests/docker_cli/attach/attach.py
+++ b/subtests/docker_cli/attach/attach.py
@@ -52,9 +52,9 @@ class attach_base(SubSubtest):
         while not dkrcmd.done:
             self.loginfo("Pulling...")
             time.sleep(3)
-        self.failif(dkrcmd.exit_status != 0,
-                    "Fail to download image %s"
-                    % image_name)
+        self.failif_ne(dkrcmd.exit_status, 0,
+                       "Fail to download image %s"
+                       % image_name)
 
     def initialize(self):
         super(attach_base, self).initialize()

--- a/subtests/docker_cli/build/expose.py
+++ b/subtests/docker_cli/build/expose.py
@@ -53,8 +53,8 @@ class expose(build_base):
     def postprocess(self):
         super(expose, self).postprocess()
         cntnr_port = self.sub_stuff['port_cntnr']
-        self.failif(cntnr_port.host_port != 8080, str(cntnr_port))
-        self.failif(cntnr_port.protocol != 'tcp', str(cntnr_port))
+        self.failif_ne(cntnr_port.host_port, 8080, str(cntnr_port))
+        self.failif_ne(cntnr_port.protocol, 'tcp', str(cntnr_port))
 
     def cleanup(self):
         for fd in self.sub_stuff.get('fds', []):

--- a/subtests/docker_cli/commit/check_default_cmd.py
+++ b/subtests/docker_cli/commit/check_default_cmd.py
@@ -25,9 +25,9 @@ class check_default_cmd(commit_base):
         self.loginfo("postprocess()")
         # Raise exception if problems found
         OutputGood(self.sub_stuff['cmdresult'])
-        self.failif(self.sub_stuff['cmdresult'].exit_status != 0,
-                    "Non-zero commit exit status: %s"
-                    % self.sub_stuff['cmdresult'])
+        self.failif_ne(self.sub_stuff['cmdresult'].exit_status, 0,
+                       "Non-zero commit exit status: %s"
+                       % self.sub_stuff['cmdresult'])
 
         im = self.check_image_exists(self.sub_stuff["new_image_name"])
         # Needed for cleanup
@@ -51,13 +51,13 @@ class check_default_cmd(commit_base):
                     pass
                 dc = DockerCmd(self, "rm", ["-f", cont.long_id])
                 rm_results = dc.execute()
-                self.failif(rm_results.exit_status != 0,
-                            "Non-zero commit exit status: %s"
-                            % rm_results)
+                self.failif_ne(rm_results.exit_status, 0,
+                               "Non-zero commit exit status: %s"
+                               % rm_results)
 
-        self.failif(results.exit_status != 0,
-                    "Non-zero commit exit status: %s"
-                    % results)
+        self.failif_ne(results.exit_status, 0,
+                       "Non-zero commit exit status: %s"
+                       % results)
 
         self.failif(not self.sub_stuff['rand_data'] in results.stdout,
                     "Unexpected command result: %s"

--- a/subtests/docker_cli/commit/commit.py
+++ b/subtests/docker_cli/commit/commit.py
@@ -95,9 +95,9 @@ class commit_base(SubSubtest):
         if self.config["docker_expected_result"] == "PASS":
             # Raise exception if problems found
             OutputGood(self.sub_stuff['cmdresult'])
-            self.failif(self.sub_stuff['cmdresult'].exit_status != 0,
-                        "Non-zero commit exit status: %s"
-                        % self.sub_stuff['cmdresult'])
+            self.failif_ne(self.sub_stuff['cmdresult'].exit_status, 0,
+                           "Non-zero commit exit status: %s"
+                           % self.sub_stuff['cmdresult'])
 
             im = self.check_image_exists(self.sub_stuff["new_image_name"])
             # Needed for cleanup
@@ -135,13 +135,13 @@ class commit_base(SubSubtest):
                            self.config['docker_commit_timeout'])
             results = cm.execute()
             if results.exit_status == 0:
-                self.failif((results.stdout.strip() !=
-                             self.sub_stuff["rand_data"]),
-                            "Data read from image do not match"
-                            " data written to container during"
-                            " test initialization: %s != %s" %
-                            (results.stdout.strip(),
-                             self.sub_stuff["rand_data"]))
+                self.failif_ne(results.stdout.strip(),
+                               self.sub_stuff["rand_data"],
+                               "Data read from image do not match"
+                               " data written to container during"
+                               " test initialization: %s != %s" %
+                               (results.stdout.strip(),
+                                self.sub_stuff["rand_data"]))
 
 
 class good(commit_base):

--- a/subtests/docker_cli/cp/cp.py
+++ b/subtests/docker_cli/cp/cp.py
@@ -103,9 +103,9 @@ class simple(CpBase):
         with open(copied_file, 'r') as copied_content:
             data = copied_content.read()
         copied_md5 = hashlib.md5(data).hexdigest()
-        self.failif(self.sub_stuff['cpfile_md5'] != copied_md5,
-                    "Copied file '%s' does not match docker file "
-                    "'%s'." % (copied_file, docker_file))
+        self.failif_ne(self.sub_stuff['cpfile_md5'], copied_md5,
+                       "Copied file '%s' does not match docker file "
+                       "'%s'." % (copied_file, docker_file))
         self.loginfo("Copied file matches docker file.")
 
 

--- a/subtests/docker_cli/create/create.py
+++ b/subtests/docker_cli/create/create.py
@@ -81,9 +81,9 @@ class create_base(SubSubtest):
         dkrcmd = self.sub_stuff['dkrcmd']
         OutputGood(dkrcmd.cmdresult)
         expected = 0  # always
-        self.failif(dkrcmd.exit_status != expected,
-                    "Exit status non-zero command %s"
-                    % dkrcmd.cmdresult)
+        self.failif_ne(dkrcmd.exit_status, expected,
+                       "Exit status non-zero command %s"
+                       % dkrcmd.cmdresult)
         # cid must be printed on stdout, always
         cid = self.get_cid()
         # non-forced removal must succeed, rely on rm test to verify.

--- a/subtests/docker_cli/create/create_names.py
+++ b/subtests/docker_cli/create/create_names.py
@@ -28,6 +28,6 @@ class create_names(create_base):
         self.failif(len(json) == 0)
         # docker sticks a "/" prefix on name (documented?)
         actual_name = str(json[0]['Name'][1:])
-        self.failif(actual_name != self.sub_stuff['name'],
-                    "Actual name %s != expected name %s"
-                    % (actual_name, self.sub_stuff['name']))
+        self.failif_ne(actual_name, self.sub_stuff['name'],
+                       "Actual name %s != expected name %s"
+                       % (actual_name, self.sub_stuff['name']))

--- a/subtests/docker_cli/diff/diff.py
+++ b/subtests/docker_cli/diff/diff.py
@@ -65,9 +65,9 @@ class diff_base(SubSubtest):
         for key, value in expected:
             self.failif(key not in diffmap,
                         "Change to file: %s not detected." % (key))
-            self.failif(value != diffmap[key],
-                        "Change type detection error for "
-                        "change: %s %s" % (value, key))
+            self.failif_ne(value, diffmap[key],
+                           "Change type detection error for "
+                           "change: %s %s" % (value, key))
 
     def cleanup(self):
         super(diff_base, self).cleanup()

--- a/subtests/docker_cli/history/history.py
+++ b/subtests/docker_cli/history/history.py
@@ -86,9 +86,9 @@ class history_base(SubSubtest):
         if self.config["docker_expected_result"] == "PASS":
             # Raise exception if problems found
             OutputGood(self.sub_stuff['cmdresult'])
-            self.failif(self.sub_stuff['cmdresult'].exit_status != 0,
-                        "Non-zero history exit status: %s"
-                        % self.sub_stuff['cmdresult'])
+            self.failif_ne(self.sub_stuff['cmdresult'].exit_status, 0,
+                           "Non-zero history exit status: %s"
+                           % self.sub_stuff['cmdresult'])
 
             new_img_name = self.sub_stuff["new_image_name"]
             new_img_name2 = self.sub_stuff["new_image_name2"]

--- a/subtests/docker_cli/import_export/import_export.py
+++ b/subtests/docker_cli/import_export/import_export.py
@@ -102,6 +102,6 @@ class simple(import_export_base):
         # Fail test if bad command or other stdout/stderr problems detected
         cmdresult = self.sub_stuff['cmdresult']
         OutputGood(cmdresult)
-        self.failif(cmdresult.exit_status != 0,
-                    "Problem with export import cmd detail :%s" %
-                    cmdresult)
+        self.failif_ne(cmdresult.exit_status, 0,
+                       "Problem with export import cmd detail :%s" %
+                       cmdresult)

--- a/subtests/docker_cli/import_url/import_url.py
+++ b/subtests/docker_cli/import_url/import_url.py
@@ -94,7 +94,6 @@ class md5sum(base):
         cp_file = open(join(self.tmpdir, self.sub_stuff['filename']), 'rb')
         data = cp_file.read()
         actual_md5 = md5(data).hexdigest()
-        failmsg = ("File %s in tarball from %s md5 (%s) != expected %s"
-                   % (self.sub_stuff['filename'], self.config['tar_url'],
-                      actual_md5, self.config['md5sum']))
-        self.failif(actual_md5 != self.config['md5sum'], failmsg)
+        failmsg = ("File %s in tarball from %s md5"
+                   % (self.sub_stuff['filename'], self.config['tar_url']))
+        self.failif_ne(actual_md5, self.config['md5sum'], failmsg)

--- a/subtests/docker_cli/info/info.py
+++ b/subtests/docker_cli/info/info.py
@@ -56,12 +56,12 @@ class info(subtest.Subtest):
         outputgood = OutputGood(self.stuff['cmdresult'])
         info_map = self._build_table(outputgood.stdout_strip)
         # Verify some individual items
-        self.failif(info_map['Storage Driver'].lower() != 'devicemapper',
-                    info_map['Storage Driver'])
-        self.failif(info_map['Data file'].lower() != '',
-                    info_map['Data file'])
-        self.failif(info_map['Metadata file'].lower() != '',
-                    info_map['Metadata file'])
+        self.failif_ne(info_map['Storage Driver'].lower(), 'devicemapper',
+                       'Storage Driver')
+        self.failif_ne(info_map['Data file'].lower(), '',
+                       'Data file')
+        self.failif_ne(info_map['Metadata file'].lower(), '',
+                       'Metadata file')
         di = DockerImages(self)
         # Make sure nothing is 'hidden'
         di.images_args = "%s --all" % di.images_args
@@ -69,9 +69,9 @@ class info(subtest.Subtest):
         img_set = set(di.list_imgs_ids())  # don't count multi-tags
         # ...with this
         img_cnt = int(info_map['Images'].lower())
-        self.failif(len(img_set) != img_cnt,
-                    "More/less images %d than info reported %d"
-                    % (len(img_set), img_cnt))
+        self.failif_ne(len(img_set), img_cnt,
+                       "More/less images %d than info reported %d"
+                       % (len(img_set), img_cnt))
         # verify value of elements
         self.verify_pool_name(info_map['Pool Name'])
         data_name = 'Data loop file'

--- a/subtests/docker_cli/kill/kill_utils.py
+++ b/subtests/docker_cli/kill/kill_utils.py
@@ -237,9 +237,8 @@ class kill_base(subtest.SubSubtest):
         super(kill_base, self).postprocess()
         for kill_result in self.sub_stuff.get('kill_results', []):
             OutputGood(kill_result)
-            self.failif(kill_result.exit_status != 0, "Exit status of the %s "
-                        "command was not 0 (%s)"
-                        % (kill_result.command, kill_result.exit_status))
+            self.failif_ne(kill_result.exit_status, 0,
+                           "Exit status of %s command" % kill_result.command)
 
     def cleanup(self):
         super(kill_base, self).cleanup()

--- a/subtests/docker_cli/kill_stopped/kill_utils.py
+++ b/subtests/docker_cli/kill_stopped/kill_utils.py
@@ -237,9 +237,8 @@ class kill_base(subtest.SubSubtest):
         super(kill_base, self).postprocess()
         for kill_result in self.sub_stuff.get('kill_results', []):
             OutputGood(kill_result)
-            self.failif(kill_result.exit_status != 0, "Exit status of the %s "
-                        "command was not 0 (%s)"
-                        % (kill_result.command, kill_result.exit_status))
+            self.failif_ne(kill_result.exit_status, 0,
+                           "Exit status of %s command" % kill_result.command)
 
     def cleanup(self):
         super(kill_base, self).cleanup()

--- a/subtests/docker_cli/kill_stress/kill_utils.py
+++ b/subtests/docker_cli/kill_stress/kill_utils.py
@@ -237,9 +237,8 @@ class kill_base(subtest.SubSubtest):
         super(kill_base, self).postprocess()
         for kill_result in self.sub_stuff.get('kill_results', []):
             OutputGood(kill_result)
-            self.failif(kill_result.exit_status != 0, "Exit status of the %s "
-                        "command was not 0 (%s)"
-                        % (kill_result.command, kill_result.exit_status))
+            self.failif_ne(kill_result.exit_status, 0,
+                           "Exit status of %s command" % kill_result.command)
 
     def cleanup(self):
         super(kill_base, self).cleanup()

--- a/subtests/docker_cli/logs/basic.py
+++ b/subtests/docker_cli/logs/basic.py
@@ -55,6 +55,4 @@ class basic(Base):
         for key in ('before_start', 'after_start'):
             stdout = logs_cmd[key].stdout.strip()
             expected = expected_stdout[key].strip()
-            self.failif(stdout != expected,
-                        'Logs command output "%s" != Expected "%s"'
-                        % (stdout, expected))
+            self.failif_ne(stdout, expected, 'Logs command output')

--- a/subtests/docker_cli/negativeusage/negativeusage.py
+++ b/subtests/docker_cli/negativeusage/negativeusage.py
@@ -180,9 +180,8 @@ class Base(subtest.SubSubtest):
         NoPanic(self.sub_stuff['cmdresult'])
         expected_exit_status = self.config['extcmd']
         cmdresult = self.sub_stuff['cmdresult']
-        self.failif(cmdresult.exit_status != expected_exit_status,
-                    "Exit status was not %d:\n%s"
-                    % (expected_exit_status, cmdresult))
+        self.failif_ne(cmdresult.exit_status, expected_exit_status,
+                       "Exit status: %s" % cmdresult)
         # Same checks for both
         for outtype in ('stdout', 'stderr'):
             if self.sub_stuff[outtype] is not None:

--- a/subtests/docker_cli/pull/pull.py
+++ b/subtests/docker_cli/pull/pull.py
@@ -101,9 +101,9 @@ class pull_base(SubSubtest):
     def exitcheck(self):
         exit_status = self.sub_stuff['dkrcmd'].exit_status
         if self.config["docker_expected_result"] == "PASS":
-            self.failif(exit_status != 0,
-                        "Non-zero pull exit status: %s"
-                        % self.sub_stuff['dkrcmd'])
+            self.failif_ne(exit_status, 0,
+                           "Non-zero pull exit status: %s"
+                           % self.sub_stuff['dkrcmd'])
         elif self.config["docker_expected_result"] == "FAIL":
             self.failif(exit_status == 0,
                         "Zero pull exit status: Command should fail due to"

--- a/subtests/docker_cli/rm/rm.py
+++ b/subtests/docker_cli/rm/rm.py
@@ -175,10 +175,9 @@ class rm_sub_base(SubSubtest):
     def verify_output(self):
         cmdresult = self.sub_stuff['cmdresult']
         rm_cmdresult = self.sub_stuff['rm_cmdresult']
-        self.failif(cmdresult.exit_status != 0, ("Expected zero exit: %s"
-                                                 % cmdresult))
-        self.failif(rm_cmdresult.exit_status != 0, "Expected zero exit: %s"
-                    % rm_cmdresult)
+        self.failif_ne(cmdresult.exit_status, 0, "Exit status: %s" % cmdresult)
+        self.failif_ne(rm_cmdresult.exit_status, 0, "Expected zero exit: %s"
+                       % rm_cmdresult)
         OutputGood(cmdresult)
         OutputGood(rm_cmdresult)
 
@@ -186,7 +185,7 @@ class rm_sub_base(SubSubtest):
         cid = self.sub_stuff['container_id']
         self.loginfo("Verifying container %s is gone", cid)
         cl = self.sub_stuff['dc'].list_containers_with_cid(cid)
-        self.failif(cl != [], "Container %s was not removed!" % cid)
+        self.failif_ne(cl, [], "Container %s was not removed!" % cid)
         self.loginfo("Container is gone.  Verifying output")
 
     def verify_start(self):
@@ -197,9 +196,7 @@ class rm_sub_base(SubSubtest):
         start_file = open(start_filename, 'rb')
         start_time = int(start_file.read())
         init_time = self.sub_stuff['init_time']
-        self.failif(start_time != init_time,
-                    "Static data does not match, %s != %s"
-                    % (start_time, init_time))
+        self.failif_ne(start_time, init_time, "Static data")
 
     def verify_stop(self):
         stop_filename = os.path.join(self.sub_stuff['volume'], 'stop')
@@ -252,8 +249,8 @@ class forced(rm_sub_base):
         rm_cmdresult = self.sub_stuff['rm_cmdresult']
         self.failif(cmdresult.exit_status == 0, ("Expected non-zero exit: %s"
                                                  % cmdresult))
-        self.failif(rm_cmdresult.exit_status != 0, "Expected zero exit: %s"
-                    % rm_cmdresult)
+        self.failif_ne(rm_cmdresult.exit_statusm, 0, ("Expected zero exit: %s"
+                                                      % rm_cmdresult))
         OutputGood(cmdresult)
         OutputGood(rm_cmdresult)
 

--- a/subtests/docker_cli/rmi/rmi.py
+++ b/subtests/docker_cli/rmi/rmi.py
@@ -92,14 +92,14 @@ class rmi_base(SubSubtest):
         if self.config["docker_expected_result"] == "PASS":
             # Raise exception if problems found
             OutputGood(self.sub_stuff['cmdresult'])
-            self.failif(self.sub_stuff['cmdresult'].exit_status != 0,
-                        "Non-zero rmi exit status: %s"
-                        % self.sub_stuff['cmdresult'])
+            self.failif_ne(self.sub_stuff['cmdresult'].exit_status, 0,
+                           "Non-zero rmi exit status: %s"
+                           % self.sub_stuff['cmdresult'])
 
             im = self.check_image_exists(self.sub_stuff["image_name"])
             self.sub_stuff['image_list'] = im
-            self.failif(im != [], "Deleted image still exits: %s" %
-                        self.sub_stuff["image_name"])
+            self.failif_ne(im, [], "Deleted image still exits: %s" %
+                           self.sub_stuff["image_name"])
 
         elif self.config["docker_expected_result"] == "FAIL":
             self.failif(self.sub_stuff['cmdresult'].exit_status == 0,

--- a/subtests/docker_cli/run/run.py
+++ b/subtests/docker_cli/run/run.py
@@ -76,9 +76,7 @@ class run_base(SubSubtest):
         dockercmd = self.sub_stuff['dkrcmd']
         OutputGood(dockercmd.cmdresult)
         expected = self.config['exit_status']
-        self.failif(dockercmd.exit_status != expected,
-                    "Exit status %d, expected %d"
-                    % (dockercmd.exit_status, expected))
+        self.failif_ne(dockercmd.exit_status, expected, "Exit status")
 
     def cleanup(self):
         super(run_base, self).cleanup()

--- a/subtests/docker_cli/run/run_names.py
+++ b/subtests/docker_cli/run/run_names.py
@@ -35,6 +35,4 @@ class run_names(run_base):
         self.failif(len(json) == 0)
         # docker sticks a "/" prefix on name (documented?)
         actual_name = str(json[0]['Name'][1:])
-        self.failif(actual_name != self.sub_stuff['expected_name'],
-                    "Actual name %s != expected name %s"
-                    % (actual_name, self.sub_stuff['expected_name']))
+        self.failif_ne(actual_name, self.sub_stuff['expected_name'], "Name")

--- a/subtests/docker_cli/run_cidfile/run_cidfile.py
+++ b/subtests/docker_cli/run_cidfile/run_cidfile.py
@@ -165,8 +165,8 @@ class basic(subtest.SubSubtest):
     def _get_container_by_name(self, name):
         """ Checks only one container of given name exists and returns it """
         conts = self.sub_stuff['dc'].list_containers_with_name(name)
-        self.failif(len(conts) != 1, "0 or multiple containers of the same "
-                    "name (%s) found (%s)" % (name, conts))
+        self.failif_ne(len(conts), 1, "0 or multiple containers of the same "
+                       "name (%s) found (%s)" % (name, conts))
         return conts[0]
 
     def _nonexisting_path(self, path, prefix):
@@ -186,8 +186,7 @@ class basic(subtest.SubSubtest):
             if act != "":
                 break
             time.sleep(1)
-        self.failif(long_id != act, "Cidfile output (%s) doesn't match "
-                    "expected long_id (%s)" % (act, long_id))
+        self.failif_ne(long_id, act, "Cidfile output")
 
     def _cleanup_cidfiles(self):
         """ Unlink all used cidfiles """

--- a/subtests/docker_cli/run_env/run_env.py
+++ b/subtests/docker_cli/run_env/run_env.py
@@ -117,7 +117,7 @@ class spam(SubSubtest):
                 self.logwarning("var %s value %s does not match %s's %s",
                                 value, key, name, compareto[key])
         # Now fail after checking all the keys/values
-        self.failif(expected != actual)
+        self.failif_ne(actual, expected)
 
     def initialize(self):
         super(spam, self).initialize()

--- a/subtests/docker_cli/run_exec/run_exec.py
+++ b/subtests/docker_cli/run_exec/run_exec.py
@@ -172,7 +172,5 @@ class exec_pid_count(exec_base):
         OutputGood(dkrcmd_exec.cmdresult)
         pids = dkrcmd_exec.stdout.strip().splitlines()
         expected = self.config["pid_count"]
-        self.failif(len(pids) != expected,
-                    "Expecting %d pids: %s"
-                    % (expected, pids))
+        self.failif_ne(len(pids), expected, "Number of pids: %s" % pids)
         super(exec_pid_count, self).postprocess()

--- a/subtests/docker_cli/run_user/run_user.py
+++ b/subtests/docker_cli/run_user/run_user.py
@@ -37,9 +37,9 @@ class run_user(subtest.SubSubtestCaller):
         subargs.append("cat /etc/passwd")
         cmd = DockerCmd(self, 'run', subargs, verbose=False)
         result = cmd.execute()
-        self.failif(result.exit_status != 0,
-                    "Failed to get container's /etc/passwd. Exit status is !0"
-                    "\n%s" % result)
+        self.failif_ne(result.exit_status, 0,
+                       "Failed to get container's /etc/passwd."
+                       " Exit status is !0\n%s" % result)
         OutputGood(result)
         return result.stdout
 
@@ -134,9 +134,9 @@ class run_user_base(subtest.SubSubtest):
         """
         result = self.sub_stuff['result']
         OutputGood(result)
-        self.failif(result.exit_status != 0,
-                    "Container's exit status is !0 although it should pass"
-                    ":\n%s" % result)
+        self.failif_ne(result.exit_status, 0,
+                       "Container's exit status is !0 although it should pass"
+                       ":\n%s" % result)
         output = (str(result.stdout) + str(result.stderr))
         self.failif(self.sub_stuff['uid_check'] not in output, "UID "
                     "check line '%s' not present in the container output:\n%s"

--- a/subtests/docker_cli/run_volumes/run_volumes.py
+++ b/subtests/docker_cli/run_volumes/run_volumes.py
@@ -233,18 +233,16 @@ class volumes_rw(volumes_base):
         results_data = zip(self.sub_stuff['cmdresults'],
                            self.sub_stuff['path_info'])
         for cmdresult, test_dict in results_data:
-            self.failif(cmdresult.exit_status != 0,
-                        "Non-zero exit status: %s" % cmdresult)
+            self.failif_ne(cmdresult.exit_status, 0,
+                           "Non-zero exit status: %s" % cmdresult)
             wh = test_dict['write_hash']
             rh = test_dict['read_hash']
             hp = test_dict['host_path']
             cp = test_dict['cntr_path']
             msg = ("Test hash mismatch for volume %s:%s; "
-                   "Expecting data %s, read data %s; "
                    "Command result %s"
-                   # wh/rh order is backwards for readability
-                   % (hp, cp, rh, wh, cmdresult))
-            self.failif(wh != rh, msg)
+                   % (hp, cp, cmdresult))
+            self.failif_ne(wh, rh, msg)
 
     def cleanup(self):
         self.cleanup_test_dict(self, self.sub_stuff['path_info'])

--- a/subtests/docker_cli/run_volumes/volumes_one_source.py
+++ b/subtests/docker_cli/run_volumes/volumes_one_source.py
@@ -52,8 +52,7 @@ class volumes_one_source(volumes_base):
         super(volumes_one_source, self).postprocess()
         # assert exit statuses
         for result in self.sub_stuff['cmdresults']:
-            self.failif(result.exit_status != 0,
-                        "Failed: %s" % (result))
+            self.failif_ne(result.exit_status, 0, "Failed: %s" % (result))
         # assert md5sums
         cntr_md5s = [x.stdout.split()[0] for x in self.sub_stuff['cmdresults']]
         cntr_results = zip(self.sub_stuff['names'], cntr_md5s)
@@ -66,8 +65,8 @@ class volumes_one_source(volumes_base):
                 # print file_path
                 # print data
             md5 = hashlib.md5(data).hexdigest()
-            self.failif(result != md5,
-                        "MD5 mismatch for container: %s" % (name))
+            self.failif_ne(result, md5,
+                           "MD5 mismatch for container: %s" % (name))
 
     def cleanup(self):
         super(volumes_one_source, self).cleanup()

--- a/subtests/docker_cli/run_volumes_selinux/run_volumes_selinux.py
+++ b/subtests/docker_cli/run_volumes_selinux/run_volumes_selinux.py
@@ -106,8 +106,8 @@ class selinux_base(subtest.SubSubtest):
                 self.logdebug("File %s Context: %s",
                               os.path.join(pwd, filename),
                               act)
-                self.failif(act != context, "Context of file %s is not %s (%s)"
-                            % ("%s/%s" % (pwd, filename), context, act))
+                self.failif_ne(act, context, "Context of file %s/%s"
+                               % (pwd, filename))
 
     def init_volume(self, context):
         """
@@ -160,9 +160,7 @@ class selinux_base(subtest.SubSubtest):
                         % cont.stdout)
         context_post = get_selinux_context(volume)
         if context_eq:
-            self.failif(context_pre != context_post,
-                        "Selinux context is not"
-                        "%s (%s)" % (context_pre, context_post))
+            self.failif_ne(context_post, context_pre, "Selinux context")
         else:
             self.failif(context_pre == context_post,
                         "Selinux context had not "

--- a/subtests/docker_cli/save_load/save_load.py
+++ b/subtests/docker_cli/save_load/save_load.py
@@ -152,17 +152,17 @@ class simple(save_load_base):
         str_load = self.sub_stuff['cmdresult_load']
         str_del = self.sub_stuff['cmdresult_del']
 
-        self.failif(str_save.exit_status != 0,
-                    "Problem with save cmd detail :%s" %
-                    str_save)
+        self.failif_ne(str_save.exit_status, 0,
+                       "Problem with save cmd detail :%s" %
+                       str_save)
 
-        self.failif(str_load.exit_status != 0,
-                    "Problem with load cmd detail :%s" %
-                    str_load)
+        self.failif_ne(str_load.exit_status, 0,
+                       "Problem with load cmd detail :%s" %
+                       str_load)
 
-        self.failif(str_del.exit_status != 0,
-                    "Problem with del cmd detail :%s" %
-                    str_del)
+        self.failif_ne(str_del.exit_status, 0,
+                       "Problem with del cmd detail :%s" %
+                       str_del)
 
         img_name = self.sub_stuff["rand_name"]
         images = self.sub_stuff["img"].list_imgs_with_full_name(img_name)

--- a/subtests/docker_cli/start/long_term_app.py
+++ b/subtests/docker_cli/start/long_term_app.py
@@ -35,9 +35,9 @@ class long_term_app(short_term_app):
         super(long_term_app, self).postprocess()
         # Raise exception if problems found
         cmdresult = self.sub_stuff['dkrcmd'].cmdresult
-        self.failif(cmdresult.exit_status != 0,
-                    "Non-zero start exit status: %s"
-                    % cmdresult)
+        self.failif_ne(cmdresult.exit_status, 0,
+                       "Non-zero start exit status: %s"
+                       % cmdresult)
 
         dc = DockerContainersRunOnly(self)
         running_c = dc.list_containers_with_cid(

--- a/subtests/docker_cli/start/start.py
+++ b/subtests/docker_cli/start/start.py
@@ -96,9 +96,9 @@ class start_base(SubSubtest):
         super(start_base, self).postprocess()
         self.outputgood()
         cmdresult = self.sub_stuff['dkrcmd'].cmdresult
-        self.failif(cmdresult.exit_status != 0,
-                    "Non-zero start exit status: %s"
-                    % cmdresult)
+        self.failif_ne(cmdresult.exit_status, 0,
+                       "Non-zero start exit status: %s"
+                       % cmdresult)
 
     def cleanup(self):
         super(start_base, self).cleanup()

--- a/subtests/docker_cli/stop/stop.py
+++ b/subtests/docker_cli/stop/stop.py
@@ -117,12 +117,12 @@ class stop_base(SubSubtest):
         # Look for docker failures
         OutputGood(stop_results)
         OutputGood(self.sub_stuff['container_results'])
-        self.failif(stop_results.exit_status != 0, "Exit status of the docker "
-                    "stop command was not 0: %s" % stop_results)
+        self.failif_ne(stop_results.exit_status, 0, "Exit status of the "
+                       "docker stop command was not 0: %s" % stop_results)
         exp = self.config.get('docker_exit_code', 0)
-        self.failif(self.sub_stuff['container_results'].exit_status != exp,
-                    "Exit status of the docker run command was not %s: %s"
-                    % (exp, self.sub_stuff['container_results']))
+        self.failif_ne(self.sub_stuff['container_results'].exit_status, exp,
+                       "Exit status of the docker run command was not %s: %s"
+                       % (exp, self.sub_stuff['container_results']))
 
     def cleanup(self):
         super(stop_base, self).cleanup()

--- a/subtests/docker_cli/tag/tag.py
+++ b/subtests/docker_cli/tag/tag.py
@@ -102,9 +102,9 @@ class tag_base(SubSubtest):
         OutputGood(self.sub_stuff['cmdresult'], ignore_error=not expect_pass)
         if expect_pass:
             # Raise exception if problems found
-            self.failif(self.sub_stuff['cmdresult'].exit_status != 0,
-                        "Non-zero tag exit status: %s"
-                        % self.sub_stuff['cmdresult'])
+            self.failif_ne(self.sub_stuff['cmdresult'].exit_status, 0,
+                           "Non-zero tag exit status: %s"
+                           % self.sub_stuff['cmdresult'])
 
             img = self.get_images_by_name(self.sub_stuff["new_image_name"])
             # Needed for cleanup

--- a/subtests/docker_cli/top/runsleep.py
+++ b/subtests/docker_cli/top/runsleep.py
@@ -33,8 +33,8 @@ class runsleep(base):
         OutputGood(self.sub_stuff['run_dkrcmd'].cmdresult)
         OutputGood(self.sub_stuff['top_dkrcmd'].cmdresult)
         pstable = TextTable(self.sub_stuff['top_dkrcmd'].stdout)
-        self.failif(len(pstable) != 1)
+        self.failif_ne(len(pstable), 1)
         psrow = pstable[0]
-        self.failif(psrow['USER'] != 'root')
+        self.failif_ne(psrow['USER'], 'root')
         self.failif(int(psrow['PID']) == 1)
-        self.failif(psrow['COMMAND'] != self.COMMAND)
+        self.failif_ne(psrow['COMMAND'], self.COMMAND)

--- a/subtests/docker_cli/wait/wait.py
+++ b/subtests/docker_cli/wait/wait.py
@@ -157,8 +157,7 @@ class WaitBase(SubSubtest):
             return
         dkrcmd_exit = self.sub_stuff['dkrcmd'].exit_status
         expect_exit = int(_exit)
-        self.failif(dkrcmd_exit != expect_exit,
-                    "Wait exit %d != %d" % (dkrcmd_exit, expect_exit))
+        self.failif_ne(dkrcmd_exit, expect_exit, "Wait exit")
 
     def pproc_stdio(self, which):
         stdio = self.config[which]

--- a/subtests/docker_cli/workdir/workdir.py
+++ b/subtests/docker_cli/workdir/workdir.py
@@ -74,8 +74,8 @@ class workdir(subtest.Subtest):
         for name, _dir in self.stuff['good_dirs'].items():
             _command = self.stuff['cmdresults'][name].command
             self.logdebug("Commands: %s" % _command)
-            self.failif(self.stuff['cmdresults'][name].stdout.strip() != _dir,
-                        "fail to set workdir %s" % _dir)
+            self.failif_ne(self.stuff['cmdresults'][name].stdout.strip(), _dir,
+                           "failed to set workdir")
             self.logdebug("workdir %s set successful for container" % _dir)
         for name, _dir in self.stuff['bad_dirs'].items():
             _command = self.stuff['cmdresults'][name].command


### PR DESCRIPTION
failif(actual != expected) doesn't provide helpful diagnostics
on failure: the human reader might be able to figure out the
expected value by reading the code, but can't know actual.

This commit provides a new failif_ne(actual, expected) which,
on failure, displays both.

Signed-off-by: Ed Santiago <santiago@redhat.com>