### PR TITLE
pylint 1.5 fixes & workarounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ git:
     submodules: false
 
 install:
-    - pip install Pylint==1.4.5 Pep8==1.6.2 Sphinx==1.2.2
+    - pip install Pylint==1.5.5 Pep8==1.6.2 Sphinx==1.2.2
     - pip install Autotest==0.16.2
     - pip install inspektor==0.2.0
     - pip install unittest2==0.8.0

--- a/dockertest/config.py
+++ b/dockertest/config.py
@@ -85,10 +85,7 @@ class ConfigSection(object):
         :param section: Name of section to check.
         :returns: True/False if section exists.
         """
-        if section == self._section:
-            return True
-        else:
-            return False
+        return section == self._section
 
     def options(self):
         """
@@ -247,6 +244,7 @@ class ConfigDict(MutableMapping):
     def __init__(self, section, defaults=None, *args, **dargs):
         self._config_section = ConfigSection(defaults=defaults,
                                              section=section)
+        # pylint: disable=E1101
         super(ConfigDict, self).__init__(*args, **dargs)
 
     # Private method doesn't need docstring

--- a/dockertest/containers.py
+++ b/dockertest/containers.py
@@ -423,7 +423,7 @@ class DockerContainers(object):
         cmd = 'kill '
         if _signal is not None:
             if _signal.upper().startswith('SIG'):
-                _signal = _signal[3:]
+                _signal = _signal[3:]          # pylint: disable=E0012,E1136
             cmd += "--signal=%s " % str(_signal)
         cmd += str(long_id)
         if self.verify_output:
@@ -563,14 +563,14 @@ class DockerContainers(object):
             preserve_cnames = get_as_list(preserve_cnames)
         else:
             preserve_cnames = []
-        preserve_cnames = set(preserve_cnames)
-        preserve_cnames.discard(None)
-        preserve_cnames.discard('')
+        preserve_cnames_set = set(preserve_cnames)
+        preserve_cnames_set.discard(None)
+        preserve_cnames_set.discard('')
         self.verbose = False
         try:
             for name in containers:
                 name = name.strip()
-                if name in preserve_cnames:
+                if name in preserve_cnames_set:
                     continue
                 try:
                     self.subtest.logdebug("Cleaning %s", name)

--- a/dockertest/docker_daemon.py
+++ b/dockertest/docker_daemon.py
@@ -8,9 +8,9 @@ Docker Daemon interface helpers and utilities
 import httplib
 import socket
 import json
-from output import wait_for_output
 from autotest.client.shared import service
 from autotest.client import utils
+from output import wait_for_output
 
 
 class ClientBase(object):

--- a/dockertest/images.py
+++ b/dockertest/images.py
@@ -26,17 +26,15 @@ Note: As in other places, the terms 'repo' and 'image' are used
 # pylint: disable=W0403
 
 import re
+from autotest.client import utils
 from autotest.client.shared import error
 from config import Config
 from config import none_if_empty
 from config import get_as_list
-from autotest.client import utils
-from output import OutputGood
-from output import TextTable
+from output import OutputGood, TextTable
 from subtestbase import SubBase
-from xceptions import DockerTestError
+from xceptions import DockerTestError, DockerCommandError
 from xceptions import DockerFullNameFormatError
-from xceptions import DockerCommandError
 
 
 # Many attributes simply required here
@@ -641,13 +639,13 @@ class DockerImages(object):
         else:
             preserve_fqins = []
         preserve_fqins.append(self.default_image)
-        preserve_fqins = set(preserve_fqins)
-        preserve_fqins.discard(None)
-        preserve_fqins.discard('')
+        preserve_fqins_set = set(preserve_fqins)
+        preserve_fqins_set.discard(None)
+        preserve_fqins_set.discard('')
         self.verbose = False
         try:
             for name in fqins:
-                if name in preserve_fqins:
+                if name in preserve_fqins_set:
                     continue
                 try:
                     self.subtest.logdebug("Cleaning %s", name)

--- a/dockertest/output/dockerversion.py
+++ b/dockertest/output/dockerversion.py
@@ -6,8 +6,8 @@ Handlers for docker version parsing
 # pylint: disable=W0403
 
 import re
-from autotest.client import utils
 import subprocess
