### PR TITLE
Replace run_ping with run_install

### DIFF
--- a/config_defaults/subtests/docker_cli/run.ini
+++ b/config_defaults/subtests/docker_cli/run.ini
@@ -1,5 +1,5 @@
 [docker_cli/run]
-subsubtests = run_true,run_false,run_interactive,run_attach_stdout,run_remote_tag,run_names,run_tmpfs,run_passwd,run_ping
+subsubtests = run_true,run_false,run_interactive,run_attach_stdout,run_remote_tag,run_names,run_tmpfs,run_passwd,run_install
 #: The most basic sub-subtests can be generated from a generic
 #: class at runtime, set 'yes' to enable this feature.
 generate_generic = no
@@ -19,7 +19,6 @@ exit_status = 0
 [docker_cli/run/run_true]
 generate_generic = yes
 cmd = /bin/true
-exit_status = 0
 
 [docker_cli/run/run_false]
 generate_generic = yes
@@ -31,15 +30,6 @@ generate_generic = yes
 #: String to search for with ``grep`` (see ``cmd`` option value)
 expected_status = "Password set"
 cmd = 'passwd --status root | grep -qv %(expected_status)s'
-exit_status = 0
-
-[docker_cli/run/run_ping]
-generate_generic = yes
-__example__ = ping_url
-#: Host to ping
-ping_url = www.google.com
-cmd = 'ping -c 10 -q %(ping_url)s'
-exit_status = 0
 
 [docker_cli/run/run_names]
 cmd = sleep 2s
@@ -52,14 +42,12 @@ run_append_name = no
 last_name_sticks = yes
 #: The number of ``--name`` options to generate for the command line.
 names_count = 1000
-exit_status = 0
 
 [docker_cli/run/run_tmpfs]
 #: --tmpfs parameter
 tmpfs_path = /run
 run_options_csv = --tmpfs,%(tmpfs_path)s
-cmd = findmnt -n -t tmpfs %(tmpfs_path)s
-exit_status = 0
+cmd = 'findmnt -n -t tmpfs %(tmpfs_path)s'
 
 [docker_cli/run/run_interactive]
 run_options_csv = --interactive,--rm
@@ -75,7 +63,6 @@ secret_sauce = 4c93bb78d98f
 # Yes it's ugly / crude, but it's simple and works in all but most
 # heavily loaded cases.
 cmd = 'sleep 5s && echo "%(secret_sauce)s"'
-exit_status = 0
 
 [docker_cli/run/run_remote_tag]
 #: Change this to an image remotely available within test environment
@@ -85,3 +72,9 @@ docker_timeout = 60
 remote_image_fqin = stackbrew/centos:7
 run_options_csv =
 cmd = /bin/true
+
+[docker_cli/run/run_install]
+#: Full command to execute which installs something inside the container
+install_cmd = yum install --disablerepo="*" --enablerepo="base" --assumeyes yajl
+#: Full command to run in commited container to verify installation
+verify_cmd = bash -c "echo '[{}]' | json_verify -q"

--- a/subtests/docker_cli/run/run_install.py
+++ b/subtests/docker_cli/run/run_install.py
@@ -1,0 +1,33 @@
+from run import run_base
+from dockertest.dockercmd import DockerCmd
+from dockertest.output.validate import mustpass
+
+
+class run_install(run_base):
+    """Verify installing packages in a container is functional"""
+
+    def init_subargs(self):
+        cont = self.sub_stuff['cont']
+        # Name will be used for image, must be lower-case
+        self.sub_stuff['name'] = name = cont.get_unique_name().lower()
+        self.sub_stuff['subargs'] += ["--name %s" % name,
+                                      self.sub_stuff['fqin'],
+                                      self.config['install_cmd']]
+
+    def postprocess(self):
+        super(run_install, self).postprocess()
+
+        name = self.sub_stuff['name']
+        # ancestor method must have been successful
+        self.sub_stuff['containers'].append(name)
+
+        # images with same names as containers are confusing
+        eman = name[-1::-1]  # the name, backwards
+        mustpass(DockerCmd(self, 'commit',
+                           [name, "%s:latest" % eman]).execute())
+        # mustpass() was successful
+        self.sub_stuff['images'].append(name)
+
+        eman = name[-1::-1]  # committed image
+        subargs = ['-i', '--rm', eman, self.config['verify_cmd']]
+        mustpass(DockerCmd(self, 'run', subargs).execute())


### PR DESCRIPTION
With some base images (those lacking iputils), the run_ping test must
perform two operations.  Both are required for the sub-subtest to
pass, which can make it difficult to identify higher-level repo. /
install problems vs ping-related problems.

This commit adds a new sub-subtest, and a new option ``install_cmd``.  When
non-empty, this command will be logically ANDed along with ``cmd``.
A simplistic check for ``bash -c`` was added since ``&&`` is
shell-specific.

The new ``run_install`` test uses the ``install_cmd`` twice.  Once to
verify that installation works, including with existing packages.
The run_ping test was updated to use this option instead of jamming both
commands together on it's own.  Though the eventual docker command is
unchanged, it makes the configuration cleaner and more modular.

Signed-off-by: Chris Evich <cevich@redhat.com>