### PR TITLE
results2junit: handle repeated test calls

### DIFF
--- a/results2junit
+++ b/results2junit
@@ -70,6 +70,7 @@ class TestSuite(object):
             testcase = TestCase(result, self.name)
             self.add_testcase(testcase)
 
+        self._indicate_multi_test_runs()
         self._consolidate_garbage_checks()
 
     def add_testcase(self, testcase):
@@ -80,16 +81,25 @@ class TestSuite(object):
         self.testcases.append(testcase)
 
         # Differentiate repeated runs of the same test, e.g. info(2), info(3)
-        if testcase.name in self.testname_count:
-            self.testname_count[testcase.name] += 1
-            if testcase.name != 'garbage_check':
-                testcase.name += '(%d)' % self.testname_count[testcase.name]
-        else:
-            self.testname_count[testcase.name] = 1
+        if testcase.name not in self.testname_count:
+            self.testname_count[testcase.name] = 0
+        self.testname_count[testcase.name] += 1
 
         self.count['tests'] += 1
         if testcase.category in self.count:
             self.count[testcase.category] += 1
+
+    def _indicate_multi_test_runs(self):
+        """
+        Append '(N)' to all tests that are run more than once
+        """
+        for name, count in self.testname_count.items():
+            if count > 1 and name != 'garbage_check':
+                seq = 1
+                for tc in self.testcases:
+                    if tc.name == name:
+                        tc.name += '(%d)' % seq
+                        seq += 1
 
     def _consolidate_garbage_checks(self):
         for i, tc in enumerate(self.testcases):

--- a/results2junit
+++ b/results2junit
@@ -183,6 +183,12 @@ class TestCase(object):
         self.time = result['run_time']
         self.set_status(result)
 
+        # *Sob*. Jenkins intercepts URLs ending in '/run', redirecting them
+        # to a non-useful page. This makes it impossible to view failures
+        # in the run test. Workaround: use a different name in junit. Ugh.
+        if self.name == 'run':
+            self.name = 'docker_run'
+
     def set_status(self, result):
         """
         Sets category and message based on result status (good, error, etc)

--- a/results2junit
+++ b/results2junit
@@ -65,6 +65,7 @@ class TestSuite(object):
         parsed_time = time.localtime(overall['timestamp'])
         self.timestamp = time.strftime('%Y-%m-%d', parsed_time)
         self.testcases = []
+        self.testname_count = {}
         for result in self.results:
             testcase = TestCase(result, self.name)
             self.add_testcase(testcase)
@@ -77,6 +78,14 @@ class TestSuite(object):
         of tests, number of failures/errors/skipped).
         """
         self.testcases.append(testcase)
+
+        # Differentiate repeated runs of the same test, e.g. info(2), info(3)
+        if testcase.name in self.testname_count:
+            self.testname_count[testcase.name] += 1
+            if testcase.name != 'garbage_check':
+                testcase.name += '(%d)' % self.testname_count[testcase.name]
+        else:
+            self.testname_count[testcase.name] = 1
 
         self.count['tests'] += 1
         if testcase.category in self.count:

--- a/results2junit
+++ b/results2junit
@@ -183,12 +183,6 @@ class TestCase(object):
         self.time = result['run_time']
         self.set_status(result)
 
-        # *Sob*. Jenkins intercepts URLs ending in '/run', redirecting them
-        # to a non-useful page. This makes it impossible to view failures
-        # in the run test. Workaround: use a different name in junit. Ugh.
-        if self.name == 'run':
-            self.name = 'docker_run'
-
     def set_status(self, result):
         """
         Sets category and message based on result status (good, error, etc)

--- a/results2junit
+++ b/results2junit
@@ -95,7 +95,7 @@ class TestSuite(object):
         for i, tc in enumerate(self.testcases):
             if tc.name == 'garbage_check':
                 tc.classname = self.testcases[i-1].classname
-                tc.name = self.testcases[i-1].name + '--garbage-check'
+                tc.name = self.testcases[i-1].name + ' [garbage check]'
 
     def write_xml(self, outfile):
         """