+from autotest.client import utils
 from dockertest.xceptions import DockerOutputError, DockerTestNAError
 from dockertest.version import LooseVersion
 

--- a/dockertest/output/validate.py
+++ b/dockertest/output/validate.py
@@ -6,8 +6,8 @@ Handlers for command-line output processing, crash/panic detection, etc.
 # pylint: disable=W0403
 
 import re
-from autotest.client import utils
 import subprocess
+from autotest.client import utils
 from dockertest.xceptions import DockerExecError, DockerOutputError
 from . dockerversion import DockerVersion
 

--- a/dockertest/subtest.py
+++ b/dockertest/subtest.py
@@ -168,7 +168,7 @@ class Subtest(subtestbase.SubBase, test.test):
             except (IOError, OSError, Error):
                 self.logwarning("Failed to load reference '%s' and/or"
                                 "it's '[Control]' section.", fullpath)
-                self._control_ini = {}
+                self._control_ini = {}    # pylint: disable=E0012,R0204
         if self._control_ini == {}:
             self.logdebug("No reference control.ini found, returning None")
             return None

--- a/dockertest/subtestbase.py
+++ b/dockertest/subtestbase.py
@@ -246,6 +246,6 @@ class SubBase(object):
                                               exc_info[1],
                                               exc_info[2])
 
-        error_tb = "".join(error_tb).strip() + "\n"
+        error_tb_str = "".join(error_tb).strip() + "\n"
         cls.logerror(error_head)
-        cls.logdebug(error_tb)
+        cls.logdebug(error_tb_str)

--- a/dockertest/xceptions.py
+++ b/dockertest/xceptions.py
@@ -11,8 +11,8 @@ Exception subclasses specific to docker subtests
 # Some code runs deep, many ancestors actually needed
 # pylint: disable=R0901
 
-from autotest.client.shared import error
 from ConfigParser import InterpolationError
+from autotest.client.shared import error
 
 
 # Pass-throughs, to help hide autotest.client.shared.error import

--- a/subtests/docker_cli/cp/cp.py
+++ b/subtests/docker_cli/cp/cp.py
@@ -22,6 +22,7 @@ Prerequisites
 
 from StringIO import StringIO
 import pickle
+import hashlib
 import inspect
 import os.path
 from autotest.client import utils
@@ -33,7 +34,6 @@ from dockertest.images import DockerImage
 from dockertest.images import DockerImages
 from dockertest.containers import DockerContainers
 from dockertest.environment import set_selinux_context
-import hashlib
 
 
 class cp(SubSubtestCaller):

--- a/subtests/docker_cli/create/create_remote_tag.py
+++ b/subtests/docker_cli/create/create_remote_tag.py
@@ -1,10 +1,10 @@
 import os.path
+from autotest.client import utils
 from autotest.client.shared import error
 from dockertest.output import mustpass
 from dockertest.dockercmd import DockerCmd
 from dockertest.config import get_as_list
 from dockertest.xceptions import DockerTestFail
-from autotest.client import utils
 from create import create_base
 
 

--- a/subtests/docker_cli/create/create_signal.py
+++ b/subtests/docker_cli/create/create_signal.py
@@ -29,8 +29,8 @@ class create_signal(create_base):
         sigdkrcmd = DockerCmd(self, 'kill',
                               ['--signal', str(sig),
                                self.get_cid()])
-        sigdkrcmd = mustfail(sigdkrcmd.execute(), 1)
-        self.sub_stuff['sigdkrcmd'] = sigdkrcmd
+        sigdkrcmd_result = mustfail(sigdkrcmd.execute(), 1)
+        self.sub_stuff['sigdkrcmd'] = sigdkrcmd_result
 
     def postprocess(self):
         super(create_signal, self).postprocess()

