### PR TITLE
docker_switch: docker-current <-> docker-latest

### DIFF
--- a/config_defaults/control.ini
+++ b/config_defaults/control.ini
@@ -15,7 +15,7 @@ include =
 # in addition to any specified by --args x=<csv> sub-option.
 # e.g. "docker_cli/run,docker_cli/attach/no_stdin"
 exclude = example,subexample,pretest_example,intratest_example,
-          posttest_example
+          posttest_example, redhat/docker_switch
 
 # Subtests/Sub-subtest to consider for inclusion before
 # consulting include/exclude (above).

--- a/subtests/redhat/docker_switch/docker_switch.py
+++ b/subtests/redhat/docker_switch/docker_switch.py
@@ -1,0 +1,76 @@
+r"""
+Summary
+---------
+
+Textual description of *what* this subtest and/or sub-subtests
+will exercize in general terms.  The next section describes the
+general operations that will be performed (i.e. **how** they
+will be tested).
+
+Operational Summary
+----------------------
+
+#. Summary of step one
+#. Summary of step two
+#. Summary of step three
+
+Operational Detail
+--------------------
+
+Example test, nothing detailed about it.
+
+Prerequisites
+---------------
+
+This example test does not require anything other than
+Autotest, Docker autotest, and this file.
+"""
+
+from dockertest import subtest
+
+
+class docker_switch(subtest.Subtest):
+    iterations = 3
+    stuff = None  # Will turn into empty dictionary, store private data here
+
+    def initialize(self):
+        """
+        Called every time the test is run, first thing.
+        """
+        super(docker_switch, self).initialize()  # Prints out basic info
+        # Do Something useful here, store run_once input in 'stuff'
+
+    def setup(self):
+        """
+        Called once per version change, after initialize()
+        """
+        super(docker_switch, self).setup()  # Prints out basic info
+        # Do Something useful here
+
+    def run_once(self):
+        """
+        Called to run test, after initialize/setup
+        """
+        super(docker_switch, self).run_once()  # Prints out basic info
+        # Do Something useful here, store results in 'stuff'
+
+    def postprocess_iteration(self):
+        """
+        Called to process each iteration of run_once()
+        """
+        super(docker_switch, self).postprocess_iteration()  # Prints out basic info
+        # Do Something useful here, check 'stuff' for iteration-errors
+
+    def postprocess(self):
+        """
+        Called to process all results after all postprocess_iteration()'s
+        """
+        super(docker_switch, self).postprocess()  # Prints out basic info
+        # Do Something useful here, check 'stuff' for overall errors
+
+    def cleanup(self):
+        """
+        Always called, after all other methods
+        """
+        super(docker_switch, self).cleanup()  # Prints out basic info
+        # Do Something useful here, leave environment as we received it


### PR DESCRIPTION
This pair of sub-subtests simply switches back and forth between
docker-current and docker-latest (in RHEL and CentOS).  Then after
restarting the docker daemon, it confirms the version change. This test
is intended for use along with a customized sequence of other tests.
There is no provison made for recovering the system if the one of these
tests fail.  Therefor, both tests are disabled/excluded by default.

Signed-off-by: Chris Evich cevich@redhat.com
