### PR TITLE
Log docker rpm version

### DIFF
--- a/dockertest/docker_daemon.py
+++ b/dockertest/docker_daemon.py
@@ -114,7 +114,7 @@ class SocketClient(ClientBase):
 # Group of utils for managing docker daemon service.
 
 
-def _which_docker():
+def which_docker():
     """
     Returns 'docker' or 'docker-latest' based on setting in
     /etc/sysconfig/docker.
@@ -134,7 +134,7 @@ def _which_docker():
 
 
 def _systemd_action(action):
-    return utils.run("systemctl %s %s.service" % (action, _which_docker()))
+    return utils.run("systemctl %s %s.service" % (action, which_docker()))
 
 
 def stop():
@@ -197,7 +197,7 @@ def edit_options_file(remove=None, add=None):
     :param remove: string or list of strings - option(s) to remove from line
     :param add: string or list of strings - option(s) to add to line
     """
-    sysconfig_file = '/etc/sysconfig/%s' % _which_docker()
+    sysconfig_file = '/etc/sysconfig/%s' % which_docker()
     sysconfig_bkp = sysconfig_file + PRESERVED_EXTENSION
     if os.path.exists(sysconfig_bkp):
         raise RuntimeError("Backup file already exists: %s" % sysconfig_bkp)
@@ -256,7 +256,7 @@ def revert_options_file():
     situation in which it makes sense to revert options without restarting
     docker daemon.
     """
-    sysconfig_file = '/etc/sysconfig/%s' % _which_docker()
+    sysconfig_file = '/etc/sysconfig/%s' % which_docker()
     sysconfig_bkp = sysconfig_file + PRESERVED_EXTENSION
     if os.path.exists(sysconfig_bkp):
         os.rename(sysconfig_bkp, sysconfig_file)

--- a/pretests/log_versions/log_versions.py
+++ b/pretests/log_versions/log_versions.py
@@ -1,0 +1,50 @@
+r"""
+Summary
+-------
+
+Preserve docker versions in state files.
+
+Operational Summary
+-------------------
+
+#. Run 'docker version'; use DockerVersion module to parse output
+#. Run 'rpm -q docker|docker-latest' (whichever one is in use)
+#. Preserve output in sysinfo files
+
+"""
+
+import os.path
+from autotest.client import utils
+from dockertest import subtest
+from dockertest.dockercmd import DockerCmd
+from dockertest.output import DockerVersion, mustpass
+from dockertest.docker_daemon import which_docker
+
+
+class log_versions(subtest.Subtest):
+
+    def run_once(self):
+        """
+        Determine the installed version of docker, and preserve it
+        in a sysinfo file.
+        """
+        super(log_versions, self).run_once()
+        cmdresult = mustpass(DockerCmd(self, "version").execute())
+        docker_version = DockerVersion(cmdresult.stdout)
+        info = ("docker version client: %s server %s"
+                % (docker_version.client, docker_version.server))
+        self.loginfo("Found %s", info)
+        self.write_sysinfo('docker_version', info + "\n")
+        self.write_sysinfo('docker_rpm', self._docker_rpm())
+
+    def write_sysinfo(self, filename, content):
+        """
+        Write the given content to sysinfodir/filename
+        """
+        path = os.path.join(self.job.sysinfo.sysinfodir, filename)
+        with open(path, 'wb') as outfile:
+            outfile.write(content)
+
+    @staticmethod
+    def _docker_rpm():
+        return utils.run("rpm -q %s" % which_docker()).stdout

--- a/pretests/log_versions/log_versions.py
+++ b/pretests/log_versions/log_versions.py
@@ -35,7 +35,9 @@ class log_versions(subtest.Subtest):
                 % (docker_version.client, docker_version.server))
         self.loginfo("Found %s", info)
         self.write_sysinfo('docker_version', info + "\n")
-        self.write_sysinfo('docker_rpm', self._docker_rpm())
+        self.write_sysinfo('docker_rpm_active', self._rpmq(which_docker()))
+        self.write_sysinfo('docker_rpm_current', self._rpmq('docker'))
+        self.write_sysinfo('docker_rpm_latest', self._rpmq('docker-latest'))
 
     def write_sysinfo(self, filename, content):
         """
