### PR TITLE
Adding create subtest with --tmpfs option

### DIFF
--- a/config_defaults/subtests/docker_cli/create.ini
+++ b/config_defaults/subtests/docker_cli/create.ini
@@ -1,6 +1,6 @@
 [docker_cli/create]
 subsubtests = create_true,create_false,create_signal,
-              create_remote_tag,create_names
+              create_remote_tag,create_names,create_tmpfs
 #: Extremely short timeout, all these commands should return
 #: almost immediatly.
 docker_timeout = 10
@@ -18,6 +18,11 @@ cmd = /bin/true
 
 [docker_cli/create/create_false]
 cmd = /bin/false
+
+[docker_cli/create/create_tmpfs]
+#: --tmpfs parameter to create container
+tmpfs_arg = /run
+run_options_csv = --tmpfs,%(tmpfs_arg)s
 
 [docker_cli/create/create_names]
 cmd = sleep 2s

--- a/subtests/docker_cli/create/create_tmpfs.py
+++ b/subtests/docker_cli/create/create_tmpfs.py
@@ -1,0 +1,28 @@
+"""
+Create container with --tmpfs option and inspect it
+"""
+
+from create import create_base
+from dockertest.output import DockerVersion
+
+
+class create_tmpfs(create_base):
+
+    def initialize(self):
+        super(create_tmpfs, self).initialize()
+        # Minimum docker version 1.10 is required for --tmpfs
+        DockerVersion().require_server("1.10")
+
+    def run_once(self):
+        super(create_tmpfs, self).run_once()
+        cid = self.get_cid()
+        self.sub_stuff['metadata'] = (
+            self.sub_stuff['cont'].json_by_long_id(cid))
+
+    def postprocess(self):
+        super(create_tmpfs, self).postprocess()
+        tmpfs_arg = self.config['tmpfs_arg']
+        actual_tmpfs = self.sub_stuff['metadata'][0]['HostConfig']['Tmpfs']
+        self.failif(tmpfs_arg not in actual_tmpfs,
+                    "Container was not created with: --tmpfs %s"
+                    % tmpfs_arg)


### PR DESCRIPTION
Adding a create container subtest with --tmpfs option and inspecting the
created container for the --tmpfs parameter

Signed-off-by: Afom Michael <tmichael@redhat.com>