--- a/test_results2junit.d/03multitest/results.junit
+++ b/test_results2junit.d/03multitest/results.junit
@@ -1,0 +1,15 @@
+<testsuites>
+    <testsuite name="03multitest" timestamp="2016-11-30" failures="0" tests="8" skipped="0" errors="0">
+        <properties>
+            <property name="input_name" value="03multitest"/>
+        </properties>
+        <testcase classname="03multitest.pretests" name="docker_test_images" time="2"/>
+        <testcase classname="03multitest.subtests.docker_cli" name="info" time="2"/>
+        <testcase classname="03multitest.subtests.docker_cli" name="info--garbage-check" time="4"/>
+        <testcase classname="03multitest.subtests.docker_cli" name="info(2)" time="2"/>
+        <testcase classname="03multitest.subtests.docker_cli" name="info(2)--garbage-check" time="4"/>
+        <testcase classname="03multitest.subtests.docker_cli" name="info(3)" time="2"/>
+        <testcase classname="03multitest.subtests.docker_cli" name="info(3)--garbage-check" time="4"/>
+        <testcase classname="03multitest.posttests" name="esm_example" time="2"/>
+    </testsuite>
+</testsuites>

--- a/test_results2junit.d/03multitest/results.junit
+++ b/test_results2junit.d/03multitest/results.junit
@@ -5,11 +5,11 @@
         </properties>
         <testcase classname="03multitest.pretests" name="docker_test_images" time="2"/>
         <testcase classname="03multitest.subtests.docker_cli" name="info" time="2"/>
-        <testcase classname="03multitest.subtests.docker_cli" name="info--garbage-check" time="4"/>
+        <testcase classname="03multitest.subtests.docker_cli" name="info [garbage check]" time="4"/>
         <testcase classname="03multitest.subtests.docker_cli" name="info(2)" time="2"/>
-        <testcase classname="03multitest.subtests.docker_cli" name="info(2)--garbage-check" time="4"/>
+        <testcase classname="03multitest.subtests.docker_cli" name="info(2) [garbage check]" time="4"/>
         <testcase classname="03multitest.subtests.docker_cli" name="info(3)" time="2"/>
-        <testcase classname="03multitest.subtests.docker_cli" name="info(3)--garbage-check" time="4"/>
+        <testcase classname="03multitest.subtests.docker_cli" name="info(3) [garbage check]" time="4"/>
         <testcase classname="03multitest.posttests" name="esm_example" time="2"/>
     </testsuite>
 </testsuites>

--- a/test_results2junit.d/03multitest/results.junit
+++ b/test_results2junit.d/03multitest/results.junit
@@ -4,8 +4,8 @@
             <property name="input_name" value="03multitest"/>
         </properties>
         <testcase classname="03multitest.pretests" name="docker_test_images" time="2"/>
-        <testcase classname="03multitest.subtests.docker_cli" name="info" time="2"/>
-        <testcase classname="03multitest.subtests.docker_cli" name="info [garbage check]" time="4"/>
+        <testcase classname="03multitest.subtests.docker_cli" name="info(1)" time="2"/>
+        <testcase classname="03multitest.subtests.docker_cli" name="info(1) [garbage check]" time="4"/>
         <testcase classname="03multitest.subtests.docker_cli" name="info(2)" time="2"/>
         <testcase classname="03multitest.subtests.docker_cli" name="info(2) [garbage check]" time="4"/>
         <testcase classname="03multitest.subtests.docker_cli" name="info(3)" time="2"/>

