### PR TITLE
Extra run_pylint checking

### DIFF
--- a/run_unittests.sh
+++ b/run_unittests.sh
@@ -27,7 +27,7 @@ else
     python -c 'import autotest'
     if [ "$?" -ne "0" ]
     then
-        echo "ERROR: autotest module won't load or"\
+        echo "ERROR: autotest module won't load or " \
              "AUTOTEST_PATH env. var. is not set"
         exit 1
     fi


### PR DESCRIPTION
It's been an unwritten rule that the pyhong 'print'
statement shouldn't appear anywhere in module or test code.
Additionally, while used for debugging, the pdb module also
shouldn't appear in any checked-in code.  Update run_pylint
to with a function to check for both of these.

There is no easy way to add these checks to pylint/pep8.  In
the case of pylint and pdb, the workaround is to mark the pdb
module itself as deprecated instead.  This ensures all the possible
ways of importing it are checked.

In the case of print, the simplest solution is to just egrep
for it in every checked file.  If found, the file and line
references are printed.

Finally, I added a check for AUTOTEST_PATH or successful autotest
import, similar to the one that appears in run_unittests.sh

Signed-off-by: Chris Evich <cevich@redhat.com>