### PR TITLE
DockerCmd : always run with verbose

### DIFF
--- a/subtests/docker_cli/attach/attach.py
+++ b/subtests/docker_cli/attach/attach.py
@@ -45,8 +45,7 @@ class attach_base(SubSubtest):
 
     def pull_image(self, image_name):
         dkrcmd = AsyncDockerCmd(self, 'pull', [image_name],
-                                self.config['docker_timeout'],
-                                verbose=True)
+                                self.config['docker_timeout'])
         self.loginfo("Executing background command: %s" % dkrcmd)
         dkrcmd.execute()
         while not dkrcmd.done:
@@ -91,8 +90,7 @@ class simple_base(attach_base):
         self.sub_stuff['file_desc'].append(run_in_pipe_r)
         self.sub_stuff['file_desc'].append(run_in_pipe_w)
         self.sub_stuff["run_in_pipe_w"] = run_in_pipe_w
-        dkrcmd = AsyncDockerCmd(self, 'run', self.sub_stuff['subargs'],
-                                verbose=True)
+        dkrcmd = AsyncDockerCmd(self, 'run', self.sub_stuff['subargs'])
 
         # Runs in background
         self.sub_stuff['cmdresult'] = dkrcmd.execute(run_in_pipe_r)
@@ -121,8 +119,7 @@ class simple_base(attach_base):
 
         self.sub_stuff['subargs_a'].append(self.sub_stuff["rand_name"])
 
-        dkrcmd = AsyncDockerCmd(self, 'attach', self.sub_stuff['subargs_a'],
-                                verbose=True)
+        dkrcmd = AsyncDockerCmd(self, 'attach', self.sub_stuff['subargs_a'])
         # Runs in background
         self.sub_stuff['cmd_attach'] = dkrcmd
         self.sub_stuff['cmdresult_attach'] = dkrcmd.execute(attach_in_pipe_r)
@@ -198,8 +195,7 @@ class sig_proxy_off_base(attach_base):
         self.sub_stuff['file_desc'].append(run_in_pipe_r)
         self.sub_stuff['file_desc'].append(run_in_pipe_w)
         self.sub_stuff["run_in_pipe_w"] = run_in_pipe_w
-        dkrcmd = AsyncDockerCmd(self, 'run', self.sub_stuff['subargs'],
-                                verbose=True)
+        dkrcmd = AsyncDockerCmd(self, 'run', self.sub_stuff['subargs'])
 
         # Runs in background
         self.sub_stuff['cmdresult'] = dkrcmd.execute(run_in_pipe_r)
@@ -224,8 +220,7 @@ class sig_proxy_off_base(attach_base):
 
         self.sub_stuff['subargs_a'].append(self.sub_stuff["rand_name"])
 
-        dkrcmd = AsyncDockerCmd(self, 'attach', self.sub_stuff['subargs_a'],
-                                verbose=True)
+        dkrcmd = AsyncDockerCmd(self, 'attach', self.sub_stuff['subargs_a'])
         # Runs in background
         self.sub_stuff['cmd_attach'] = dkrcmd
         self.sub_stuff['cmdresult_attach'] = dkrcmd.execute()

--- a/subtests/docker_cli/build/build.py
+++ b/subtests/docker_cli/build/build.py
@@ -79,9 +79,8 @@ class build(subtest.SubSubtestCaller):
             for cid in self.stuff['dc'].list_container_ids():
                 if cid in self.stuff['existing_containers']:
                     continue    # don't remove previously existing ones
-                self.logdebug("Remoivng container %s", cid)
-                dcmd = DockerCmd(self, 'rm', ['--force', '--volumes', cid],
-                                 verbose=False)
+                self.logdebug("Removing container %s", cid)
+                dcmd = DockerCmd(self, 'rm', ['--force', '--volumes', cid])
                 dcmd.execute()
             dimg = self.stuff['di']
             base_repo_fqin = DockerImage.full_name_from_defaults(self.config)
@@ -96,9 +95,8 @@ class build(subtest.SubSubtestCaller):
                     # never ever remove base_repo_fqin under any circumstance
                     if thing == base_repo_fqin:
                         continue
-                self.logdebug("Remoivng image %s", img)
-                dcmd = DockerCmd(self, 'rmi', ['--force', thing],
-                                 verbose=False)
+                self.logdebug("Removing image %s", img)
+                dcmd = DockerCmd(self, 'rmi', ['--force', thing])
                 dcmd.execute()
 
 