--- a/subtests/docker_cli/dockerinspect/dockerinspect.py
+++ b/subtests/docker_cli/dockerinspect/dockerinspect.py
@@ -12,6 +12,8 @@ Operational Summary
 #. Check output
 """
 
+import json
+import os
 from autotest.client import utils
 from dockertest.containers import DockerContainers
 from dockertest.dockercmd import DockerCmd
@@ -20,8 +22,6 @@ from dockertest.images import DockerImage
 from dockertest.subtest import SubSubtest
 from dockertest.subtest import SubSubtestCaller
 from dockertest.xceptions import DockerTestError
-import json
-import os
 
 
 class dockerinspect(SubSubtestCaller):
@@ -33,7 +33,7 @@ class inspect_base(SubSubtest):
 
     @staticmethod
     def verify_same_configs(subtest, source, comp, ignore_fields=None):
-        for i in range(len(comp)):
+        for i in range(len(comp)):  # pylint: disable=E0012,C0200
             for key in comp[i].keys():
                 if ignore_fields and key in ignore_fields:
                     continue

--- a/subtests/docker_cli/dockerinspect/inspect_keys.py
+++ b/subtests/docker_cli/dockerinspect/inspect_keys.py
@@ -7,12 +7,12 @@ https://bugzilla.redhat.com/show_bug.cgi?id=1092773
 3. Check output keys againt known keys and a regex
 """
 
+import re
 from dockerinspect import inspect_base
 from dockertest.output import mustpass
 from dockertest.dockercmd import DockerCmd
 from dockertest.images import DockerImage
 from dockertest.xceptions import DockerTestError
-import re
 
 
 class inspect_keys(inspect_base):

--- a/subtests/docker_cli/dockerinspect/test_inspect_keys.py
+++ b/subtests/docker_cli/dockerinspect/test_inspect_keys.py
@@ -1,8 +1,8 @@
+import json
 from unittest2 import TestCase, main        # pylint: disable=unused-import
 from mock import Mock
 import autotest  # pylint: disable=unused-import
 import inspect_keys
-import json
 
 
 class TestFilterKeys(TestCase):

--- a/subtests/docker_cli/info/info.py
+++ b/subtests/docker_cli/info/info.py
@@ -21,13 +21,13 @@ Prerequisites
 ``dmsetup``, ``stat`` and ``du`` commands are available on host.
 """
 
+import os
 from autotest.client import utils
 from dockertest import subtest
 from dockertest.output import OutputGood
 from dockertest.dockercmd import DockerCmd
 from dockertest.output import mustpass
 from dockertest.images import DockerImages
-import os
 
 
 class info(subtest.Subtest):

--- a/subtests/docker_cli/iptable/iptable.py
+++ b/subtests/docker_cli/iptable/iptable.py
@@ -22,6 +22,7 @@ Prerequisites
 """
 
 from difflib import unified_diff
+from autotest.client import utils
 from dockertest.dockercmd import DockerCmd
 from dockertest.output import mustpass
 from dockertest.containers import DockerContainers
@@ -29,7 +30,6 @@ from dockertest.config import get_as_list
 from dockertest.images import DockerImage
 from dockertest.subtest import SubSubtest
 from dockertest.subtest import SubSubtestCallerSimultaneous
-from autotest.client import utils
 
 
 class iptable(SubSubtestCallerSimultaneous):

--- a/subtests/docker_cli/kill/kill_utils.py
+++ b/subtests/docker_cli/kill/kill_utils.py
@@ -113,9 +113,9 @@ class kill_base(subtest.SubSubtest):
         else:
             subargs = []
         subargs.append(name)
-        container = AsyncDockerCmd(self, 'attach', subargs)
-        self.sub_stuff['container_cmd'] = container  # overwrites finished cmd
-        container.execute()
+        c_attach = AsyncDockerCmd(self, 'attach', subargs)
+        self.sub_stuff['container_cmd'] = c_attach  # overwrites finished cmd
+        c_attach.execute()
 
     def initialize(self):
         super(kill_base, self).initialize()
@@ -336,7 +336,7 @@ class kill_check_base(kill_base):
         _check = self.config['check_stdout']
         timeout = self.config['stress_cmd_timeout']
         self.sub_stuff['kill_results'] = []
-        stopped_log = False
+        stopped_log = None
         _container_pid = container_cmd.process_id
         self.loginfo("Running kill sequence...")
         for cmd, signal in itertools.izip(kill_cmds, signals_sequence):
@@ -346,13 +346,13 @@ class kill_check_base(kill_base):
             elif signal == 9 or signal is None:   # SIGTERM
                 self._kill_dash_nine(container_cmd)
             elif signal == 19:    # SIGSTOP can't be caught
-                if stopped_log is False:
+                if stopped_log is None:
                     stopped_log = set()
             elif signal == 18:  # SIGCONT, check previous payload
                 self._check_previous_payload(stopped_log, container_out,
                                              timeout, _check)
