### PR TITLE
More fixes for race conditions

### DIFF
--- a/config_defaults/subtests/docker_cli/kill.ini
+++ b/config_defaults/subtests/docker_cli/kill.ini
@@ -18,7 +18,7 @@ kill_map_signals = false
 #: maximal acceptable delay caused by stress command
 stress_cmd_timeout = 5
 #: modifies the container command
-exec_cmd = 'for NUM in `seq 1 64`; do trap "echo Received $NUM, ignoring..." $NUM; done; while :; do sleep 0.1; done'
+exec_cmd = 'for NUM in `seq 1 64`; do trap "echo Received $NUM, ignoring..." $NUM; done; echo READY; while :; do sleep 0.1; done'
 #: allows you to force given sequence of signals
 signals_sequence =
 #: used kill command (``false`` -> ``docker kill $name``;

--- a/config_defaults/subtests/docker_cli/kill_stopped.ini
+++ b/config_defaults/subtests/docker_cli/kill_stopped.ini
@@ -18,7 +18,7 @@ kill_map_signals = false
 #: maximal acceptable delay caused by stress command
 stress_cmd_timeout = 5
 #: modifies the container command
-exec_cmd = 'for NUM in `seq 1 64`; do trap "echo Received $NUM, ignoring..." $NUM; done; while :; do sleep 0.1; done'
+exec_cmd = 'for NUM in `seq 1 64`; do trap "echo Received $NUM, ignoring..." $NUM; done; echo READY; while :; do sleep 0.1; done'
 #: allows you to force given sequence of signals
 signals_sequence =
 #: used kill command (``false`` -> ``docker kill $name``;

--- a/subtests/docker_cli/kill/kill_utils.py
+++ b/subtests/docker_cli/kill/kill_utils.py
@@ -129,7 +129,8 @@ class kill_base(subtest.SubSubtest):
         else:
             self._init_container_normal(name)
 
-        time.sleep(self.config['wait_start'])
+        cmd = self.sub_stuff['container_cmd']
+        cmd.wait_for_ready(timeout=self.config['wait_start'])
 
         # Prepare the "kill" command
         if self.config.get('kill_options_csv'):

--- a/subtests/docker_cli/kill_stopped/kill_utils.py
+++ b/subtests/docker_cli/kill_stopped/kill_utils.py
@@ -129,7 +129,8 @@ class kill_base(subtest.SubSubtest):
         else:
             self._init_container_normal(name)
 
-        time.sleep(self.config['wait_start'])
+        cmd = self.sub_stuff['container_cmd']
+        cmd.wait_for_ready(timeout=self.config['wait_start'])
 
         # Prepare the "kill" command
         if self.config.get('kill_options_csv'):

--- a/subtests/docker_cli/kill_stress/kill_utils.py
+++ b/subtests/docker_cli/kill_stress/kill_utils.py
@@ -129,7 +129,8 @@ class kill_base(subtest.SubSubtest):
         else:
             self._init_container_normal(name)
 
-        time.sleep(self.config['wait_start'])
+        cmd = self.sub_stuff['container_cmd']
+        cmd.wait_for_ready(timeout=self.config['wait_start'])
 
         # Prepare the "kill" command
         if self.config.get('kill_options_csv'):


### PR DESCRIPTION
 - kill subtest: use new wait_for_ready()
 - run_cidfile subtest: allow time for container to
   appear in 'docker ps' output. Also, document a
   rare and hard-to-fix SIGPIPE.

Signed-off-by: Ed Santiago <santiago@redhat.com>