### PR TITLE
Race condition fix: stop test

### DIFF
--- a/config_defaults/subtests/docker_cli/stop.ini
+++ b/config_defaults/subtests/docker_cli/stop.ini
@@ -1,7 +1,7 @@
 [docker_cli/stop]
 docker_timeout = 60
 #: delay before this test starts using created containers
-wait_start = 3
+wait_start = 10
 #: modifies the docker run options
 run_options_csv = --rm,--attach=stdout
 #: modifies the docker stop options
@@ -20,24 +20,24 @@ subsubtests = nice,force,stopped,zerotime
 
 [docker_cli/stop/nice]
 check_stdout = Received SIGTERM, finishing
-exec_cmd = "trap 'echo %(check_stdout)s; exit' SIGTERM; while :; do sleep 1; done"
+exec_cmd = "trap 'echo %(check_stdout)s; exit' SIGTERM; echo READY; while :; do sleep 1; done"
 stop_duration = 2
 
 [docker_cli/stop/force]
 check_stdout = SIGTERM ignored
-exec_cmd = "trap 'echo %(check_stdout)s' SIGTERM; while :; do sleep 1; done"
+exec_cmd = "trap 'echo %(check_stdout)s' SIGTERM; echo READY; while :; do sleep 1; done"
 stop_duration = 12
 docker_exit_code = 137
 
 [docker_cli/stop/stopped]
 check_stdout =
-exec_cmd = "true"
+exec_cmd = "echo READY"
 run_options_csv = --attach=stdout
 stop_duration = 2
 
 [docker_cli/stop/zerotime]
 check_stdout = Received SIGTERM, finishing
-exec_cmd = "trap 'echo %(check_stdout)s; exit' SIGTERM; while :; do sleep 1; done"
+exec_cmd = "trap 'echo %(check_stdout)s; exit' SIGTERM; echo READY; while :; do sleep 1; done"
 stop_options_csv = --time=0
 stop_duration = 2
 check_output_inverted = true

--- a/subtests/docker_cli/stop/stop.py
+++ b/subtests/docker_cli/stop/stop.py
@@ -52,7 +52,7 @@ class stop_base(SubSubtest):
         container = AsyncDockerCmd(self, 'run', subargs)
         self.sub_stuff['container_cmd'] = container
         container.execute()
-        time.sleep(self.config['wait_start'])
+        container.wait_for_ready(timeout=self.config['wait_start'])
         # Prepare the "stop" command
         if self.config.get('stop_options_csv'):
             subargs = [arg for arg in


### PR DESCRIPTION
Another few hours lost to a transient failure. On two of my
virts, for reasons I don't understand, docker image spinup
is taking many seconds. More than the 'sleep 3' previously
hardcoded in the stop test. Solution: switch to wait_for_ready()
instead of hardcoded sleep. And, since I'm seeing lots of
these sort of timeouts, make it 10 seconds.

Signed-off-by: Ed Santiago <santiago@redhat.com>