### PR TITLE
exit codes: fix docker-daemon corner case

### DIFF
--- a/dockertest/output.py
+++ b/dockertest/output.py
@@ -812,7 +812,8 @@ def mustfail(cmdresult, expected_status=None, failmsg=None):
         OutputNotBad(cmdresult)
     # FIXME: temporary; remove once we no longer run on pre-1.10 docker
     if not DockerVersion().has_distinct_exit_codes:
-        expected_status = 1
+        # Docker <1.10 exits 2 on daemon error (125 in 1.10), 1 on all else
+        expected_status = 1 + (expected_status == 125)
     if cmdresult.exit_status != expected_status:
         raise xceptions.DockerExecError("Unexpected exit code %d; expected %d."
                                         " Details: %s" % (

--- a/subtests/docker_cli/run_dns/run_dns.py
+++ b/subtests/docker_cli/run_dns/run_dns.py
@@ -118,7 +118,7 @@ class run_dns(subtest.Subtest):
         for bad_dns in ("bad.dns", "256.0.0.1", "1.1.1.256", "19216801",
                         "4.2.2.1.1"):
             self._execute_bad([bad_dns], None)
-        for bad_search in ("bad search", "-example", "exam..ple", 'X' * 300):
+        for bad_search in ("bad/search", "-example", "exam..ple", 'X' * 300):
             self._execute_bad(None, [bad_search])
 
     def generate_ipaddr(self, mask=None):


### PR DESCRIPTION
docker <1.10 does *not* exit 1 on all errors: on daemon errors,
it exits 2. Recognize that in mustfail() by converting 125
(new 1.10 exit code for daemon errors) to 2.

Also: fix one test case. "bad search" was used as an argument
to the --dns-search option. This would work if we ran docker
via exec, or quoting args, but when run via shell it becomes:

    docker ... --dns-search bad search --privileged ...

...which unsurprisingly results in the following error:

   Unable to find image 'search:latest' locally
   Trying to pull repository [...]/search ... not found

...which of course has exit code 1, not 2. (TL;DR this test case
was not actually testing what it intended to).

Signed-off-by: Ed Santiago <santiago@redhat.com>