### PR TITLE
Yet more exit code cleanup

### DIFF
--- a/subtests/docker_cli/kill_bad/kill_bad.py
+++ b/subtests/docker_cli/kill_bad/kill_bad.py
@@ -71,14 +71,14 @@ class kill_bad_base(subtest.SubSubtest):
             mustfail(DockerCmd(self, 'kill',
                                ['-s', signal,
                                 self.sub_stuff['container_name']],
-                               verbose=False).execute(), 125)
+                               verbose=False).execute(), 1)
             self.failif(self.sub_stuff['container_cmd'].done, "Testing "
                         "container died after using signal %s." % signal)
         dkrcnt = DockerContainers(self)
         nonexisting_name = dkrcnt.get_unique_name()
         self.logdebug("Killing nonexisting containe.")
         mustfail(DockerCmd(self, 'kill', [nonexisting_name],
-                           verbose=False).execute(), 125)
+                           verbose=False).execute(), 1)
 
     def postprocess(self):
         """

--- a/subtests/docker_cli/start/simple.py
+++ b/subtests/docker_cli/start/simple.py
@@ -63,7 +63,7 @@ class simple(subtest.SubSubtest):
                    "in the output:\n%s")
         # Nonexisting container
         missing_msg = self.config['missing_msg']
-        result = mustfail(DockerCmd(self, "start", [name]).execute(), 125)
+        result = mustfail(DockerCmd(self, "start", [name]).execute(), 1)
         self.failif(missing_msg not in str(result), err_msg
                     % ("non-existing", missing_msg, result))
 


### PR DESCRIPTION
Two instances -- kill and start -- which really seem like docker
daemon exit codes (i.e. docker <1.10 should exit 2) are exiting 1.
Don't understand it and am giving up on trying. We'll have to sort
this out when docker-1.10 comes out.

Signed-off-by: Ed Santiago <santiago@redhat.com>