### PR TITLE
run_sigproxy test: race condition fix

### DIFF
--- a/subtests/docker_cli/run_sigproxy/run_sigproxy.py
+++ b/subtests/docker_cli/run_sigproxy/run_sigproxy.py
@@ -92,6 +92,11 @@ class sigproxy_base(SubSubtest):
             time.sleep(0.5)
             if 'READY' in container_cmd.stdout:
                 return
+            # Some containers run detached; use 'docker logs' to check output
+            logs = DockerCmd(self, 'logs', [self.sub_stuff['container_name']])
+            logs.execute()
+            if 'READY' in logs.stdout:
+                return
         self.failif(container_cmd.done, "Container exited before ready")
         raise DockerTestFail("timed out waiting for container READY")
 


### PR DESCRIPTION
...at least, it's acting like a race condition (unpredictable
failures), even though on examination it looks like a pretty
clear bug that should fail every time.

The problem seems to be that some containers are run with --detach,
hence we don't see READY in stdout. Solution: use 'docker logs' in
addition to checking stdout. But why do the tests pass sometimes??

Signed-off-by: Ed Santiago <santiago@redhat.com>