### PR TITLE
Add runc component for optional bugzilla integration

### DIFF
--- a/config_defaults/control.ini
+++ b/config_defaults/control.ini
@@ -78,5 +78,6 @@ key_match = docker-autotest
 product = Red Hat Enterprise Linux 7
 component = docker, docker-distribution, docker-registry, atomic,
             rhel-server-atomic, rhel-server-docker, rhel-tools-docker,
-            rsyslog-docker, sadc-docker, sssd-docker
+            rsyslog-docker, sadc-docker, sssd-docker, runc, skopeo,
+            ostree, rpm-ostree
 status = NEW, ASSIGNED, POST, MODIFIED, ON_DEV


### PR DESCRIPTION
Needed to support skipping of certain tests based
on results of bugzilla query.  The search is limited
to specific components, not all current/relevant
were listed.

Signed-off-by: Chris Evich <cevich@redhat.com>