### PR TITLE
Pre-pull test images to save subsubtest timeout

### DIFF
--- a/control
+++ b/control
@@ -580,6 +580,9 @@ class StepInit(Context, collections.Callable):
         self.items += [Step(uri, self) for uri in posttest_uris]
         # TIMEOUT is a global defined at top of module
         self.step_timeout = float(TIMEOUT) / float(len(subtest_uris) + 1)
+        # Presume most tests will use no-more than half of their timeout
+        self.step_timeout *= 1.5
+        logging.info("Subtest timeout set to %0.4fs" % self.step_timeout)
         # This is incremented by steps, reset for execution
         self.index = 0
 

--- a/control
+++ b/control
@@ -378,7 +378,7 @@ class ControlINI(ConfigParser.SafeConfigParser, Singleton):
                 version, subthing = groups[0:2]
                 # Version is optional (and not currently used) but
                 # contains a trailing ':' that needs pruning
-                if version[-1] == ':':
+                if version and version[-1] == ':':
                     version = version[:-1]
                 # Multiple bugs may be associated with a subthing
                 bzs = result.get(subthing, [])

--- a/dockertest/containers.py
+++ b/dockertest/containers.py
@@ -200,7 +200,12 @@ class DockerContainers(object):
     def __init__(self, subtest, timeout=None, verbose=False):
         if timeout is None:
             # Defined in [DEFAULTS] guaranteed to exist
-            self.timeout = subtest.config['docker_timeout']
+            cfgto = subtest.config['docker_timeout']
+            self.timeout = float(cfgto)
+            if self.timeout != cfgto:
+                subtest.logwarning("Configured docker_timeout value '%s' did "
+                                   "not automatically converted to an "
+                                   "int/float by the config module." % cfgto)
         else:
             # config() auto-converts otherwise catch non-float convertible
             self.timeout = float(timeout)

--- a/dockertest/images.py
+++ b/dockertest/images.py
@@ -340,7 +340,12 @@ class DockerImages(object):
     def __init__(self, subtest, timeout=None, verbose=False):
         if timeout is None:
             # Defined in [DEFAULTS] guaranteed to exist
-            self.timeout = subtest.config['docker_timeout']
+            cfgto = subtest.config['docker_timeout']
+            self.timeout = float(cfgto)
+            if self.timeout != cfgto:
+                subtest.logwarning("Configured docker_timeout value '%s' did "
+                                   "not automatically converted to an "
+                                   "int/float by the config module." % cfgto)
         else:
             # config() auto-converts otherwise catch non-float convertible
             self.timeout = float(timeout)

--- a/pretests/docker_test_images/docker_test_images.py
+++ b/pretests/docker_test_images/docker_test_images.py
@@ -1,0 +1,80 @@
+r"""
+Summary
+---------
+
+Pre-testing pulling and listing of test image(s) into sysinfo results
+
+Operational Summary
+----------------------
+
+#. Parse the default test image into FQIN format
+#. Pull the default, and any configured ``extra_fqins_csv`` images
+#. Log a listing of all current images to debug and a sysinfo file
+#. Optionally, update ``config_defaults/defaults.ini`` (if it exists)
+   to preserve all pulled images.  Configured by ``update_defaults_ini``
+   option (default: False)
+
+Prerequisites
+---------------
+
+The default image and any ``extra_fqins_csv`` images exist and are pull-able
+within the testing timeout period.  If it is to be updated with pulled images,
+the file ``config_defaults/defaults.ini`` must exist.
+"""
+
+import os.path
+from dockertest.subtest import Subtest
+from dockertest.images import DockerImages
+from dockertest.dockercmd import DockerCmd
+from dockertest.config import get_as_list
+from dockertest.config import CONFIGCUSTOMS
+from dockertest.config import ConfigSection
+
+
+class docker_test_images(Subtest):
+    """Pull, then log a listing of docker images present on system"""
+
+    def initialize(self):
+        super(docker_test_images, self).initialize()
+        self.stuff['di'] = di = DockerImages(self)
+        extra_fqins_csv = self.config.get('extra_fqins_csv', '')
+        update_defaults_ini = self.config.get('update_defaults_ini', False)
+        self.stuff['defaults_ini'] = os.path.join(CONFIGCUSTOMS,
+                                                  'defaults.ini')
+        defaults_ini_exists = os.path.isfile(self.stuff['defaults_ini'])
+        self.stuff['update'] = update_defaults_ini and defaults_ini_exists
+        self.stuff['fqins'] = [di.default_image] + get_as_list(extra_fqins_csv)
+
+    def run_once(self):
+        super(docker_test_images, self).run_once()
+        for fqin in self.stuff['fqins']:
+            self.loginfo("Pulling %s", fqin)
+            # TODO: Support pulling/verifying with atomic command
+            DockerCmd(self, 'pull', [fqin]).execute()
+
+    def postprocess(self):
+        super(docker_test_images, self).postprocess()
+        # File in top-level 'results/default/sysinfo' directory
+        with open(os.path.join(self.job.sysinfo.sysinfodir,
+                               'docker_images'), 'wb') as info_file:
+            for img in self.stuff['di'].list_imgs():
+                info_file.write("%s\n" % str(img))
+                self.loginfo(str(img))
+        # Hopefully not a TOCTOU race with initialize()
+        if self.stuff['update'] and self.stuff['fqins']:
+            # These /are/ the customized defaults, don't re-default them
+            cfgsec = ConfigSection(dict(), 'DEFAULTS')
+            # This may not exist
+            if cfgsec.has_option('preserve_fqins'):
+                preserve_fqins = get_as_list(cfgsec.get('preserve_fqins'))
+            else:
+                preserve_fqins = []
+            self.logdebug("Old preserve_fqins: %s", preserve_fqins)
+            # Update the existing list
+            preserve_fqins += self.stuff['fqins']
+            # Convert back to CSV, value still in memory only
+            cfgsec.set('preserve_fqins', ",".join(preserve_fqins))
+            # This will get picked up when next test executes
+            cfgsec.merge_write(open(self.stuff['defaults_ini'], 'wb'))
+            self.loginfo("Updated preserve_fqins: %s",
+                         cfgsec.get('preserve_fqins'))


### PR DESCRIPTION
It's easier for subtests to timeout if they're required to pull the test
image across a network of unknown capacity.  However, no test here is
exercizing network bandwidth, so any pull-related timeouts are failures
to be avoided.

The default control file does not impose the global timeout onto
pretests.  Add a pre-test that pulls the default testing image, and
optionally additional images.  Also optionally (default: False) update
the config_custom/defaults.ini file (if it exists) with these images.

Finally, log information about all images that exist on the system into
the sysinfo results directory.  This makes it easy to find the initial
repository state of the system, including image ID's.

Signed-off-by: Chris Evich <cevich@redhat.com>