### PR TITLE
Refactor: new subtest.require_docker_version()

### DIFF
--- a/dockertest/output.py
+++ b/dockertest/output.py
@@ -34,7 +34,14 @@ class DockerVersion(object):
     _client_info = None
     _server_info = None
 
-    def __init__(self, version_string):
+    def __init__(self, version_string=None, docker_path=None):
+        # If called without an explicit version string, run docker to find out
+        if version_string is None:
+            if docker_path is None:
+                docker_path = 'docker'
+            version_string = subprocess.check_output(docker_path + ' version',
+                                                     shell=True,
+                                                     close_fds=True)
         self.version_string = version_string
 
     def _oops(self, what):
@@ -220,15 +227,6 @@ class DockerVersion(object):
         :raises DockerTestNAError: installed docker < wanted
         """
         return self._require(wanted, 'client', self.client)
-
-    @classmethod
-    def helper(cls, docker_path=''):
-        """
-        Shortcut around DockerCmd for output, w/ less verification/validation
-        """
-        return cls(subprocess.check_output('%sdocker version' % docker_path,
-                                           shell=True,  # $PATH from profile
-                                           close_fds=True))  # more safe
 
 
 class ColumnRanges(Mapping):

--- a/dockertest/subtest.py
+++ b/dockertest/subtest.py
@@ -24,6 +24,11 @@ from autotest.client import test
 import version
 import config
 import subtestbase
+# There is a bug in Pylint + virtualenv that makes this fail in Travis CI
+# https://github.com/PyCQA/pylint/issues/73
+from distutils.version import LooseVersion  # pylint: disable=E0611,F0401
+from dockercmd import DockerCmd
+from output import DockerVersion
 from xceptions import DockerTestFail
 from xceptions import DockerTestNAError
 from xceptions import DockerTestError
@@ -290,6 +295,22 @@ class SubSubtest(subtestbase.SubBase):
         logging.warning("SubSubtest.make_subsubtest_config() is deprecated!")
         self.config = self.make_config(all_configs, parent_config,
                                        self.config_section)
+
+    def require_docker_version(self, wanted):
+        """
+        Run 'docker version', parse client version, compare to wanted.
+
+        :param wanted: required docker version
+        :raises DockerTestNAError: installed docker < wanted
+        """
+        stdout = DockerCmd(self, "version").execute().stdout
+        dockerversion = DockerVersion(stdout)
+        client_version = LooseVersion(dockerversion.client)
+        required_version = LooseVersion(wanted)
+        if client_version < required_version:
+            raise DockerTestNAError("Test requires docker version >= %s;"
+                                    " %s installed" % (required_version,
+                                                       client_version))
 
 
 class SubSubtestCaller(Subtest):

--- a/subtests/docker_cli/create/create_signal.py
+++ b/subtests/docker_cli/create/create_signal.py
@@ -3,15 +3,9 @@ Test sending signal to created but not started container exits non-zero.
 """
 
 import signal
-# There is a bug in Pylint + virtualenv that makes this fail in Travis CI
-# https://github.com/PyCQA/pylint/issues/73
-from distutils.version import LooseVersion  # pylint: disable=E0611
 from dockertest.dockercmd import DockerCmd
 from dockertest.output import mustfail
-from dockertest.output import mustpass
 from dockertest.output import OutputNotBad
-from dockertest.output import DockerVersion
-from dockertest.xceptions import DockerTestNAError
 from create import create_base
 
 
@@ -20,22 +14,9 @@ class create_signal(create_base):
     #: The exit behavior changed in docker version and later
     non_zero_exit_version = "1.8.2"
 
-    def is_newer_docker(self):
-        ver_stdout = mustpass(DockerCmd(self, "version").execute()).stdout
-        dv = DockerVersion(ver_stdout)
-        client_version = LooseVersion(dv.client)
-        dep_version = LooseVersion(self.non_zero_exit_version)
-        if client_version < dep_version:
-            return False
-        else:
-            return True
-
     def initialize(self):
         super(create_signal, self).initialize()
