### PR TITLE
Remove individual subtest timeouts

### DIFF
--- a/control
+++ b/control
@@ -5,8 +5,6 @@ TIME = "LONG"
 TEST_TYPE = "CLIENT"
 # timeout in seconds
 TIMEOUT = 60 * 60 * 4  # 4 hours, divided among each subtest step
-# Extra multiple to apply onto each subtest to account for early-finishes
-TIMEOUT_FUDGE_FACTOR = 2
 
 import sys
 import os
@@ -580,11 +578,8 @@ class StepInit(Context, collections.Callable):
             self.items.append(subtest_step)
             self.items += [Step(uri, self, False) for uri in intratest_uris]
         self.items += [Step(uri, self) for uri in posttest_uris]
-        # TIMEOUT is a global defined at top of module
-        self.step_timeout = float(TIMEOUT) / float(len(subtest_uris) + 1)
-        # Presume most tests will use no-more than half of their timeout
-        self.step_timeout *= TIMEOUT_FUDGE_FACTOR
-        logging.info("Subtest timeout set to %0.4fs" % self.step_timeout)
+        # Let autotest enforce global timeout across all subtests
+        self.step_timeout = 0
         # This is incremented by steps, reset for execution
         self.index = 0
 


### PR DESCRIPTION
It's not possible to have a variable timeout across steps, they all need
to be defined up-front before anything runs.  This meant quick tests
disproportionately utilize their time vs long tests.  Instead, remove
the individual timeouts and fudge-factor.  Autotest will then impose the
global (``TIMEOUT``) value.  This could cause a cascade failure of all
subsequent tests, if one consumes too much time.  This could make
results hard to debug in the worst-case, but the best-case (no timeouts)
should make the run-to-run results more consistent.

Signed-off-by: Chris Evich <cevich@redhat.com>