-                stopped_log = False
-            elif stopped_log is not False:  # if not false it's set()
+                stopped_log = None
+            elif stopped_log is not None:  # if not false it's set()
                 if cmd is not False:
                     # Using docker kill: signals are forwarded when the cont
                     #                    is ready

--- a/subtests/docker_cli/kill_stopped/kill_utils.py
+++ b/subtests/docker_cli/kill_stopped/kill_utils.py
@@ -113,9 +113,9 @@ class kill_base(subtest.SubSubtest):
         else:
             subargs = []
         subargs.append(name)
-        container = AsyncDockerCmd(self, 'attach', subargs)
-        self.sub_stuff['container_cmd'] = container  # overwrites finished cmd
-        container.execute()
+        c_attach = AsyncDockerCmd(self, 'attach', subargs)
+        self.sub_stuff['container_cmd'] = c_attach  # overwrites finished cmd
+        c_attach.execute()
 
     def initialize(self):
         super(kill_base, self).initialize()
@@ -336,7 +336,7 @@ class kill_check_base(kill_base):
         _check = self.config['check_stdout']
         timeout = self.config['stress_cmd_timeout']
         self.sub_stuff['kill_results'] = []
-        stopped_log = False
+        stopped_log = None
         _container_pid = container_cmd.process_id
         self.loginfo("Running kill sequence...")
         for cmd, signal in itertools.izip(kill_cmds, signals_sequence):
@@ -346,13 +346,13 @@ class kill_check_base(kill_base):
             elif signal == 9 or signal is None:   # SIGTERM
                 self._kill_dash_nine(container_cmd)
             elif signal == 19:    # SIGSTOP can't be caught
-                if stopped_log is False:
+                if stopped_log is None:
                     stopped_log = set()
             elif signal == 18:  # SIGCONT, check previous payload
                 self._check_previous_payload(stopped_log, container_out,
                                              timeout, _check)
-                stopped_log = False
-            elif stopped_log is not False:  # if not false it's set()
+                stopped_log = None
+            elif stopped_log is not None:  # if not false it's set()
                 if cmd is not False:
                     # Using docker kill: signals are forwarded when the cont
                     #                    is ready

--- a/subtests/docker_cli/kill_stress/kill_stress.py
+++ b/subtests/docker_cli/kill_stress/kill_stress.py
@@ -51,7 +51,7 @@ class stress(kill_base):
                  signals_set = set of signals, which should be present in the
                                output.
         """
-        stopped = False
+        stopped = None
         mapped = False
         signals_set = set()
         signals_sequence = []
@@ -65,7 +65,7 @@ class stress(kill_base):
                 if signal == 18:
                     if stopped:
                         signals_set.add(stopped)
-                    stopped = False
+                    stopped = None
                     signals_set.add(signal)
                 elif signal == 19:
                     stopped = set()

--- a/subtests/docker_cli/kill_stress/kill_utils.py
+++ b/subtests/docker_cli/kill_stress/kill_utils.py
@@ -113,9 +113,9 @@ class kill_base(subtest.SubSubtest):
         else:
             subargs = []
         subargs.append(name)
-        container = AsyncDockerCmd(self, 'attach', subargs)
-        self.sub_stuff['container_cmd'] = container  # overwrites finished cmd
-        container.execute()
+        c_attach = AsyncDockerCmd(self, 'attach', subargs)
+        self.sub_stuff['container_cmd'] = c_attach  # overwrites finished cmd
+        c_attach.execute()
 
     def initialize(self):
         super(kill_base, self).initialize()
@@ -336,7 +336,7 @@ class kill_check_base(kill_base):
         _check = self.config['check_stdout']
         timeout = self.config['stress_cmd_timeout']
         self.sub_stuff['kill_results'] = []
-        stopped_log = False
+        stopped_log = None
         _container_pid = container_cmd.process_id
         self.loginfo("Running kill sequence...")
         for cmd, signal in itertools.izip(kill_cmds, signals_sequence):
@@ -346,13 +346,13 @@ class kill_check_base(kill_base):
             elif signal == 9 or signal is None:   # SIGTERM
                 self._kill_dash_nine(container_cmd)
             elif signal == 19:    # SIGSTOP can't be caught
-                if stopped_log is False:
+                if stopped_log is None:
                     stopped_log = set()
             elif signal == 18:  # SIGCONT, check previous payload
                 self._check_previous_payload(stopped_log, container_out,
                                              timeout, _check)
-                stopped_log = False
-            elif stopped_log is not False:  # if not false it's set()
+                stopped_log = None
+            elif stopped_log is not None:  # if not false it's set()
                 if cmd is not False:
                     # Using docker kill: signals are forwarded when the cont
                     #                    is ready

--- a/subtests/docker_cli/load/load.py
+++ b/subtests/docker_cli/load/load.py
@@ -12,6 +12,7 @@ Operational Summary
 #.  Verify expected ID exists.
 #.  Remove loaded image
 """