@@ -368,7 +366,7 @@ class postprocessing(object):
         else:
             cmd = 'ls -la "%s"' % path
         subargs = ['--rm', '--attach', 'stdout', build_def.image_name, cmd]
-        dkrcmd = DockerCmd(self, 'run', subargs, verbose=False)
+        dkrcmd = DockerCmd(self, 'run', subargs)
         dkrcmd.quiet = True
         dkrcmd.execute()
         exists = dkrcmd.exit_status == 0
@@ -470,7 +468,7 @@ class build_base(postprocessing, subtest.SubSubtest):
             os.chdir(dockerfile_dir_path)
         subargs = docker_build_options + ["-t", image_name,
                                           dockerfile_dir_path]
-        dockercmd = DockerCmd(self, 'build', subargs, verbose=True)
+        dockercmd = DockerCmd(self, 'build', subargs)
         # Pass as keywords allows ignoring parameter order
         return [self.BuildDef(image_name=image_name,
                               dockercmd=dockercmd,
@@ -510,9 +508,8 @@ class build_base(postprocessing, subtest.SubSubtest):
             for cid in self.sub_stuff['dc'].list_container_ids():
                 if cid in self.sub_stuff['existing_containers']:
                     continue    # don't remove previously existing ones
-                self.logdebug("Remoivng container %s", cid)
-                dcmd = DockerCmd(self, 'rm', ['--force', '--volumes', cid],
-                                 verbose=False)
+                self.logdebug("Removing container %s", cid)
+                dcmd = DockerCmd(self, 'rm', ['--force', '--volumes', cid])
                 dcmd.execute()
             dimg = self.sub_stuff['di']
             base_repo_fqin = DockerImage.full_name_from_defaults(self.config)
@@ -527,9 +524,8 @@ class build_base(postprocessing, subtest.SubSubtest):
                     # never ever remove base_repo_fqin under any circumstance
                     if thing == base_repo_fqin:
                         continue
-                self.logdebug("Remoivng image %s", img)
-                dcmd = DockerCmd(self, 'rmi', ['--force', thing],
-                                 verbose=False)
+                self.logdebug("Removing image %s", img)
+                dcmd = DockerCmd(self, 'rmi', ['--force', thing])
                 dcmd.execute()
 
 

--- a/subtests/docker_cli/cp/cp.py
+++ b/subtests/docker_cli/cp/cp.py
@@ -149,8 +149,7 @@ class every_last(CpBase):
                    "--attach=stdout",
                    fqin,
                    "python -c '%s'" % code]
-        # Data transfered over stdout, don't log it!
-        nfdc = DockerCmd(self, "run", subargs, verbose=False)
+        nfdc = DockerCmd(self, "run", subargs)
         nfdc.quiet = True
         self.logdebug("Executing %s", nfdc.command)
         mustpass(nfdc.execute())
@@ -175,8 +174,7 @@ class every_last(CpBase):
                     % (self.config['max_files'], total))
         self.loginfo("Testing copy of %d files from container" % total)
         self.sub_stuff['results'] = {}  # cont_path -> cmdresult
-        # Avoid excessive logging
-        nfdc = DockerCmd(self, 'cp', verbose=False)
+        nfdc = DockerCmd(self, 'cp')
         nfdc.quiet = True
         nfiles = 0
         for index, srcfile in enumerate(self.sub_stuff['lastfiles']):

--- a/subtests/docker_cli/create/create_remote_tag.py
+++ b/subtests/docker_cli/create/create_remote_tag.py
@@ -44,7 +44,7 @@ class create_remote_tag(create_base):
             self.loginfo("Removing images...")
             subargs = ['--force']
             subargs += [img.full_name for img in existing_images]
