### PR TITLE
refactor: make wait_for_ready() reusable

### DIFF
--- a/dockertest/dockercmd.py
+++ b/dockertest/dockercmd.py
@@ -334,7 +334,7 @@ class AsyncDockerCmd(DockerCmdBase):
                                          stdin=stdin, close_fds=True)
         return self.cmdresult
 
-    def wait_for_ready(self, timeout=None, timestep=0.2):
+    def wait_for_ready(self, cid=None, timeout=None, timestep=0.2):
         """
         Monitor the output of a container (including docker logs, in
         case stdout is detached), waiting for the string 'READY'. Return
@@ -348,9 +348,10 @@ class AsyncDockerCmd(DockerCmdBase):
             if 'READY' in self.stdout:
                 return
             # Also check docker logs
-            cid = self.container_id
+            if cid is None:
+                cid = self.container_id
             if cid is not None:
-                logs = DockerCmd(self.subtest, 'logs', [self.container_id])
+                logs = DockerCmd(self.subtest, 'logs', [cid])
                 logs.execute()
                 if 'READY' in logs.stdout:
                     return

--- a/dockertest/dockercmd.py
+++ b/dockertest/dockercmd.py
@@ -345,7 +345,8 @@ class AsyncDockerCmd(DockerCmdBase):
         end_time = time.time() + timeout
         while time.time() <= end_time:
             time.sleep(timestep)
-            if 'READY' in self.stdout:
+            stdout = self.stdout
+            if 'READY' in stdout:
                 return
             # Also check docker logs
             if cid is None:
@@ -353,7 +354,8 @@ class AsyncDockerCmd(DockerCmdBase):
             if cid is not None:
                 logs = DockerCmd(self.subtest, 'logs', [cid])
                 logs.execute()
-                if 'READY' in logs.stdout:
+                stdout = logs.stdout
+                if 'READY' in stdout:
                     return
 
         # Never saw READY. Did container exit? If so, help user understand why
@@ -370,11 +372,7 @@ class AsyncDockerCmd(DockerCmdBase):
 
         # Container still running. Must be a timeout.
         msg = "Timed out waiting for container READY"
-        stdout = self.stdout
         if stdout:
-            # Juuuuuuust in case it appeared since we last checked
-            if 'READY' in stdout:
-                return
             msg += "; stdout='%s'" % stdout
         raise DockerExecError(msg)
 

--- a/subtests/docker_cli/run_sigproxy/run_sigproxy.py
+++ b/subtests/docker_cli/run_sigproxy/run_sigproxy.py
@@ -99,7 +99,7 @@ class sigproxy_base(SubSubtest):
         else:
             self._init_container_normal(name)
         cmd = self.sub_stuff['container_cmd']
-        cmd.wait_for_ready(timeout=self.config['wait_start'])
+        cmd.wait_for_ready(cid=name, timeout=self.config['wait_start'])
         # Prepare the "sigproxy" command
         kill_sigs = [int(sig) for sig in self.config['kill_signals'].split()]
         self.sub_stuff['kill_signals'] = kill_sigs


### PR DESCRIPTION
Other subtests (e.g. kill and possibly run_cidfile) are
experiencing spurious failures that look suspiciously like
the race condition that prompted wait_for_ready() in
run_sigproxy, i.e. we may be starting tests on containers
that aren't fully running yet.

This moves wait_for_ready() into a method of AsyncDockerCmd.
It's kind of complicated because we need to determine our
own container's ID, and that's not trivial or robust, but
for our purposes I think it's safe enough.

There is no corresponding method for DockerCmd, because it
only makes sense if invoked with --detach, and even in that
case there's no sane way to get the container ID.

In order to keep things simple, this is purely a refactor
with no extra functionality. If this code is acceptable, I'll
follow up with PRs for other failing tests.

Signed-off-by: Ed Santiago <santiago@redhat.com>