### PR TITLE
Fix bzexclude

### DIFF
--- a/control
+++ b/control
@@ -445,7 +445,7 @@ class ControlINI(ConfigParser.SafeConfigParser, Singleton):
         log_list(logging.info,
                  "Sub/sub-subtests blocked by bugzillas:",
                  bug_blocked.items())
-        self.set('Bugzilla', 'exclude',
+        self.set('Bugzilla', 'excluded',
                  ", ".join(bug_blocked.keys()))
         return bug_blocked
 

--- a/dockertest/subtest.py
+++ b/dockertest/subtest.py
@@ -11,7 +11,6 @@ loading the specified configuration section (see `configuration module`_)
 # Pylint runs from a different directory, it's fine to import this way
 # pylint: disable=W0403
 
-import logging
 import tempfile
 import os.path
 import imp
@@ -246,6 +245,8 @@ class SubSubtest(subtestbase.SubBase):
         """
         Form subsubtest configuration by inheriting parent subtest config
         """
+        # Many branches needed to keep this method compact
+        # pylint: disable=R0912
         subsubtest_config = all_configs.get(name, {})
         # don't redefine the module
         _config = copy.deepcopy(parent_config)  # a copy

--- a/dockertest/subtest.py
+++ b/dockertest/subtest.py
@@ -211,7 +211,6 @@ class SubSubtest(subtestbase.SubBase):
         self.config_section = self.make_name(pscs)
         # Allow child to inherit and override parent config
         all_configs = config.Config()
-        # make_subsubtest_config will modify this
         parent_config = self.parent_subtest.config
         # subsubtest config is optional, overrides parent.
         if self.config_section not in all_configs:
@@ -281,16 +280,6 @@ class SubSubtest(subtestbase.SubBase):
             else:
                 _config[key] = val
         return _config
-
-    def make_subsubtest_config(self, all_configs, parent_config,
-                               subsubtest_config):
-        """
-        Deprecated, use make_config() instead, will be removed soon
-        """
-        del subsubtest_config  # not used
-        logging.warning("SubSubtest.make_subsubtest_config() is deprecated!")
-        self.config = self.make_config(all_configs, parent_config,
-                                       self.config_section)
 
 
 class SubSubtestCaller(Subtest):


### PR DESCRIPTION
All sub-subtests defined in a subtest's ``subsubtests`` config.
option must have corresponding config. sections.  However, if a
sub-subtest is excluded by an open bugzilla, the code assumes
it's configuration section must exist.  This is not always the
case, esp. if the excluded sub-subtest was removed from config.

Introduce a new property that grants access to only the exclusions
returned by bugzilla (if any).  During initialization of either
"caller" subtest, refrain from including these bugzilla excluded
items in the subsubtest_names attribute.