### PR TITLE
import_url: inconsistent exit codes in docker-1.10

### DIFF
--- a/subtests/docker_cli/import_url/import_url.py
+++ b/subtests/docker_cli/import_url/import_url.py
@@ -26,7 +26,6 @@ from dockertest.containers import DockerContainers
 from dockertest.images import DockerImages
 from dockertest.dockercmd import DockerCmd
 from dockertest.output import mustpass
-from dockertest.output import mustfail
 
 
 class import_url(SubSubtestCaller):
@@ -48,7 +47,10 @@ class base(SubSubtest):
         subargs += [self.sub_stuff['import_repo']]
         subargs += ['some', 'dummy', 'command']
         self.logdebug("Next docker command should fail...")
-        mustfail(DockerCmd(self, 'run', subargs).execute(), 125)
+        cmdresult = DockerCmd(self, 'run', subargs).execute()
+        if cmdresult.exit_status not in [125, 127]:
+            self.failif(True, "Unexpected exit code %d; expected 125 or 127."
+                        % cmdresult.exit_status)
 
     def initialize(self):
         super(base, self).initialize()


### PR DESCRIPTION
The import_url test runs a docker command that's expected to fail:

    docker run Not-A-Valid_Image some dummy command

docker-1.9 consistently fails with "some" not in $PATH

docker-1.10 fails in three (AFAICT) different ways:

    exec: "some": executable file not found in $PATH

Then one of these three errors:

    docker: Error response from daemon: Cannot start container <cid>: [9] System error: invalid character 'e' looking for beginning of value.
    docker: Error response from daemon: Cannot start container <cid>: [9] System error: json: cannot unmarshal string into Go value of type libcontainer.generic Error.
    docker: Error response from daemon: Container command not found or does not exist..

...and an exit code of 125 (first two) or 127 (last). This makes it
impossible to test with mustfail().

Workaround: do our own test. Allow exit code 125 or 127.

Signed-off-by: Ed Santiago <santiago@redhat.com>