+import os
 from dockertest import subtest
 from dockertest.dockercmd import DockerCmd
 from dockertest.images import DockerImages
@@ -20,7 +21,6 @@ from dockertest.output import mustpass
 from dockertest.output import OutputGood
 from dockertest.output import DockerVersion
 from dockertest import xceptions
-import os
 
 
 class load(subtest.Subtest):

--- a/subtests/docker_cli/logs/basic.py
+++ b/subtests/docker_cli/logs/basic.py
@@ -6,9 +6,9 @@
 #. Verify produced output with expected output
 """
 
+from datetime import datetime
 from time import sleep
 from logs import Base
-from datetime import datetime
 
 
 class basic(Base):

--- a/subtests/docker_cli/negativeusage/negativeusage.py
+++ b/subtests/docker_cli/negativeusage/negativeusage.py
@@ -120,12 +120,12 @@ class Base(subtest.SubSubtest):
             raise xceptions.DockerTestNAError("Failed to initialize %s"
                                               % self.config_section)
         # Throw away cntr, all we need is the CID
-        cntr = mustpass(dockercmd.DockerCmd(self, 'run',
-                                            ['--detach',
-                                             self.sub_stuff['FQIN'],
-                                             'true']).execute())
+        result = mustpass(dockercmd.DockerCmd(self, 'run',
+                                              ['--detach',
+                                               self.sub_stuff['FQIN'],
+                                               'true']).execute())
         # Only the CID is needed
-        self.sub_stuff['STPCNTR'] = cntr.stdout.splitlines()[-1].strip()
+        self.sub_stuff['STPCNTR'] = result.stdout.splitlines()[-1].strip()
 
     def init_substitutions(self):
         di = self.sub_stuff['di']
@@ -151,6 +151,7 @@ class Base(subtest.SubSubtest):
                                                  xcpt.message))
             else:
                 value = ''
+            # pylint: disable=E0012,R0204
             if key == 'subarg':  # This is a CSV option
                 if value.strip() == '':
                     value = []

--- a/subtests/docker_cli/run_attach/run_attach.py
+++ b/subtests/docker_cli/run_attach/run_attach.py
@@ -11,12 +11,12 @@ Operational Summary
    each subtest executes 6 variants of tty/non-tty vs stdin/out/err.
 #. Analyze results (exit_code, input_handling, correct_output)
 """
+import re
 from autotest.client import utils
 from dockertest import config, xceptions, subtest
 from dockertest.containers import DockerContainers
 from dockertest.dockercmd import DockerCmd
 from dockertest.images import DockerImage
-import re
 
 
 LS_GOOD = ["bin", "etc", "lib", "root", "var"]

--- a/subtests/docker_cli/run_cidfile/run_cidfile.py
+++ b/subtests/docker_cli/run_cidfile/run_cidfile.py
@@ -15,6 +15,7 @@ Operational Summary
 5.  Stop the container and cleanup
 """
 import os
+import time
 
 from autotest.client.shared import utils
 from dockertest import config, subtest, dockercmd
@@ -22,7 +23,6 @@ from dockertest.containers import DockerContainers
 from dockertest.images import DockerImage
 from dockertest.output import mustfail
 from dockertest.output import mustpass
-import time
 
 
 class InteractiveAsyncDockerCmd(dockercmd.AsyncDockerCmd):

--- a/subtests/docker_cli/run_dns/run_dns.py
+++ b/subtests/docker_cli/run_dns/run_dns.py
@@ -10,6 +10,7 @@ Operational Summary
 #.  Execute couple of correctly set dns/dns-search scenarios
 #.  Execute couple of incorrect dns/dns-search scenarios
 """