@@ -46,5 +48,5 @@ class log_versions(subtest.Subtest):
             outfile.write(content)
 
     @staticmethod
-    def _docker_rpm():
-        return utils.run("rpm -q %s" % which_docker()).stdout
+    def _rpmq(package_name):
+        return utils.run("rpm -q %s" % package_name).stdout

--- a/subtests/docker_cli/version/version.py
+++ b/subtests/docker_cli/version/version.py
@@ -18,12 +18,13 @@ None
 """
 
 import os.path
+from autotest.client import utils
 from dockertest import subtest
 from dockertest.output import OutputGood
 from dockertest.output import DockerVersion
 from dockertest.output import mustpass
 from dockertest.dockercmd import DockerCmd
-from dockertest.docker_daemon import SocketClient
+from dockertest.docker_daemon import SocketClient, which_docker
 
 
 class version(subtest.Subtest):
@@ -48,7 +49,14 @@ class version(subtest.Subtest):
         with open(os.path.join(self.job.sysinfo.sysinfodir,
                                'docker_version'), 'wb') as info_file:
             info_file.write("%s\n" % info)
+        with open(os.path.join(self.job.sysinfo.sysinfodir,
+                               'docker_rpm'), 'wb') as rpm_file:
+            rpm_file.write(self._docker_rpm())
         self.verify_version(docker_version)
+
+    @staticmethod
+    def _docker_rpm():
+        return utils.run("rpm -q %s" % which_docker()).stdout
 
     def verify_version(self, docker_version):
         # TODO: Make URL to daemon configurable

--- a/subtests/docker_cli/version/version.py
+++ b/subtests/docker_cli/version/version.py
@@ -17,14 +17,12 @@ Prerequisites
 None
 """
 
-import os.path
-from autotest.client import utils
 from dockertest import subtest
 from dockertest.output import OutputGood
 from dockertest.output import DockerVersion
 from dockertest.output import mustpass
 from dockertest.dockercmd import DockerCmd
-from dockertest.docker_daemon import SocketClient, which_docker
+from dockertest.docker_daemon import SocketClient
 
 
 class version(subtest.Subtest):
@@ -43,20 +41,7 @@ class version(subtest.Subtest):
         # Raise exception on Go Panic or usage help message
         outputgood = OutputGood(self.stuff['cmdresult'])
         docker_version = DockerVersion(outputgood.stdout_strip)
-        info = ("docker version client: %s server %s"
-                % (docker_version.client, docker_version.server))
-        self.loginfo("Found %s", info)
-        with open(os.path.join(self.job.sysinfo.sysinfodir,
-                               'docker_version'), 'wb') as info_file:
-            info_file.write("%s\n" % info)
-        with open(os.path.join(self.job.sysinfo.sysinfodir,
-                               'docker_rpm'), 'wb') as rpm_file:
-            rpm_file.write(self._docker_rpm())
         self.verify_version(docker_version)
-
-    @staticmethod
-    def _docker_rpm():
-        return utils.run("rpm -q %s" % which_docker()).stdout
 
     def verify_version(self, docker_version):
         # TODO: Make URL to daemon configurable

--- a/subtests/docker_cli/version/version.py
+++ b/subtests/docker_cli/version/version.py
@@ -41,6 +41,8 @@ class version(subtest.Subtest):
         # Raise exception on Go Panic or usage help message
         outputgood = OutputGood(self.stuff['cmdresult'])
         docker_version = DockerVersion(outputgood.stdout_strip)
+        self.loginfo("docker version client: %s server %s",
+                     docker_version.client, docker_version.server)
         self.verify_version(docker_version)
 
     def verify_version(self, docker_version):


### PR DESCRIPTION
Write a new sysinfo/docker_rpm file containing
the output of 'rpm -q docker[*]' (* - docker or
docker-latest). This requires exporting which_docker()
from dockertest.docker_daemon.

Purpose: post-run analysis can look at failures,
then cross-reference against a TBD table of known
subtest failures in specific docker builds.

Signed-off-by: Ed Santiago <santiago@redhat.com>