### PR TITLE
github issue #572: default omit_empty=True in get_as_list()

### DIFF
--- a/dockertest/config.py
+++ b/dockertest/config.py
@@ -482,7 +482,7 @@ class Config(dict):
         return the_copy
 
 
-def get_as_list(value, sep=",", omit_empty=False):
+def get_as_list(value, sep=",", omit_empty=True):
     """
     Return config value as list separated by sep.
 

--- a/dockertest/config_unittests.py
+++ b/dockertest/config_unittests.py
@@ -339,6 +339,11 @@ class TestUtilities(ConfigTestBase):
     def test_getaslist_2(self):
         testvalue = ''
         testlist = self.config.get_as_list(testvalue)
+        self.assertEqual(testlist, [])
+
+    def test_getaslist_empty(self):
+        testvalue = ''
+        testlist = self.config.get_as_list(testvalue, omit_empty=False)
         self.assertEqual(testlist, [''])
 
     def test_getaslist_3(self):

--- a/intratests/garbage_check/garbage_check.py
+++ b/intratests/garbage_check/garbage_check.py
@@ -24,11 +24,7 @@ from dockertest.subtest import SubSubtest
 from dockertest.containers import DockerContainers
 from dockertest.images import DockerImage
 from dockertest.images import DockerImages
-from dockertest import config
-
-
-def get_as_list(value):
-    return config.get_as_list(value, omit_empty=True)
+from dockertest.config import get_as_list
 
 
 class DockerImageIncomplete(DockerImage):

--- a/subtests/docker_cli/run_volumes/run_volumes.py
+++ b/subtests/docker_cli/run_volumes/run_volumes.py
@@ -118,7 +118,7 @@ class volumes_base(SubSubtest):
     def make_dockercmd(subtest, dockercmd_class, fqin,
                        run_template, cmd_tmplate, test_dict):
         # safe_substutute ignores unknown tokens
-        subargs = get_as_list(str(run_template % test_dict), omit_empty=True)
+        subargs = get_as_list(str(run_template % test_dict))
         subargs.append(fqin)
         subargs.append(cmd_tmplate % test_dict)
         return dockercmd_class(subtest, 'run', subargs)
@@ -198,8 +198,8 @@ class volumes_rw(volumes_base):
 
     def initialize(self):
         super(volumes_rw, self).initialize()
-        host_paths = get_as_list(self.config['host_paths'], omit_empty=True)
-        cntr_paths = get_as_list(self.config['cntr_paths'], omit_empty=True)
+        host_paths = get_as_list(self.config['host_paths'])
+        cntr_paths = get_as_list(self.config['cntr_paths'])
         # list of substitution dictionaries for each container
         path_info = self.sub_stuff['path_info'] = []
         self.init_path_info(path_info, host_paths, cntr_paths, self.tmpdir)


### PR DESCRIPTION
https://github.com/autotest/autotest-docker/issues/572

The omit_empty=False default caused another problem in
ADEPT tests this week. I can think of no sensible reason
for passing back empty values in the usual case.

Signed-off-by: Ed Santiago <santiago@redhat.com>