### PR TITLE
run_pylint: predictable execution order

### DIFF
--- a/run_pylint.sh
+++ b/run_pylint.sh
@@ -112,7 +112,7 @@ check_dockertest() {
 
 check_dockertests() {
     echo -e "\n\n======================================= dockertest"
-    find dockertest -name '*.py' -a -not -name '*_unittest*.py' | \
+    find dockertest -name '*.py' -a -not -name '*_unittest*.py' | sort | \
     while read LINE; do
         trap "break" INT
         check_dockertest "${LINE}"
@@ -148,7 +148,7 @@ check_subtests() {
     do
         trap "break" INT
         echo -e "\n\n======================================= ${thing}"
-        find ${thing} -name '*.py' | while read LINE; do
+        find ${thing} -name '*.py' | sort | while read LINE; do
             trap "break" INT
             check_subtest "${LINE}"
         done || exit 1


### PR DESCRIPTION
Apropos of nothing, sort file list before running tests. It
just helps greatly with readability and especially when
looking for results on a recently-touched file.

Signed-off-by: Ed Santiago <santiago@redhat.com>