### PR TITLE
Fix diff test for blocked dir removal

### DIFF
--- a/config_defaults/subtests/docker_cli/diff.ini
+++ b/config_defaults/subtests/docker_cli/diff.ini
@@ -18,5 +18,5 @@ command = /bin/chmod,777,/home
 files_changed = C,/home
 
 [docker_cli/diff/diff_delete]
-command = /bin/rm,-rf,/usr/bin
-files_changed = D,/usr/bin,C,/usr
+command = /bin/rm,/usr/bin/echo
+files_changed = D,/usr/bin/echo,C,/usr/bin


### PR DESCRIPTION
In case the /usr/bin directory is blocked from removal (due to mounts
most likely), just remove a file instead.

Signed-off-by: Chris Evich <cevich@redhat.com>