### PR TITLE
run_user test: change capitalization of docker msg

### DIFF
--- a/subtests/docker_cli/run_user/run_user.py
+++ b/subtests/docker_cli/run_user/run_user.py
@@ -236,7 +236,7 @@ class bad_user(run_user_base):
                 pass
         user = utils.get_unique_name(lambda name: name not in users, "user",
                                      length=6)
-        self.sub_stuff['execution_failure'] = "Unable to find user %s" % user
+        self.sub_stuff['execution_failure'] = "unable to find user %s" % user
         self.sub_stuff['subargs'] = ['--rm', '--interactive',
                                      '--user=%s' % user]
 
@@ -281,7 +281,7 @@ class too_high_number(run_user_base):
     """
 
     def _init_test_dependent(self):
-        self.sub_stuff['execution_failure'] = ("Uids and gids must be in "
+        self.sub_stuff['execution_failure'] = ("uids and gids must be in "
                                                "range 0-2147483647")
         self.sub_stuff['subargs'] = ['--rm', '--interactive',
                                      '--user=2147483648']


### PR DESCRIPTION
docker changed two error messages, just minor capitalization
changes that were enough to trip up our tests[1].

Since the change has now propagated into docker-1.9.1-37.el7
and docker-latest-1.10.3-22.el7, I choose to just change
the hardcoded tested-for error message. No configurability,
no regexes or flexibility, just holding my nose and accepting
that this is sometimes part of life in testland.

  [1] https://github.com/docker/docker/commit/da38ac6c79fe902ed0687afc73d731c95c6d491a#diff-29081af54e3d2dea9c82ab2e757e61bf

Signed-off-by: Ed Santiago <santiago@redhat.com>