### PR TITLE
Remove failing --tmpfs tests

### DIFF
--- a/config_defaults/subtests/docker_cli/negativeusage.ini
+++ b/config_defaults/subtests/docker_cli/negativeusage.ini
@@ -1,5 +1,5 @@
 [docker_cli/negativeusage]
-subsubtests = op1, op2, op3, if1, ov1, iv1, iv3, iv4, iv5, iv6, iv7, ip1
+subsubtests = op1, op2, op3, if1, ov1, iv1, iv3, iv4, ip1
 #: Optional docker subcommand (string). Automatically generated substitution keys:{n}
 #: {n}
 #: {t} * ``%%(FQIN)s`` **-** valid, default test image name{n}
@@ -69,24 +69,6 @@ subcmd = run
 subarg = -e,PATH=/tmp,%%(FQIN)s,true
 stderr = exec\: \"true\"\: executable file not found in \$PATH
 extcmd = 127
-
-[docker_cli/negativeusage/iv5]
-subcmd = run
-subarg = --tmpfs,/dev,%%(FQIN)s
-stderr =  no such file or directory
-extcmd = 127
-
-[docker_cli/negativeusage/iv6]
-subcmd = run
-subarg = --tmpfs,:rw,%%(FQIN)s
-stderr =  open /proc/self/task/1/attr/exec: no such file or directory
-extcmd = 125
-
-[docker_cli/negativeusage/iv7]
-subcmd = run
-subarg = --tmpfs,.,%%(FQIN)s
-stderr =  Message: Failed to open /dev/null - open /dev/null: permission denied
-extcmd = 125
 
 [docker_cli/negativeusage/ip1]
 subcmd = tag


### PR DESCRIPTION
PR 608 added three tests for invalid use of --tmpfs. All three
turned out to be fragile: docker-1.12 fails in a different
manner than 1.10. After an hour's effort I'm unable to come up
with any equivalent tests that fail similarly in 1.10 & 1.12,
so it seems best to just remove them entirely. There is still
an actual test for --tmpfs functionality.

Signed-off-by: Ed Santiago <santiago@redhat.com>