### PR TITLE
Workaround for bz1317096 : clean up stale images

### DIFF
--- a/subtests/docker_cli/rmi/rmi.py
+++ b/subtests/docker_cli/rmi/rmi.py
@@ -239,3 +239,8 @@ class with_blocking_container_by_id(with_blocking_container_by_tag):
     def check_image_exists_by_id(self, image_id):
         di = DockerImages(self)
         return di.list_imgs_with_image_id(image_id)
+
+    def cleanup(self):
+        super(with_blocking_container_by_id, self).cleanup()
+        di = DockerImages(self)
+        di.clean_all([self.sub_stuff["image_name"]])


### PR DESCRIPTION
The rmi test is leaving stale images behind, causing
garbage_check to fail on it and all subsequent tests.
This harmless cleanup code deletes images even if
their name has been clobbered by bz1317096.

Signed-off-by: Ed Santiago <santiago@redhat.com>