+import itertools
 import random
 import re
 
@@ -18,7 +19,6 @@ from dockertest import subtest
 from dockertest.dockercmd import DockerCmd
 from dockertest.output import mustpass, mustfail
 from dockertest.images import DockerImage
-import itertools
 
 
 class run_dns(subtest.Subtest):

--- a/subtests/docker_cli/run_sigproxy/run_sigproxy.py
+++ b/subtests/docker_cli/run_sigproxy/run_sigproxy.py
@@ -73,9 +73,9 @@ class sigproxy_base(SubSubtest):
         else:
             subargs = []
         subargs.append(name)
-        container = AsyncDockerCmd(self, 'attach', subargs)
-        self.sub_stuff['container_cmd'] = container  # overwrites finished cmd
-        container.execute()
+        c_attach = AsyncDockerCmd(self, 'attach', subargs)
+        self.sub_stuff['container_cmd'] = c_attach  # overwrites finished cmd
+        c_attach.execute()
 
     def init_test_specific_variables(self):
         raise NotImplementedError("Test specific variables has to be "

--- a/subtests/docker_cli/start/simple.py
+++ b/subtests/docker_cli/start/simple.py
@@ -13,12 +13,12 @@ postprocess:
 7) analyze results
 """
 
+from autotest.client.shared import utils
 from dockertest import config, subtest
 from dockertest.containers import DockerContainers
 from dockertest.dockercmd import AsyncDockerCmd, DockerCmd
 from dockertest.output import mustpass, mustfail
 from dockertest.images import DockerImage
-from autotest.client.shared import utils
 
 
 class simple(subtest.SubSubtest):

--- a/subtests/docker_cli/start/start.py
+++ b/subtests/docker_cli/start/start.py
@@ -53,10 +53,8 @@ class start_base(SubSubtest):
     def initialize(self):
         super(start_base, self).initialize()
         config.none_if_empty(self.config)
-        dc = DockerContainers(self)
-        self.sub_stuff["conts_obj"] = dc
-        dc = DockerContainersRunOnly(self)
-        self.sub_stuff["con_ro_obj"] = dc
+        self.sub_stuff["conts_obj"] = DockerContainers(self)
+        self.sub_stuff["con_ro_obj"] = DockerContainersRunOnly(self)
 
         self.sub_stuff["image_name"] = None
         self.sub_stuff["container"] = None

--- a/subtests/docker_cli/tag/change_registry.py
+++ b/subtests/docker_cli/tag/change_registry.py
@@ -13,10 +13,10 @@ clean
 4. remote tagged image from local repo.
 """
 
-from tag import change_tag
-from dockertest.images import DockerImage
 import random
 import string
+from tag import change_tag
+from dockertest.images import DockerImage
 
 
 class change_registry(change_tag):

--- a/subtests/docker_cli/tag/change_repository.py
+++ b/subtests/docker_cli/tag/change_repository.py
@@ -13,9 +13,9 @@ clean
 4. remote tagged image from local repo.
 """
 
-from tag import change_tag
-from dockertest.images import DockerImage
 from autotest.client import utils
+from dockertest.images import DockerImage
+from tag import change_tag
 
 
 class change_repository(change_tag):

--- a/subtests/docker_cli/tag/change_user.py
+++ b/subtests/docker_cli/tag/change_user.py
@@ -13,9 +13,9 @@ clean
 4. remote tagged image from local repo.
 """
 
-from tag import change_tag
-from dockertest.images import DockerImage
 from autotest.client import utils
+from dockertest.images import DockerImage
+from tag import change_tag
 
 
 class change_user(change_tag):


### PR DESCRIPTION
Fedora 24 migration hassles: pylint is now 1.5.5-1.fc24
(was: 1.4.3-2.fc22) and it has oodles of new errors, some
of them helpful, most not. These are fixed where possible:

   C0411,C0412 -- order of import statements is important (PEP8)
   R0204       -- Redefinition of x from type <t1> to <t2>

A few are disabled with pylint comments, as are some new
E1101 and E1136 errors that look like false positives to me.

Signed-off-by: Ed Santiago <santiago@redhat.com>