### PR TITLE
Functionality for restarting docker daemon

### DIFF
--- a/config_defaults/intratests.ini
+++ b/config_defaults/intratests.ini
@@ -1,5 +1,5 @@
 [garbage_check]
-subsubtests = containers,images,nones
+subsubtests = containers,images,nones,config
 #: If leftover images / containers are found, they should be removed.
 remove_garbage = yes
 #: If images / containers exist after attempted removal, fail the test

--- a/dockertest/docker_daemon.py
+++ b/dockertest/docker_daemon.py
@@ -8,9 +8,8 @@ Docker Daemon interface helpers and utilities
 import httplib
 import socket
 import json
-from autotest.client.shared import service
+import os
 from autotest.client import utils
-from output import wait_for_output
 
 
 class ClientBase(object):
@@ -112,51 +111,136 @@ class SocketClient(ClientBase):
 # Group of utils for managing docker daemon service.
 
 
-def start(docker_path, docker_args):
+def _which_docker():
     """
-    Start new docker daemon with special args.
+    Returns 'docker' or 'docker-latest' based on setting in
+    /etc/sysconfig/docker.
 
-    :param docker_path: Full path to executable
-    :param docker_args: List of string of command-line arguments to pass
-    :returns: Opaque daemon_process object (not for direct use)
+    Warning: this is not a reliable method. /etc/sysconfig/docker defines
+    the docker *client*; it is perfectly possible for a system to use
+    docker as client and docker-latest as daemon or vice-versa. It's
+    possible, but unsupported, so we're not going to worry about it.
     """
-    # _SpecificServiceManager creates it's methods during __init__()
-    if service.get_name_of_init() == "systemd":
-        # pylint: disable=E1101
-        utils.run("systemctl stop docker.socket", ignore_status=True)
-    service.SpecificServiceManager("docker").stop()  # pylint: disable=E1101
-    cmd = [docker_path]
-    cmd += docker_args
-
-    daemon_process = utils.AsyncJob(" ".join(cmd), close_fds=True)
-    return daemon_process
+    docker = 'docker'
+    with open('/etc/sysconfig/docker', 'r') as docker_sysconfig:
+        for line in docker_sysconfig:
+            if line.startswith('DOCKERBINARY='):
+                if 'docker-latest' in line:
+                    docker = 'docker-latest'
+    return docker
 
 
-def output_match(daemon_process,
-                 timeout=120,
-                 regex=r"-job acceptconnections\(\) = OK \(0\)"):
+def _systemd_action(action):
+    utils.run("systemctl %s %s.service" % (action, _which_docker()))
+    # FIXME: check status
+
+
+def stop():
+    """ stop the docker daemon """
+    _systemd_action('stop')
+
+
+def start():
+    """ start the docker daemon """
+    _systemd_action('start')
+
+
+def restart():
+    """ restart the docker daemon """
+    _systemd_action('restart')
+
+
+def _preserved_extension():
     """
-    Return True if daemon_process output matches regex within timeout period
-
-    :param daemon_process: Opaque daemon_process object (not for direct use)
-    :param regex: Regular expression to search for
-    :param timeout: Maximum time to wait before returning False
+    File extension (including dot) used for our backup files
     """
-    return wait_for_output(daemon_process.get_stderr,
-                           regex,
-                           timeout=timeout)
+    return '.docker-autotest-preserved'
 
 
-def restart_service(daemon_process=None):
+def assert_pristine_environment():
     """
-    Restart the docker service using host OS's service manager
-
-    :param daemon_process: Opaque daemon_process object (not for direct use)
+    Barf if there are any leftover .docker-autotest-preserved files
+    in /etc/sysconfig; this would indicate that a previous test
+    failed to clean up properly, and our system is in an
+    undefined state.
     """
