### PR TITLE
Remove dependency on python-nose

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -95,7 +95,7 @@ Prerequisites
     *  Optional (for building documentation), ``make``, ``python-sphinx``,
        and ``docutils`` or equivalent for your platform.
     *  Optional (for running unittests), ``pylint``, ``pep8``,
-       ``python-unittest2``, ``python2-mock`` and ``python-nose``.
+       ``python-unittest2``, and ``python2-mock``.
     *  (Optional) ``python-bugzilla`` for test exclusion based
        upon bug status.  See section `bugzilla_integration`_
 

--- a/run_unittests.sh
+++ b/run_unittests.sh
@@ -19,7 +19,7 @@ done
 
 if [ -n "$AUTOTEST_PATH" ]
 then
-    export PYTHONPATH=$(dirname $AUTOTEST_PATH)
+    export PYTHONPATH=$(dirname $AUTOTEST_PATH):$(dirname $0)
 else
     python -c 'import autotest'
     if [ "$?" -ne "0" ]
@@ -28,14 +28,15 @@ else
              "AUTOTEST_PATH env. var. is not set"
         exit 1
     fi
+    export PYTHONPATH=$(dirname $0)
 fi
 
-# Unit tests for subtests.
-# FIXME: find a way to have nosetests recurse, or move the tests into
-#        a directory structure that nose can handle.
+# Unit tests for subtests. Due to autotest layout, the subtest directories
+# aren't importable or discoverable by python itself. We have to do our
+# own discovery.
 for unittest in $(find subtests -name 'test_*.py'); do
     echo $unittest
-    nosetests -v $unittest || exit 1
+    python $unittest -v || exit 1
 done
 
 echo ""

--- a/subtests/docker_cli/dockerinspect/test_inspect_keys.py
+++ b/subtests/docker_cli/dockerinspect/test_inspect_keys.py
@@ -268,3 +268,6 @@ class TestFilterKeys(TestCase):
             raised = True
         if not raised:
             self.fail("Known-bad test did not raise exception.")
+
+if __name__ == '__main__':
+    main()

--- a/subtests/docker_cli/events/test_event_parsing.py
+++ b/subtests/docker_cli/events/test_event_parsing.py
@@ -146,3 +146,6 @@ class TestEventParsing(TestCase):
         actual = events.parse_events(event_log)
         self.maxDiff = None
         self.assertEqual(actual, expect)
+
+if __name__ == '__main__':
+    main()

--- a/subtests/docker_cli/info/test_info.py
+++ b/subtests/docker_cli/info/test_info.py
@@ -5,16 +5,7 @@
 # As of 2016-02-12 this only includes verify_pool_name(); we'll try to
 # extend coverage as needed.
 #
-# RUNNING:
-#
-#   $ nosetests -v subtests/docker_cli/info
-#
-# This assumes that your autotest-docker is checked out underneath
-# the client/tests subdirectory of a checked-out autotest repo,
-# *and* that the autotest repo is called "autotest" (e.g. not "my-autotest").
-# Also: you can't just run nosetests and hope it'll recurse. It won't.
-#
-# Yeah. Sorry. There's indubitably a better way. Please fix if you know how.
+# RUNNING: see run_unittests.sh in the top level of docker-autotest
 #
 from unittest2 import TestCase, main        # pylint: disable=unused-import
 from mock import Mock, patch
@@ -91,3 +82,6 @@ class TestVerifyPoolName(TestCase):
                            " (from docker info) not found in dmsetup ls"
                            " list '['rhel-docker--pool_tdata',"
                            " 'rhel-docker--pool_tmeta']'")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Looks like it's being abandoned. Oh well; it was nice
while it lasted.

Signed-off-by: Ed Santiago <santiago@redhat.com>