### PR TITLE
Re-locate -D to it's more useful place

### DIFF
--- a/config_defaults/defaults.ini
+++ b/config_defaults/defaults.ini
@@ -17,10 +17,10 @@ autotest_version = @!NOVERSIONCHECK!@
 docker_path = /usr/bin/docker
 
 #: Global docker client command options to use (CSV)
-docker_options = -D
+docker_options =
 
 #: Global docker daemon options to use (CSV)
-daemon_options = -d,--selinux-enabled,--add-registry,registry.access.redhat.com
+daemon_options = daemon,-D,--selinux-enabled
 
 #: Max runtime in seconds for any docker command (auto-converts to float)
 docker_timeout = 300.0


### PR DESCRIPTION
Though in CI, generally daemon_options is overridden, having it here by
default is more useful than having it on the client.  The later is
infrequently useful and at worse problematic for output parsers.  Easier
to just drop it.

Signed-off-by: Chris Evich <cevich@redhat.com>