### PR TITLE
docker run --cgroup-parent: error message change

### DIFF
--- a/config_defaults/subtests/docker_cli/run_cgroup_parent.ini
+++ b/config_defaults/subtests/docker_cli/run_cgroup_parent.ini
@@ -1,2 +1,6 @@
 [docker_cli/run_cgroup_parent]
 subsubtests = run_cgroup_parent_invalid_name,run_cgroup_parent_path,run_cgroup_parent_path_with_hyphens
+
+[docker_cli/run_cgroup_parent/run_cgroup_parent_invalid_name]
+#: Regex describing the error message we expect. Passed to re.match().
+expect_stderr = (docker: )?Error response from daemon: cgroup-parent for systemd cgroup should be a valid slice named as "xxx.slice"\.

--- a/subtests/docker_cli/run_cgroup_parent/run_cgroup_parent.py
+++ b/subtests/docker_cli/run_cgroup_parent/run_cgroup_parent.py
@@ -161,9 +161,10 @@ class run_cgroup_parent_invalid_name(run_cgroup_parent_base):
     def initialize(self):
         super(run_cgroup_parent_invalid_name, self).initialize()
         self._setup("/{rand1}")
-        self._expect(stderr="Error response from daemon:"
-                     " Cannot start container {cid}: [8] System error:"
-                     " Invalid slice name /{rand1}")
+        self._expect(stderr="docker: Error response from daemon:"
+                     " cgroup-parent for systemd cgroup should be a"
+                     " valid slice named as \"xxx.slice\".\n"
+                     "See '/usr/bin/docker run --help'.")
 
 
 class run_cgroup_parent_path(run_cgroup_parent_base):


### PR DESCRIPTION
The error message for --cgroup-parent=/xxxxx (invalid name)
changed between docker-1.9 and 1.10

Signed-off-by: Ed Santiago <santiago@redhat.com>