### PR TITLE
Adding negativeusage parameters to --tmpfs

### DIFF
--- a/config_defaults/subtests/docker_cli/create.ini
+++ b/config_defaults/subtests/docker_cli/create.ini
@@ -10,6 +10,8 @@ run_options_csv = --attach=stdout
 bash_cmd = /bin/bash,-c
 #: Specifies the executed command inside the container
 cmd =
+#: expected exit status
+exit_status = 0
 
 [docker_cli/create/create_true]
 cmd = /bin/true

--- a/config_defaults/subtests/docker_cli/negativeusage.ini
+++ b/config_defaults/subtests/docker_cli/negativeusage.ini
@@ -1,5 +1,5 @@
 [docker_cli/negativeusage]
-subsubtests = op1, op2, op3, if1, ov1, iv1, iv3, iv4, ip1
+subsubtests = op1, op2, op3, if1, ov1, iv1, iv3, iv4, iv5, iv6, iv7, ip1
 #: Optional docker subcommand (string). Automatically generated substitution keys:{n}
 #: {n}
 #: {t} * ``%%(FQIN)s`` **-** valid, default test image name{n}
@@ -69,6 +69,24 @@ subcmd = run
 subarg = -e,PATH=/tmp,%%(FQIN)s,true
 stderr = exec\: \"true\"\: executable file not found in \$PATH
 extcmd = 127
+
+[docker_cli/negativeusage/iv5]
+subcmd = run
+subarg = --tmpfs,/dev,%%(FQIN)s
+stderr =  no such file or directory
+extcmd = 127
+
+[docker_cli/negativeusage/iv6]
+subcmd = run
+subarg = --tmpfs,:rw,%%(FQIN)s
+stderr =  open /proc/self/task/1/attr/exec: no such file or directory
+extcmd = 125
+
+[docker_cli/negativeusage/iv7]
+subcmd = run
+subarg = --tmpfs,.,%%(FQIN)s
+stderr =  Message: Failed to open /dev/null - open /dev/null: permission denied
+extcmd = 125
 
 [docker_cli/negativeusage/ip1]
 subcmd = tag

--- a/subtests/docker_cli/create/create.py
+++ b/subtests/docker_cli/create/create.py
@@ -80,7 +80,7 @@ class create_base(SubSubtest):
         # Fail test if bad command or other stdout/stderr problems detected
         dkrcmd = self.sub_stuff['dkrcmd']
         OutputGood(dkrcmd.cmdresult)
-        expected = 0  # always
+        expected = self.config['exit_status']
         self.failif_ne(dkrcmd.exit_status, expected,
                        "Exit status non-zero command %s"
                        % dkrcmd.cmdresult)

--- a/subtests/docker_cli/negativeusage/negativeusage.py
+++ b/subtests/docker_cli/negativeusage/negativeusage.py
@@ -40,6 +40,7 @@ from dockertest import config
 from dockertest import output
 from dockertest import xceptions
 from dockertest.output import mustpass, mustfail
+from dockertest.output import DockerVersion
 
 
 class NoisyCmd(dockercmd.DockerCmd):
@@ -168,6 +169,9 @@ class Base(subtest.SubSubtest):
         self.init_utilities()
         self.init_substitutions()
         self.do_substitutions()
+        if '--tmpfs' in self.sub_stuff['subarg']:
+            # Minimum docker version 1.10 is required for --tmpfs
+            DockerVersion().require_server("1.10")
 
     def run_once(self):
         super(Base, self).run_once()

--- a/subtests/docker_cli/run/run.py
+++ b/subtests/docker_cli/run/run.py
@@ -75,7 +75,9 @@ class run_base(SubSubtest):
         dockercmd = self.sub_stuff['dkrcmd']
         OutputGood(dockercmd.cmdresult)
         expected = self.config['exit_status']
-        self.failif_ne(dockercmd.exit_status, expected, "Exit status")
+        self.failif_ne(dockercmd.exit_status, expected,
+                       "Exit status %s"
+                       % dockercmd.cmdresult)
 
     def cleanup(self):
         super(run_base, self).cleanup()


### PR DESCRIPTION
Added parameters to run negativeusage test with wrong parameters to --tmpfs

Signed-off-by: Afom Michael <tmichael@redhat.com>