### PR TITLE
Bump up some wait_for_ready timeouts

### DIFF
--- a/config_defaults/subtests/docker_cli/kill.ini
+++ b/config_defaults/subtests/docker_cli/kill.ini
@@ -1,7 +1,7 @@
 [docker_cli/kill]
 docker_timeout = 60
-#: how long to wait before using the container
-wait_start = 3
+#: how long to wait for READY signal from container
+wait_start = 10
 #: modifies the ``docker run`` options
 run_options_csv = --attach=stdout
 subsubtests = random_num_ttyoff,random_name_ttyoff,run_sigproxy_ttyoff,attach_sigproxy_ttyoff

--- a/config_defaults/subtests/docker_cli/kill_stopped.ini
+++ b/config_defaults/subtests/docker_cli/kill_stopped.ini
@@ -1,7 +1,7 @@
 [docker_cli/kill_stopped]
 docker_timeout = 60
-#: how long to wait before using the container
-wait_start = 3
+#: how long to wait for READY signal from container
+wait_start = 10
 #: modifies the ``docker run`` options
 run_options_csv = --attach=stdout
 subsubtests = sigstop,sigstop_ttyoff,sigstop_sigproxy_ttyoff

--- a/config_defaults/subtests/docker_cli/kill_stress.ini
+++ b/config_defaults/subtests/docker_cli/kill_stress.ini
@@ -1,7 +1,7 @@
 [docker_cli/kill_stress]
 docker_timeout = 60
-#: how long to wait before using the container
-wait_start = 3
+#: how long to wait for READY signal from container
+wait_start = 10
 #: modifies the ``docker run`` options
 run_options_csv = --attach=stdout
 subsubtests = stress_ttyoff,run_sigproxy_stress_ttyoff,attach_sigproxy_stress_ttyoff

--- a/config_defaults/subtests/docker_cli/run_sigproxy.ini
+++ b/config_defaults/subtests/docker_cli/run_sigproxy.ini
@@ -1,7 +1,7 @@
 [docker_cli/run_sigproxy]
 docker_timeout = 60
-#: how long to wait before using the container
-wait_start = 3
+#: how long to wait for READY signal from container
+wait_start = 10
 subsubtests = default,tty_on_proxy_on,tty_on_proxy_off,tty_off_proxy_on,tty_off_proxy_off,attach_default,attach_tty_on_proxy_on,attach_tty_on_proxy_off,attach_tty_off_proxy_on,attach_tty_off_proxy_off
 #: Workaround of the problem with missing signals
 #: BUG: This workaround puts sleep between kill signals (RH bugzilla #1096269)


### PR DESCRIPTION
From 3-5s to 10s. Most of the time these subtests pass just fine,
but once in a while they fail while waiting for READY. This could
just be system load, I don't know what causes it. But extending
the timeout doesn't hurt, because wait_for_ready() triggers as
soon as the container issues READY -- it's not a sleep, we're
not wasting those 10 seconds. And with this extension we should
see fewer false alarms, which means less wasted developer time.

Signed-off-by: Ed Santiago <santiago@redhat.com>