-            mustpass(DockerCmd(self, 'rmi', subargs, verbose=True).execute())
+            mustpass(DockerCmd(self, 'rmi', subargs).execute())
             # Wait for images to actually go away
             _fn = lambda: self.long_id_in_images(long_id)
             gone = utils.wait_for(_fn, 60, step=1,

--- a/subtests/docker_cli/images_all/images_all.py
+++ b/subtests/docker_cli/images_all/images_all.py
@@ -45,7 +45,7 @@ class images_all_base(SubSubtest):
         self.sub_stuff['containers'].append(name)
         subargs.append(fin)
         subargs.append(cmd)
-        mustpass(DockerCmd(self, 'run', subargs, verbose=False).execute())
+        mustpass(DockerCmd(self, 'run', subargs).execute())
         return name
 
     def _create_image(self, parent, prefix, cmd):
@@ -57,11 +57,10 @@ class images_all_base(SubSubtest):
         images = self.sub_stuff['di']
         cont_name = self._init_container("test", parent, [], cmd)
         img_name = images.get_unique_name(prefix)
-        dkrcmd = DockerCmd(self, "commit", [cont_name, img_name],
-                           verbose=False)
+        dkrcmd = DockerCmd(self, "commit", [cont_name, img_name])
         img_id = mustpass(dkrcmd.execute()).stdout.strip()
-        mustpass(DockerCmd(self, 'rm', ['--force', '--volumes', cont_name],
-                           verbose=False).execute())
+        mustpass(DockerCmd(self, 'rm',
+                           ['--force', '--volumes', cont_name]).execute())
         self.sub_stuff['images'].append(img_id)
         return [img_id, img_name]
 
@@ -135,8 +134,8 @@ class images_all_base(SubSubtest):
                             % (image[1], err_str()))
             if image[3] and image[4] is not None:
                 history = mustpass(DockerCmd(self, 'history',
-                                             ['--no-trunc', '-q', image[0]],
-                                             verbose=False).execute()).stdout
+                                             ['--no-trunc', '-q',
+                                              image[0]]).execute()).stdout
                 for parent in image[4]:
                     self.failif(parent not in history, "Parent image '%s' of "
                                 "image '%s' was not found in `docker history`:"
@@ -185,23 +184,23 @@ class two_images_with_parents(images_all_base):
         # Verify
         self.verify_images((test_a, test_a1, test_b, test_b1))
         # Untag test_a
-        mustpass(DockerCmd(self, 'rmi', [test_a[1]], verbose=False).execute())
+        mustpass(DockerCmd(self, 'rmi', [test_a[1]]).execute())
         test_a[3] = False   # exists, untagged
         # Verify
         self.verify_images((test_a, test_a1, test_b, test_b1))
         # Untag test_a.1
-        mustpass(DockerCmd(self, 'rmi', [test_a1[1]], verbose=False).execute())
+        mustpass(DockerCmd(self, 'rmi', [test_a1[1]]).execute())
         test_a1[2:4] = [False, False]   # doesn't exist, not tagged
         test_a[2:4] = [False, False]    # doesn't exist, not tagged
         # Verify
         self.verify_images((test_a, test_a1, test_b, test_b1))
         # Untag test_b.1
-        mustpass(DockerCmd(self, 'rmi', [test_b1[1]], verbose=False).execute())
+        mustpass(DockerCmd(self, 'rmi', [test_b1[1]]).execute())
         test_b1[2:4] = [False, False]  # doesn't exist, not tagged
         # Verify
         self.verify_images((test_a, test_a1, test_b, test_b1))
         # Remove the last image by id
-        mustpass(DockerCmd(self, 'rmi', [test_b[0]], verbose=False).execute())
+        mustpass(DockerCmd(self, 'rmi', [test_b[0]]).execute())
         test_b[2:4] = [False, False]    # doesn't exist, not tagged
         self.verify_images((test_a, test_a1, test_b, test_b1))
 

--- a/subtests/docker_cli/iptable/iptable.py
+++ b/subtests/docker_cli/iptable/iptable.py
@@ -107,7 +107,7 @@ class iptable_base(SubSubtest):
     def run_once(self):
         super(iptable_base, self).run_once()
         subargs = self.sub_stuff['subargs']
-        mustpass(DockerCmd(self, 'run -d', subargs, verbose=True).execute())
+        mustpass(DockerCmd(self, 'run -d', subargs).execute())
         self.sub_stuff['rules_during'] = self.read_iptable_rules(None)
 
     def postprocess(self):

--- a/subtests/docker_cli/kill/kill_utils.py
+++ b/subtests/docker_cli/kill/kill_utils.py
@@ -80,7 +80,7 @@ class kill_base(subtest.SubSubtest):
         subargs.append("bash")
         subargs.append("-c")
         subargs.append(self.config['exec_cmd'])
-        container = AsyncDockerCmd(self, 'run', subargs, verbose=False)
+        container = AsyncDockerCmd(self, 'run', subargs)
         self.sub_stuff['container_cmd'] = container
         container.execute()
 
@@ -103,7 +103,7 @@ class kill_base(subtest.SubSubtest):
         subargs.append("bash")
         subargs.append("-c")
         subargs.append(self.config['exec_cmd'])
-        container = DockerCmd(self, 'run', subargs, verbose=False)
+        container = DockerCmd(self, 'run', subargs)
         self.sub_stuff['container_cmd'] = container
         mustpass(container.execute())
 
@@ -113,7 +113,7 @@ class kill_base(subtest.SubSubtest):
         else:
             subargs = []
         subargs.append(name)
-        container = AsyncDockerCmd(self, 'attach', subargs, verbose=False)
+        container = AsyncDockerCmd(self, 'attach', subargs)
         self.sub_stuff['container_cmd'] = container  # overwrites finished cmd
         container.execute()
 
@@ -199,8 +199,7 @@ class kill_base(subtest.SubSubtest):
                     sig_long = False
                 else:
                     subargs = ["-s %s" % signal] + extra_subargs
-                kill_cmds.append(DockerCmd(self, 'kill', subargs,
-                                           verbose=False))
+                kill_cmds.append(DockerCmd(self, 'kill', subargs))
 
         # Kill -9 is the last one :-)
         signal = 9
@@ -208,8 +207,7 @@ class kill_base(subtest.SubSubtest):
         if self.config.get('kill_map_signals'):
             signal = SIGNAL_MAP.get(signal, signal)
         kill_cmds.append(DockerCmd(self, 'kill',
-                                   ["-s %s" % signal] + extra_subargs,
-                                   verbose=False))
+                                   ["-s %s" % signal] + extra_subargs))
 
         if sigproxy:
             self.logdebug("kill_command_example: Killing directly the "

--- a/subtests/docker_cli/kill_bad/kill_bad.py
+++ b/subtests/docker_cli/kill_bad/kill_bad.py
@@ -42,7 +42,7 @@ class kill_bad_base(subtest.SubSubtest):
         subargs.append("bash")
         subargs.append("-c")
         subargs.append(self.config['exec_cmd'])
-        container = AsyncDockerCmd(self, 'run', subargs, verbose=False)
+        container = AsyncDockerCmd(self, 'run', subargs)
         self.sub_stuff['container_cmd'] = container
         container.execute()
 
@@ -70,15 +70,14 @@ class kill_bad_base(subtest.SubSubtest):
         for signal in self.config['bad_signals'].split(','):
             mustfail(DockerCmd(self, 'kill',
                                ['-s', signal,
-                                self.sub_stuff['container_name']],
-                               verbose=False).execute(), 1)
+                                self.sub_stuff['container_name']]).execute(),
+                     1)
             self.failif(self.sub_stuff['container_cmd'].done, "Testing "
                         "container died after using signal %s." % signal)
         dkrcnt = DockerContainers(self)
         nonexisting_name = dkrcnt.get_unique_name()
         self.logdebug("Killing nonexisting containe.")