--- a/test_results2junit.d/03multitest/status
+++ b/test_results2junit.d/03multitest/status
@@ -1,0 +1,26 @@
+START	----	----	timestamp=1480540086	localtime=Nov 30 16:08:06	
+	START	docker/pretests/docker_test_images.1_122524623	docker/pretests/docker_test_images.1_122524623	timestamp=1480540088	timeout=7200	localtime=Nov 30 16:08:08	
+		GOOD	docker/pretests/docker_test_images.1_122524623	docker/pretests/docker_test_images.1_122524623	timestamp=1480540090	localtime=Nov 30 16:08:10	completed successfully
+	END GOOD	docker/pretests/docker_test_images.1_122524623	docker/pretests/docker_test_images.1_122524623	timestamp=1480540090	localtime=Nov 30 16:08:10	
+	START	docker/subtests/docker_cli/info.2_122524623	docker/subtests/docker_cli/info.2_122524623	timestamp=1480540090	timeout=7200	localtime=Nov 30 16:08:10	
+		GOOD	docker/subtests/docker_cli/info.2_122524623	docker/subtests/docker_cli/info.2_122524623	timestamp=1480540092	localtime=Nov 30 16:08:12	completed successfully
+	END GOOD	docker/subtests/docker_cli/info.2_122524623	docker/subtests/docker_cli/info.2_122524623	timestamp=1480540092	localtime=Nov 30 16:08:12	
+	START	docker/intratests/garbage_check.2_122524623	docker/intratests/garbage_check.2_122524623	timestamp=1480540092	timeout=7200	localtime=Nov 30 16:08:12	
+		GOOD	docker/intratests/garbage_check.2_122524623	docker/intratests/garbage_check.2_122524623	timestamp=1480540096	localtime=Nov 30 16:08:16	completed successfully
+	END GOOD	docker/intratests/garbage_check.2_122524623	docker/intratests/garbage_check.2_122524623	timestamp=1480540096	localtime=Nov 30 16:08:16	
+	START	docker/subtests/docker_cli/info.3_122524623	docker/subtests/docker_cli/info.3_122524623	timestamp=1480540096	timeout=7200	localtime=Nov 30 16:08:16	
+		GOOD	docker/subtests/docker_cli/info.3_122524623	docker/subtests/docker_cli/info.3_122524623	timestamp=1480540098	localtime=Nov 30 16:08:18	completed successfully
+	END GOOD	docker/subtests/docker_cli/info.3_122524623	docker/subtests/docker_cli/info.3_122524623	timestamp=1480540098	localtime=Nov 30 16:08:18	
+	START	docker/intratests/garbage_check.3_122524623	docker/intratests/garbage_check.3_122524623	timestamp=1480540098	timeout=7200	localtime=Nov 30 16:08:18	
+		GOOD	docker/intratests/garbage_check.3_122524623	docker/intratests/garbage_check.3_122524623	timestamp=1480540102	localtime=Nov 30 16:08:22	completed successfully
+	END GOOD	docker/intratests/garbage_check.3_122524623	docker/intratests/garbage_check.3_122524623	timestamp=1480540102	localtime=Nov 30 16:08:22	
+	START	docker/subtests/docker_cli/info.4_122524623	docker/subtests/docker_cli/info.4_122524623	timestamp=1480540102	timeout=7200	localtime=Nov 30 16:08:22	
+		GOOD	docker/subtests/docker_cli/info.4_122524623	docker/subtests/docker_cli/info.4_122524623	timestamp=1480540104	localtime=Nov 30 16:08:24	completed successfully
+	END GOOD	docker/subtests/docker_cli/info.4_122524623	docker/subtests/docker_cli/info.4_122524623	timestamp=1480540104	localtime=Nov 30 16:08:24	
+	START	docker/intratests/garbage_check.4_122524623	docker/intratests/garbage_check.4_122524623	timestamp=1480540104	timeout=7200	localtime=Nov 30 16:08:24	
+		GOOD	docker/intratests/garbage_check.4_122524623	docker/intratests/garbage_check.4_122524623	timestamp=1480540108	localtime=Nov 30 16:08:28	completed successfully
+	END GOOD	docker/intratests/garbage_check.4_122524623	docker/intratests/garbage_check.4_122524623	timestamp=1480540108	localtime=Nov 30 16:08:28	
+	START	docker/posttests/esm_example.5_122524623	docker/posttests/esm_example.5_122524623	timestamp=1480540108	timeout=7200	localtime=Nov 30 16:08:28	
+		GOOD	docker/posttests/esm_example.5_122524623	docker/posttests/esm_example.5_122524623	timestamp=1480540110	localtime=Nov 30 16:08:30	completed successfully
+	END GOOD	docker/posttests/esm_example.5_122524623	docker/posttests/esm_example.5_122524623	timestamp=1480540110	localtime=Nov 30 16:08:30	
+END GOOD	----	----	timestamp=1480540110	localtime=Nov 30 16:08:30	


### PR DESCRIPTION
Chris pointed out that some ADEPT runs will invoke a particular
subtest multiple times, e.g. when testing docker vs docker-latest
or perhaps when running stress tests.

Differentiate these by keeping track of test names, and when
we encounter one we've seen before, append '(N)' to the test
name to make it unique. (Except for garbage_check).

Signed-off-by: Ed Santiago <santiago@redhat.com>