### PR TITLE
failif_not_in() : allow multiple needles

### DIFF
--- a/dockertest/subtestbase.py
+++ b/dockertest/subtestbase.py
@@ -146,7 +146,9 @@ class SubBase(object):
         being contained in a larger string, e.g. to look for XYZ in a
         command's stdout/stderr.
 
-        :param needle: the string you're looking for
+        :param needle: the string you're looking for. May be a list of
+                       multiple strings separated by '|' and optional
+                       whitespace, e.g. 'needle | fiddle | doo wah diddy'
         :param haystack: the actual string, e.g stdout results from a command
         :param description: description of haystack, e.g. 'stdout from foo'
         :raise DockerTestFail: if needle is not found in haystack
@@ -155,8 +157,15 @@ class SubBase(object):
             description = 'string'
         if needle in haystack:
             return
-        raise DockerTestFail("Expected string '%s' not in %s '%s'"
-                             % (needle, description, haystack))
+        expect_s = "Expected string '%s'" % needle
+        if '|' in needle:
+            needles = [n.strip() for n in needle.split('|')]
+            expect_s = "Expected strings %s" % needles
+            for subneedle in needles:
+                if subneedle.strip() in haystack:
+                    return
+        raise DockerTestFail("%s not in %s '%s'" %
+                             (expect_s, description, haystack))
 
     @classmethod
     def log_x(cls, lvl, msg, *args):

--- a/dockertest/subtestbase_unittests.py
+++ b/dockertest/subtestbase_unittests.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+
+# Pylint runs from a different directory, it's fine to import this way
+# pylint: disable=W0403
+
+import os
+import sys
+import types
+from unittest2 import TestCase, main
+
+
+###############################################################################
+# BEGIN boilerplate crap needed for subtests, which should be refactored
+
+# DO NOT allow this function to get loose in the wild!
+def mock(mod_path):
+    """
+    Recursivly inject tree of mocked modules from entire mod_path
+    """
+    name_list = mod_path.split('.')
+    child_name = name_list.pop()
+    child_mod = sys.modules.get(mod_path, types.ModuleType(child_name))
+    if len(name_list) == 0:  # child_name is left-most basic module
+        if child_name not in sys.modules:
+            sys.modules[child_name] = child_mod
+        return sys.modules[child_name]
+    else:
+        # New or existing child becomes parent
+        recurse_path = ".".join(name_list)
+        parent_mod = mock(recurse_path)
+        if not hasattr(sys.modules[recurse_path], child_name):
+            setattr(parent_mod, child_name, child_mod)
+            # full-name also points at child module
+            sys.modules[mod_path] = child_mod
+        return sys.modules[mod_path]
+
+
+class DockerTestFail(Exception):
+
+    """ Fake class for errors """
+    pass
+
+# Mock module and exception class in one stroke
+setattr(mock('xceptions'), 'DockerTestFail', DockerTestFail)
+
+# END   boilerplate crap needed for subtests, which should be refactored
+###############################################################################
+
+# In each of these, the left-hand string(s) will be present at right.
+expect_pass = [
+    ['a',        'a'],
+    ['a',        'aa'],
+    ['a',        'abc'],
+    ['a',        'cba'],
+    ['a|a',      'a'],
+    ['a | a',    'a'],
+    ['string',   'ceci nest pas une string'],
+    ['no|yes',   'googlyeyes'],
+    ['no | yes', 'googlyeyes'],
+    ['needle',   'needle in a haystack'],
+    ['needle',   'haystack with a needle in the middle'],
+    ['needle',   'haystack with, at end, a needle'],
+]
+
+# The left-hand string(s) will NOT be in the right
+expect_fail = [
+    ['a',         'b'],
+    ['needle',    'haystack'],
+    ['a|b|c',     'd'],
+    ['a | b | c', 'd'],
+    ['a | a | a', 'b'],
+]
+
+
+class TestFailIfNotIn(TestCase):
+    """
+    Tests for failif_not_in()
+    """
+    pass
+
+
+# Generate tests for each case:
+#  https://stackoverflow.com/questions/32899/how-to-generate-dynamic-parametrized-unit-tests-in-python
+def test_generator_pass(needle, haystack):
+    def test(self):
+        import subtestbase
+        subtestbase.SubBase.failif_not_in(needle, haystack)
+    return test
+
+
+def test_generator_fail(needle, haystack):
+    def test(self):
+        import subtestbase
+        self.assertRaises(DockerTestFail,
+                          subtestbase.SubBase.failif_not_in,
+                          needle, haystack)
+    return test
+
+if __name__ == '__main__':
+    for t in expect_pass:
+        test_name = filter(lambda c: c.isalpha() or c == '_',
+                           'test_%s__in__%s' % (t[0], t[1]))
+        test_ref = test_generator_pass(t[0], t[1])
+        setattr(TestFailIfNotIn, test_name, test_ref)
+
+    for t in expect_fail:
+        test_name = filter(lambda c: c.isalpha() or c == '_',
+                           'test_%s__not_in__%s' % (t[0], t[1]))
+        test_ref = test_generator_fail(t[0], t[1])
+        setattr(TestFailIfNotIn, test_name, test_ref)
+
+    main()

--- a/run_unittests.sh
+++ b/run_unittests.sh
@@ -10,13 +10,13 @@ do
 done
 wait %- &> /dev/null
 RET=$?
-while [ "$RET" -ne "127" ]
+while [ $RET -ne 127 ]
 do
+    if [ $RET -ne 0 ]; then exit $RET; fi
+
     sleep "0.1s"
     wait %- &> /dev/null
     RET=$?
-
-    if [ $RET -ne 0 -a $RET -ne 127 ]; then exit $RET; fi
 done
 
 # Tests below need to include autotest modules; make sure we can access them.


### PR DESCRIPTION
failif_not_in(needle, haystack) now allows needle to be
a pipe-separated list of possibilities. The idea is to
allow support for multiple docker versions:

   foo.ini:
   expected_stderr = this is what docker-1.10 says
                   | docker-1.12 says something completely different

Since it's getting complicated, add new unit tests.

Also: run_unittests wrapper: bug fix: we were ignoring error
exit status from the first test to exit.

Signed-off-by: Ed Santiago <santiago@redhat.com>