-        mustfail(DockerCmd(self, 'kill', [nonexisting_name],
-                           verbose=False).execute(), 1)
+        mustfail(DockerCmd(self, 'kill', [nonexisting_name]).execute(), 1)
 
     def postprocess(self):
         """

--- a/subtests/docker_cli/kill_stopped/kill_utils.py
+++ b/subtests/docker_cli/kill_stopped/kill_utils.py
@@ -80,7 +80,7 @@ class kill_base(subtest.SubSubtest):
         subargs.append("bash")
         subargs.append("-c")
         subargs.append(self.config['exec_cmd'])
-        container = AsyncDockerCmd(self, 'run', subargs, verbose=False)
+        container = AsyncDockerCmd(self, 'run', subargs)
         self.sub_stuff['container_cmd'] = container
         container.execute()
 
@@ -103,7 +103,7 @@ class kill_base(subtest.SubSubtest):
         subargs.append("bash")
         subargs.append("-c")
         subargs.append(self.config['exec_cmd'])
-        container = DockerCmd(self, 'run', subargs, verbose=False)
+        container = DockerCmd(self, 'run', subargs)
         self.sub_stuff['container_cmd'] = container
         mustpass(container.execute())
 
@@ -113,7 +113,7 @@ class kill_base(subtest.SubSubtest):
         else:
             subargs = []
         subargs.append(name)
-        container = AsyncDockerCmd(self, 'attach', subargs, verbose=False)
+        container = AsyncDockerCmd(self, 'attach', subargs)
         self.sub_stuff['container_cmd'] = container  # overwrites finished cmd
         container.execute()
 
@@ -199,8 +199,7 @@ class kill_base(subtest.SubSubtest):
                     sig_long = False
                 else:
                     subargs = ["-s %s" % signal] + extra_subargs
-                kill_cmds.append(DockerCmd(self, 'kill', subargs,
-                                           verbose=False))
+                kill_cmds.append(DockerCmd(self, 'kill', subargs))
 
         # Kill -9 is the last one :-)
         signal = 9
@@ -208,8 +207,7 @@ class kill_base(subtest.SubSubtest):
         if self.config.get('kill_map_signals'):
             signal = SIGNAL_MAP.get(signal, signal)
         kill_cmds.append(DockerCmd(self, 'kill',
-                                   ["-s %s" % signal] + extra_subargs,
-                                   verbose=False))
+                                   ["-s %s" % signal] + extra_subargs))
 
         if sigproxy:
             self.logdebug("kill_command_example: Killing directly the "

--- a/subtests/docker_cli/kill_stress/kill_stress.py
+++ b/subtests/docker_cli/kill_stress/kill_stress.py
@@ -95,7 +95,7 @@ class stress(kill_base):
         if sigproxy:
             self.sub_stuff['kill_cmds'].append(False)
         else:
-            dcmd = DockerCmd(self, 'kill', extra_subargs, verbose=False)
+            dcmd = DockerCmd(self, 'kill', extra_subargs)
             self.sub_stuff['kill_cmds'].append(dcmd)
         self.sub_stuff['signals_set'] = signals_set
 

--- a/subtests/docker_cli/kill_stress/kill_utils.py
+++ b/subtests/docker_cli/kill_stress/kill_utils.py
@@ -80,7 +80,7 @@ class kill_base(subtest.SubSubtest):
         subargs.append("bash")
         subargs.append("-c")
         subargs.append(self.config['exec_cmd'])
-        container = AsyncDockerCmd(self, 'run', subargs, verbose=False)
+        container = AsyncDockerCmd(self, 'run', subargs)
         self.sub_stuff['container_cmd'] = container
         container.execute()
 
@@ -103,7 +103,7 @@ class kill_base(subtest.SubSubtest):
         subargs.append("bash")
         subargs.append("-c")
         subargs.append(self.config['exec_cmd'])
-        container = DockerCmd(self, 'run', subargs, verbose=False)
+        container = DockerCmd(self, 'run', subargs)
         self.sub_stuff['container_cmd'] = container
         mustpass(container.execute())
 
@@ -113,7 +113,7 @@ class kill_base(subtest.SubSubtest):
         else:
             subargs = []
         subargs.append(name)
-        container = AsyncDockerCmd(self, 'attach', subargs, verbose=False)
+        container = AsyncDockerCmd(self, 'attach', subargs)
         self.sub_stuff['container_cmd'] = container  # overwrites finished cmd
         container.execute()
 
@@ -199,8 +199,7 @@ class kill_base(subtest.SubSubtest):
                     sig_long = False
                 else:
                     subargs = ["-s %s" % signal] + extra_subargs
-                kill_cmds.append(DockerCmd(self, 'kill', subargs,
-                                           verbose=False))
+                kill_cmds.append(DockerCmd(self, 'kill', subargs))
 
         # Kill -9 is the last one :-)
         signal = 9
@@ -208,8 +207,7 @@ class kill_base(subtest.SubSubtest):
         if self.config.get('kill_map_signals'):
             signal = SIGNAL_MAP.get(signal, signal)
         kill_cmds.append(DockerCmd(self, 'kill',
-                                   ["-s %s" % signal] + extra_subargs,
-                                   verbose=False))
+                                   ["-s %s" % signal] + extra_subargs))
 
         if sigproxy:
             self.logdebug("kill_command_example: Killing directly the "

--- a/subtests/docker_cli/logs/logs.py
+++ b/subtests/docker_cli/logs/logs.py
@@ -79,7 +79,7 @@ class Base(SubSubtest):
         subargs += get_as_list(self.config['extra_create_args'])
         subargs += [fqin, command]
         subargs += args.strip().split()
-        dockercmd = cls(self, 'create', subargs, verbose=True)
+        dockercmd = cls(self, 'create', subargs)
         dockercmd.quiet = True
         if execute:
             dockercmd.execute()
@@ -97,7 +97,7 @@ class Base(SubSubtest):
         :return: A new DockerCmd instance
         """
         subargs = get_as_list(self.config['extra_start_args']) + [name]
