### PR TITLE
get tests working under docker 1.12

### DIFF
--- a/config_defaults/subtests/docker_cli/kill.ini
+++ b/config_defaults/subtests/docker_cli/kill.ini
@@ -6,7 +6,7 @@ wait_start = 3
 run_options_csv = --attach=stdout
 subsubtests = random_num_ttyoff,random_name_ttyoff,run_sigproxy_ttyoff,attach_sigproxy_ttyoff
 #: which signals should not be used (uncatchable signals)
-skip_signals = 9 17 19 27 18 20
+skip_signals = 9 13 17 18 19 20 27
 #: checking output produced by signal
 check_stdout = Received %%s, ignoring...
 #: range of used signals

--- a/config_defaults/subtests/docker_cli/kill_stress.ini
+++ b/config_defaults/subtests/docker_cli/kill_stress.ini
@@ -6,7 +6,7 @@ wait_start = 3
 run_options_csv = --attach=stdout
 subsubtests = stress_ttyoff,run_sigproxy_stress_ttyoff,attach_sigproxy_stress_ttyoff
 #: which signals should not be used (uncatchable signals)
-skip_signals = 9 17 19 27 18 20
+skip_signals = 9 13 17 18 19 20 27
 #: checking output produced by signal
 check_stdout = Received %%s, ignoring...
 #: range of used signals

--- a/config_defaults/subtests/docker_cli/negativeusage.ini
+++ b/config_defaults/subtests/docker_cli/negativeusage.ini
@@ -30,7 +30,7 @@ stdout =
 [docker_cli/negativeusage/op1]
 subcmd = attach
 subarg = --no-stdin,--sig-proxy
-stderr = docker: "attach" requires 1 argument.
+stderr = "(docker )?attach" requires( exactly)? 1 argument
 extcmd = 1
 
 [docker_cli/negativeusage/op2]
@@ -47,7 +47,7 @@ stderr = Unable to find image|is not a valid repository/tag
 [docker_cli/negativeusage/if1]
 subcmd = commit
 subarg = --authormessage,%%(STPCNTR)s,%%(NOFQIN)s
-stderr = flag provided but not defined
+stderr = flag provided but not defined|unknown flag: --authormessage
 
 [docker_cli/negativeusage/ov1]
 subcmd = load
@@ -57,7 +57,7 @@ stderr = flag needs an argument
 [docker_cli/negativeusage/iv1]
 subcmd = attach
 subarg = --no-stdin=sig-proxy
-stderr = invalid boolean value "sig-proxy" for  --no-stdin
+stderr = invalid boolean value "sig-proxy" for  --no-stdin|invalid argument "sig-proxy" for --no-stdin=sig-proxy
 
 [docker_cli/negativeusage/iv3]
 subcmd = run
@@ -90,7 +90,7 @@ extcmd = 125
 
 [docker_cli/negativeusage/ip1]
 subcmd = tag
-subarg = --force,%%(RUNCNTR)s,%%(NOFQIN)s
+subarg = %%(RUNCNTR)s,%%(NOFQIN)s
 stderr = no such id:
 extcmd = 1
 

--- a/config_defaults/subtests/docker_cli/run_cgroup_parent.ini
+++ b/config_defaults/subtests/docker_cli/run_cgroup_parent.ini
@@ -3,4 +3,4 @@ subsubtests = run_cgroup_parent_invalid_name,run_cgroup_parent_path,run_cgroup_p
 
 [docker_cli/run_cgroup_parent/run_cgroup_parent_invalid_name]
 #: Regex describing the error message we expect. Passed to re.match().
-expect_stderr = (docker: )?Error response from daemon: cgroup-parent for systemd cgroup should be a valid slice named as "xxx.slice"\.
+expect_stderr = .*Error response from daemon: cgroup-parent for systemd cgroup should be a valid slice named as "xxx.slice"\.

--- a/subtests/docker_cli/login/login.py
+++ b/subtests/docker_cli/login/login.py
@@ -161,6 +161,9 @@ class login_base(SubSubtest):
         """
         if password is None:
             password = self.sub_stuff['passwd']
+        # FIXME: --email option is deprecated in 1.12, and will be
+        # removed in 1.13. We still need it for <= 1.10; otherwise
+        # docker prompts from stdin, and we hang.
         dc = DockerCmd(self, 'login', ['--username', self.sub_stuff['user'],
                                        '--password', password,
                                        '--email', 'nobody@redhat.com',
@@ -258,8 +261,6 @@ class login_fail(login_base):
         cmdresult = self.sub_stuff['cmdresult']
         OutputGood(cmdresult, ignore_error=True)
         mustfail(cmdresult, 1)
-        self.failif_not_in("no successful auth challenge", cmdresult.stderr,
-                           "stderr from failed docker login")
         self.failif_not_in("401 Unauthorized", cmdresult.stderr,
                            "stderr from failed docker login")
 

--- a/subtests/docker_cli/tag/tag.py
+++ b/subtests/docker_cli/tag/tag.py
@@ -203,3 +203,10 @@ class double_tag_force(double_tag):
         # Difference from parent is that we use --force, and should pass
         self.sub_stuff['force_tag'] = True
         self.expect_pass(True)
+
+        # -f option removed in docker 1.12
+        try:
+            DockerVersion().require_server("1.12")
+            self.expect_pass(False)
+        except xceptions.DockerTestNAError:
+            pass

--- a/subtests/docker_cli/top/runsleep.py
+++ b/subtests/docker_cli/top/runsleep.py
@@ -33,8 +33,8 @@ class runsleep(base):
         OutputGood(self.sub_stuff['run_dkrcmd'].cmdresult)
         OutputGood(self.sub_stuff['top_dkrcmd'].cmdresult)
         pstable = TextTable(self.sub_stuff['top_dkrcmd'].stdout)
-        self.failif_ne(len(pstable), 1)
+        self.failif_ne(len(pstable), 1, "Number of rows returned by top")
         psrow = pstable[0]
-        self.failif_ne(psrow['USER'], 'root')
-        self.failif(int(psrow['PID']) == 1)
-        self.failif_ne(psrow['COMMAND'], self.COMMAND)
+        self.failif_ne(psrow['USER'], 'root', 'Expected user')
+        self.failif(int(psrow['PID']) == 1, 'Process PID is 1')
+        self.failif_ne(psrow['COMMAND'], self.COMMAND, 'Expected command')


### PR DESCRIPTION
 - kill, kill_stress: docker now silently ignores SIGPIPE
   (see docker commit 55a367d), so passthrough (--sig-proxy)
   no longer works. Add it to the skip list.
 - negativeusage:
   - ip1: remove --force option from tag. Option no longer
     exists in docker 1.12, and it isn't necessary in 1.10
   - error message changes.
 - run_cgroup_parent: allow any prefix before error (docker,
   docker-current, /usr/bin/docker-current, etc)
 - login: error message changes. "no successful auth challenge"
   is gone. "401 Unauthorized" remains, and that's good enough.
 - login: add a FIXME noting that the --email option to login
   is now deprecated
 - tag: -f (force) option removed in 1.12
 - top: better diagnostics

Signed-off-by: Ed Santiago <santiago@redhat.com>