-    if daemon_process:
-        daemon_process.kill_func()
-        daemon_process.wait_for(10)
-    # _SpecificServiceManager creates it's methods during __init__()
-    if service.get_name_of_init() == "systemd":
-        utils.run("systemctl start docker.socket", ignore_status=True)
-    service.SpecificServiceManager("docker").start()  # pylint: disable=E1101
+    for suffix in ['', '-latest']:
+        path = '/etc/sysconfig/docker%s%s' % (suffix, _preserved_extension())
+        if os.path.exists(path):
+            raise RuntimeError("Leftover backup file: %s. System is"
+                               " in undefined state! Please examine that"
+                               " and its original file; if appropriate,"
+                               " mv it back into place." % path)
+
+
+def edit_options_file(remove=None, add=None):
+    """
+    Write a new /etc/sysconfig/docker* file with new OPTIONS string.
+    Preserve the original.
+
+    :param remove: string or list of strings - option(s) to remove from line
+    :param add: string or list of strings - option(s) to add to line
+    """
+    sysconfig_file = '/etc/sysconfig/%s' % _which_docker()
+    sysconfig_bkp = sysconfig_file + _preserved_extension()
+    if os.path.exists(sysconfig_bkp):
+        raise RuntimeError("Backup file already exists: %s" % sysconfig_bkp)
+    sysconfig_tmp = sysconfig_file + '.tmp'
+    with open(sysconfig_file, 'r') as sysconfig_fh_in:
+        with open(sysconfig_tmp, 'w') as sysconfig_fh_out:
+            for line in sysconfig_fh_in:
+                if line.startswith('OPTIONS='):
+                    line = edit_options_string(line, remove=remove, add=add)
+                sysconfig_fh_out.write(line)
+    os.link(sysconfig_file, sysconfig_bkp)
+    os.rename(sysconfig_tmp, sysconfig_file)
+
+
+def edit_options_string(line, remove=None, add=None):
+    """
+    Helper for edit_options_file(). Given an OPTIONS='...' string,
+    returns OPTIONS='...'\n with the given options removed and/or added.
+
+    :param line: string of the form OPTIONS='something'
+    :param remove: string or list of strings - option(s) to remove from line
+    :param add: string or list of strings - option(s) to add to line
+    """
+    if not line.startswith('OPTIONS='):
+        raise ValueError("input line does not start with OPTIONS= : %s" % line)
+    line = line[8:].rstrip()
+    quote = ''
+    if line[0] == '"' or line[0] == "'":
+        quote = line[0]
+        if line[-1] != quote:
+            raise ValueError("mismatched quotes in %s" % line)
+        line = line[1:-1]
+    if remove:
+        removes = remove if isinstance(remove, list) else [remove]
+        for remove_opt in removes:
+            if remove_opt in line:
+                line = line.replace(remove_opt, '')
+    if add:
+        adds = add if isinstance(add, list) else [add]
+        for add_opt in adds:
+            if add_opt not in line:
+                line = line + ' ' + add_opt
+    return 'OPTIONS=%s%s%s\n' % (quote, line.strip(), quote)
+
+
+def revert_options_file():
+    """
+    Revert back to preserved /etc/sysconfig/docker* file.
+
+    This function is safe to invoke even if the preserved file doesn't
+    exist; the only situation in which that makes sense is in a test's
+    cleanup() method if test prep has failed before edit_options_file().
+
+    Note that we automatically invoke restart(): there is no possible
+    situation in which it makes sense to revert options without restarting
+    docker daemon.
+    """
+    sysconfig_file = '/etc/sysconfig/%s' % _which_docker()
+    sysconfig_bkp = sysconfig_file + _preserved_extension()
+    if os.path.exists(sysconfig_bkp):
+        os.rename(sysconfig_bkp, sysconfig_file)
+        restart()

--- a/intratests/garbage_check/garbage_check.py
+++ b/intratests/garbage_check/garbage_check.py
@@ -25,6 +25,7 @@ from dockertest.containers import DockerContainers
 from dockertest.images import DockerImage
 from dockertest.images import DockerImages
 from dockertest.config import get_as_list
+from dockertest.docker_daemon import assert_pristine_environment
 
 
 class DockerImageIncomplete(DockerImage):
@@ -285,3 +286,10 @@ class nones(Base):
                 self.logwarning(fail_images)
             else:
                 self.failif(fail_images, fail_images)
+
+
+class config(Base):
+
+    def postprocess(self):
+        super(config, self).run_once()
+        assert_pristine_environment()


### PR DESCRIPTION
...including possibly editing run options. Tricky bits:

  - determining docker vs docker-latest
  - preserving a backup of original system options
  - making sure we restore that when done
  - making double-sure, in gc, that we leave no trace

Signed-off-by: Ed Santiago <santiago@redhat.com>