-        dockercmd = cls(self, 'start', subargs, verbose=True)
+        dockercmd = cls(self, 'start', subargs)
         dockercmd.quiet = True
         if execute:
             dockercmd.execute()
@@ -117,7 +117,7 @@ class Base(SubSubtest):
         subargs = args.strip().split()
         subargs += [name]
         # This is test subject, provide additional details
-        dockercmd = cls(self, 'logs', subargs, verbose=True)
+        dockercmd = cls(self, 'logs', subargs)
         dockercmd.quiet = False
         if execute:
             dockercmd.execute()

--- a/subtests/docker_cli/negativeusage/negativeusage.py
+++ b/subtests/docker_cli/negativeusage/negativeusage.py
@@ -110,8 +110,7 @@ class Base(subtest.SubSubtest):
         cntr = dockercmd.AsyncDockerCmd(self, 'run',
                                         ['--detach',
                                          self.sub_stuff['FQIN'],
-                                         'sleep 5m'],
-                                        verbose=False)
+                                         'sleep 5m'])
         cntr.execute()
         # cntr.stdout is a property
         if output.wait_for_output(lambda: cntr.stdout, r'^\w{64}$'):
@@ -122,8 +121,8 @@ class Base(subtest.SubSubtest):
         # Throw away cntr, all we need is the CID
         cntr = mustpass(dockercmd.DockerCmd(self, 'run',
                                             ['--detach',
-                                             self.sub_stuff['FQIN'], 'true'],
-                                            verbose=False).execute())
+                                             self.sub_stuff['FQIN'],
+                                             'true']).execute())
         # Only the CID is needed
         self.sub_stuff['STPCNTR'] = cntr.stdout.splitlines()[-1].strip()
 