-        if not self.is_newer_docker():
-            raise DockerTestNAError("Test does not support "
-                                    "docker version < %s",
-                                    self.non_zero_exit_version)
+        self.require_docker_version(self.non_zero_exit_version)
         self.sub_stuff['sigdkrcmd'] = None
 
     def run_once(self):

--- a/subtests/docker_cli/create/create_signal.py
+++ b/subtests/docker_cli/create/create_signal.py
@@ -17,7 +17,7 @@ class create_signal(create_base):
 
     def initialize(self):
         super(create_signal, self).initialize()
-        DockerVersion.helper().require_client(self.non_zero_exit_version)
+        DockerVersion().require_client(self.non_zero_exit_version)
         self.sub_stuff['sigdkrcmd'] = None
 
     def run_once(self):

--- a/subtests/docker_cli/rmi/rmi.py
+++ b/subtests/docker_cli/rmi/rmi.py
@@ -13,9 +13,6 @@ Operational Summary
 """
 
 import time
-# There is a bug in Pylint + virtualenv that makes this fail in Travis CI
-# https://github.com/PyCQA/pylint/issues/73
-from distutils.version import LooseVersion  # pylint: disable=E0611
 from autotest.client import utils
 from dockertest import subtest
 from dockertest import config
@@ -23,10 +20,8 @@ from dockertest import images
 from dockertest.subtest import SubSubtest
 from dockertest.images import DockerImages
 from dockertest.output import OutputGood
-from dockertest.output import DockerVersion
 from dockertest.dockercmd import AsyncDockerCmd
 from dockertest.dockercmd import DockerCmd
-from dockertest.output import mustpass
 from dockertest.xceptions import DockerTestNAError
 from dockertest.containers import DockerContainers
 
@@ -41,9 +36,6 @@ class rmi(subtest.SubSubtestCaller):
 
 
 class rmi_base(SubSubtest):
-
-    #: The --run option marked for deprecation in this version and later
-    commit_run_deprecated_version = "1.1.1"
 
     def initialize(self):
         super(rmi_base, self).initialize()
@@ -126,17 +118,6 @@ class rmi_base(SubSubtest):
         di = DockerImages(self)
         return di.list_imgs_with_full_name(full_name)
 
-    # FIXME: Clobber this method when 'commit_run_params' goes away (below)
-    def run_is_deprecated(self):
-        ver_stdout = mustpass(DockerCmd(self, "version").execute()).stdout
-        dv = DockerVersion(ver_stdout)
-        client_version = LooseVersion(dv.client)
-        dep_version = LooseVersion(self.commit_run_deprecated_version)
-        if client_version < dep_version:
-            return False
-        else:
-            return True
-
 
 class with_blocking_container_by_tag(rmi_base):
 
@@ -203,8 +184,6 @@ class with_blocking_container_by_tag(rmi_base):
     def complete_commit_command_line(self):
         c_author = self.config["commit_author"]
         c_msg = self.config["commit_message"]
-        # FIXME: Remove commit_run_params entirely in future version
-        run_params = self.config.get("commit_run_params")
         repo_addr = self.sub_stuff["image_name"]
 
         cmds = []
@@ -212,8 +191,6 @@ class with_blocking_container_by_tag(rmi_base):
             cmds.append("-a %s" % c_author)
         if c_msg:
             cmds.append("-m %s" % c_msg)
-        if run_params and not self.run_is_deprecated():
-            cmds.append("--run=%s" % run_params)
 
         cmds.append(self.sub_stuff["container"])
 


### PR DESCRIPTION
Raises DockerTestNAError if currently-installed docker
version is less than a specified requirement.

Also: removed obsolete version checks and code from rmi

Signed-off-by: Ed Santiago <santiago@redhat.com>