### PR TITLE
start/simple subtest: extend 'docker logs' timeout

### DIFF
--- a/config_defaults/subtests/docker_cli/start.ini
+++ b/config_defaults/subtests/docker_cli/start.ini
@@ -17,8 +17,6 @@ docker_timeout = 60
 missing_msg = o such
 #: modifies the running container options
 run_options_csv = --interactive=true
-docker_attach = no
-docker_interactive = no
 
 [docker_cli/start/short_term_app]
 run_cmd = ls -l /etc

--- a/subtests/docker_cli/start/simple.py
+++ b/subtests/docker_cli/start/simple.py
@@ -23,13 +23,8 @@ from dockertest.images import DockerImage
 
 class simple(subtest.SubSubtest):
 
-    def _init_stuff(self):
-        """ Initialize stuff """
-        self.sub_stuff['container_name'] = None     # name of the container
-
     def initialize(self):
         super(simple, self).initialize()
-        self._init_stuff()
         config.none_if_empty(self.config)
         # Get free name
         docker_containers = DockerContainers(self)
@@ -38,7 +33,6 @@ class simple(subtest.SubSubtest):
 
     def _start_container(self, name):
         """ Create, store in self.sub_stuff and execute container """
-        self.sub_stuff['container_name'] = name
         if self.config.get('run_options_csv'):
             subargs = [arg for arg in
                        self.config['run_options_csv'].split(',')]
@@ -52,27 +46,29 @@ class simple(subtest.SubSubtest):
         subargs.append("'echo STARTED: $(date); while :; do sleep 0.1; done'")
         container = AsyncDockerCmd(self, 'run', subargs)
         container.execute()
-        utils.wait_for(lambda: container.stdout.startswith("STARTED"), 5,
-                       step=0.1)
+        ok = utils.wait_for(lambda: container.stdout.startswith("STARTED"), 9,
+                            step=0.1)
+        self.failif(not ok, "Timed out waiting for STARTED from container.\n"
+                    "Output: '%s'" % container.stdout)
 
     def run_once(self):
         # Execute the start command
         super(simple, self).run_once()
         name = self.sub_stuff['container_name']
-        err_msg = ("Start of the %s container failed, but '%s' message is not "
-                   "in the output:\n%s")
-        # Nonexisting container
-        missing_msg = self.config['missing_msg']
+        # Container does not yet exist; 'start' should fail.
         result = mustfail(DockerCmd(self, "start", [name]).execute(), 1)
-        self.failif(missing_msg not in str(result), err_msg
-                    % ("non-existing", missing_msg, result))
+        self.failif_not_in(self.config['missing_msg'], str(result),
+                           "'docker start <nonexistent container>' failed"
+                           " (as expected), but docker error message did not"
+                           " include expected diagnostic.")
 
-        # Running container
+        # Now run the container. The first "start" here should be a NOP.
         self._start_container(name)
         result = mustpass(DockerCmd(self, "start", [name]).execute())
 
-        # Stopped container
+        # Stop container, then restart it.
         mustpass(DockerCmd(self, "kill", [name]).execute())
+        mustpass(DockerCmd(self, "wait", [name]).execute(), 137)
         result = mustpass(DockerCmd(self, "start", [name]).execute())
 
     def postprocess(self):
@@ -80,11 +76,9 @@ class simple(subtest.SubSubtest):
         name = self.sub_stuff['container_name']
         logs = AsyncDockerCmd(self, "logs", ['-f', name])
         logs.execute()
-        utils.wait_for(lambda: logs.stdout.count("\n") == 2, 5, step=0.1)
-        out = logs.stdout
-        self.failif(out.count("\n") != 2, "The container was executed twice, "
-                    "there should be 2 lines with start dates, but is "
-                    "%s.\nContainer output:\n%s" % (out.count("\n"), out))
+        ok = utils.wait_for(lambda: logs.stdout.count("\n") == 2, 20, step=0.1)
+        self.failif(not ok, "Timed out waiting for second STARTED message.\n"
+                    "Output: '%s'" % logs.stdout)
         mustpass(DockerCmd(self, "kill", [name]).execute())
 
     def cleanup(self):


### PR DESCRIPTION
'docker logs -f' doesn't seem to be real-time: in simple
manual tests, I've seen it take 15 seconds for the STARTED
message to appear in the docker logs output. This is, I
believe, what causes the start/simple test to fail seemingly
at random on some runs. FWIW 'docker logs' (without the -f)
has no such lag. I don't know if this is a stdout buffering
issue or if -f is implemented by sleep-check (vs select).

Workaround: call `docker logs` directly, in a loop, waiting for
two STARTEDs.

Also: removed unused code and config settings, cleaned up
some confusing comments.

Signed-off-by: Ed Santiago <santiago@redhat.com>