--- a/subtests/docker_cli/ps_size/ps_size.py
+++ b/subtests/docker_cli/ps_size/ps_size.py
@@ -39,7 +39,7 @@ class ps_size_base(SubSubtest):
         fin = DockerImage.full_name_from_defaults(self.config)
         subargs.append(fin)
         subargs.append(cmd)
-        dkrcmd = DockerCmd(self, 'run', subargs, verbose=False)
+        dkrcmd = DockerCmd(self, 'run', subargs)
         return dkrcmd
 
     def initialize(self):

--- a/subtests/docker_cli/pull/pull.py
+++ b/subtests/docker_cli/pull/pull.py
@@ -76,8 +76,7 @@ class pull_base(SubSubtest):
         image_fn = self.init_image_fn()
         # set by run_once()
         self.sub_stuff['image_list'] = []
-        dkrcmd = AsyncDockerCmd(self, 'pull',
-                                [image_fn], verbose=True)
+        dkrcmd = AsyncDockerCmd(self, 'pull', [image_fn])
         dkrcmd.quiet = False
         self.sub_stuff['dkrcmd'] = dkrcmd
         self.clean_all()

--- a/subtests/docker_cli/rm/rm.py
+++ b/subtests/docker_cli/rm/rm.py
@@ -41,7 +41,7 @@ class rm_sub_base(SubSubtest):
         # Can't use containers module b/c "rm" is the test-subject
         subargs = self.config['rm_options_csv'].strip().split(',')
         subargs.append(what)
-        rm_cmd = DockerCmd(self, 'rm', subargs, verbose=True)
+        rm_cmd = DockerCmd(self, 'rm', subargs)
         self.sub_stuff['rm_cmdresult'] = rm_cmd.execute()
         wait_rm = self.config['wait_rm']
         self.loginfo("Sleeping %d seconds after rm",

--- a/subtests/docker_cli/run/run.py
+++ b/subtests/docker_cli/run/run.py
@@ -49,8 +49,7 @@ class run_base(SubSubtest):
         subargs.append(self.config['cmd'])
 
     def init_dockercmd(self):
-        dkrcmd = DockerCmd(self, 'run', self.sub_stuff['subargs'],
-                           verbose=True)
+        dkrcmd = DockerCmd(self, 'run', self.sub_stuff['subargs'])
         self.sub_stuff['dkrcmd'] = dkrcmd
 
     def initialize(self):

--- a/subtests/docker_cli/run_attach/run_attach.py
+++ b/subtests/docker_cli/run_attach/run_attach.py
@@ -53,7 +53,7 @@ class run_attach_base(subtest.SubSubtest):
         fin = DockerImage.full_name_from_defaults(self.config)
         subargs.append(fin)
         subargs.append(cmd)
-        cmd = DockerCmd(self, 'run', subargs, timeout=30, verbose=False)
+        cmd = DockerCmd(self, 'run', subargs, timeout=30)
         try:
             cmd.execute(cmd_input)
         finally:

--- a/subtests/docker_cli/run_cidfile/run_cidfile.py
+++ b/subtests/docker_cli/run_cidfile/run_cidfile.py
@@ -32,11 +32,10 @@ class InteractiveAsyncDockerCmd(dockercmd.AsyncDockerCmd):
     with PIPE as stdin and allows use of stdin(data) to interact with process.
     """
 
-    def __init__(self, subbase, subcmd, subargs=None, timeout=None,
-                 verbose=True):
+    def __init__(self, subbase, subcmd, subargs=None, timeout=None):
         super(InteractiveAsyncDockerCmd, self).__init__(subbase, subcmd,
                                                         subargs, timeout,
-                                                        verbose)
+                                                        verbose=True)
         self._stdin = None
         self._stdout_idx = 0
 
@@ -145,8 +144,7 @@ class basic(subtest.SubSubtest):
                                                lambda x: mustfail(x, 125)))
         self._check_failure_cidfile_present(containers[-1])
         # restart container with cidfile
-        mustpass(dockercmd.DockerCmd(self, 'start', [name],
-                                     verbose=False).execute())
+        mustpass(dockercmd.DockerCmd(self, 'start', [name]).execute())
         is_alive = lambda: 'Up' in self._get_container_by_name(name).status
         self.failif(utils.wait_for(is_alive, 10) is None, "Container %s "
                     "was not restarted in 10 seconds." % name)

--- a/subtests/docker_cli/run_dns/run_dns.py
+++ b/subtests/docker_cli/run_dns/run_dns.py
@@ -38,8 +38,7 @@ class run_dns(subtest.Subtest):
         if search:
             for name in search:
                 subargs.insert(0, '--dns-search %s' % name)
-        return mustfail(DockerCmd(self, 'run', subargs,
-                                  verbose=False).execute(), 125)
+        return mustfail(DockerCmd(self, 'run', subargs).execute(), 125)
 
     def _execute_and_record(self, dns, search, dnss, searches):
         """ Execute and store the new dns/searches """
@@ -50,8 +49,7 @@ class run_dns(subtest.Subtest):
         if search:
             for name in search:
                 subargs.insert(0, '--dns-search %s' % name)
-        res = mustpass(DockerCmd(self, 'run', subargs,
-                                 verbose=False).execute())
+        res = mustpass(DockerCmd(self, 'run', subargs).execute())
         dnss.append(self.re_nameserver.findall(res.stdout))
         search = self.re_search.findall(res.stdout)
         self.failif(len(search) > 1, "Number of search lines is > 1:\n%s"

--- a/subtests/docker_cli/run_env/run_env.py
+++ b/subtests/docker_cli/run_env/run_env.py
@@ -74,7 +74,7 @@ class spam(SubSubtest):
             subargs.append("%s=%s" % (key, value))
         subargs.append(DockerImages(self).default_image)
         subargs.append("bash -c 'env > /x/env.output'")
-        _ = DockerCmd(self, 'run', subargs, verbose=False)
+        _ = DockerCmd(self, 'run', subargs)
         _.quiet = True
         self.sub_stuff['dkrcmd'] = _
 

--- a/subtests/docker_cli/run_user/run_user.py
+++ b/subtests/docker_cli/run_user/run_user.py
@@ -35,7 +35,7 @@ class run_user(subtest.SubSubtestCaller):
         fin = DockerImage.full_name_from_defaults(self.config)
         subargs.append(fin)
         subargs.append("cat /etc/passwd")
-        cmd = DockerCmd(self, 'run', subargs, verbose=False)
+        cmd = DockerCmd(self, 'run', subargs)
         result = cmd.execute()
         self.failif_ne(result.exit_status, 0,
                        "Failed to get container's /etc/passwd."
@@ -74,7 +74,7 @@ class run_user_base(subtest.SubSubtest):
         subargs.append("bash")
         subargs.append("-c")
         subargs.append(cmd)
-        self.sub_stuff['cmd'] = DockerCmd(self, 'run', subargs, verbose=False)
+        self.sub_stuff['cmd'] = DockerCmd(self, 'run', subargs)
 
     def _init_test_depenent(self):
         """

--- a/subtests/docker_cli/save_load/save_load.py
+++ b/subtests/docker_cli/save_load/save_load.py
@@ -49,7 +49,7 @@ class save_load_base(SubSubtest):
         fin = DockerImage.full_name_from_defaults(self.config)
         subargs.append(fin)
         subargs.append(cmd)
-        container = DockerCmd(self, 'run', subargs, verbose=False)
+        container = DockerCmd(self, 'run', subargs)
         return container, name
 
     def initialize(self):
@@ -120,14 +120,12 @@ class simple(save_load_base):
                                       "tmpdir": self.tmpdir})
 
         dkrcmd = DockerCmd(self, 'save',
-                           [self.sub_stuff['save_ar']],
-                           verbose=True)
+                           [self.sub_stuff['save_ar']])
         self.sub_stuff['cmdresult_save'] = dkrcmd.execute()
 
         # Delete image
         dkrcmd = DockerCmd(self, 'rmi',
-                           [self.sub_stuff["rand_name"]],
-                           verbose=True)
+                           [self.sub_stuff["rand_name"]])
         self.sub_stuff['cmdresult_del'] = dkrcmd.execute()
 
         # Load image
@@ -137,8 +135,7 @@ class simple(save_load_base):
                                       "tmpdir": self.tmpdir})
 
         dkrcmd = DockerCmd(self, 'load',
-                           [self.sub_stuff['load_ar']],
-                           verbose=True)
+                           [self.sub_stuff['load_ar']])
         dkrcmd.verbose = True
         self.sub_stuff['cmdresult_load'] = dkrcmd.execute()
 

--- a/subtests/docker_cli/tag/tag.py
+++ b/subtests/docker_cli/tag/tag.py
@@ -58,10 +58,9 @@ class tag_base(SubSubtest):
 
     def prep_image(self, base_image):
         """ Tag the dockertest image to this test name """
-        mustpass(DockerCmd(self, "pull", [base_image],
-                           verbose=True).execute())
+        mustpass(DockerCmd(self, "pull", [base_image]).execute())
         subargs = [base_image, self.sub_stuff["image"]]
-        tag_results = DockerCmd(self, "tag", subargs, verbose=True).execute()
+        tag_results = DockerCmd(self, "tag", subargs).execute()
         if tag_results.exit_status:
             raise xceptions.DockerTestNAError("Problems during "
                                               "initialization of"
@@ -185,8 +184,8 @@ class double_tag(change_tag):
         super(double_tag, self).initialize()
         # Tag it for the first time. This should pass...
         self.sub_stuff['tmp_image_list'].add(self.sub_stuff["new_image_name"])
-        mustpass(DockerCmd(self, 'tag', self.complete_docker_command_line(),
-                           verbose=True).execute())
+        mustpass(DockerCmd(self, 'tag',
+                           self.complete_docker_command_line()).execute())
         # On docker 1.10, the second tag should pass. On < 1.10, fail.
         try:
             DockerVersion().require_server("1.10")

--- a/subtests/docker_cli/wait/wait.py
+++ b/subtests/docker_cli/wait/wait.py
@@ -63,9 +63,7 @@ class WaitBase(SubSubtest):
                                                        str(target.sleep))
         subargs += get_as_list(target_cmd)
         timeout = self.config['target_timeout']
-        return DockerCmd(self, command, subargs,
-                         verbose=self.config['target_verbose'],
-                         timeout=timeout)
+        return DockerCmd(self, command, subargs, timeout=timeout)
 
     def target_wait_dkrcmd(self, name, fqin, setup, wait_opr, sleep):
         del sleep  # not used for now


### PR DESCRIPTION
When looking at a debug log of a failure, the first and
most important thing I want to know is: what docker commands
led to this? Too often it's not in the log, and I see this
in the source:

    DockerCmd(...., verbose=False)

...requiring an edit, and rerunning the test, then (when not
trivially reproducible) rerunning and rerunning some more.

Enough. Let's just always log docker commands. Since verbose
is the default, just remove most instances of verbose=False.
(And, while we're at it, also remove verbose=True since
it's a possibly-misleading NOP).

Also: fixed minor misspellings.

Signed-off-by: Ed Santiago <santiago@redhat.com>