### PR TITLE
Configured test images exist between every test

### DIFF
--- a/intratests/docker_test_images
+++ b/intratests/docker_test_images
@@ -1,0 +1,1 @@
+../pretests/docker_test_images


### PR DESCRIPTION
It's possible that one test deletes one of the test images.  This could
leave the next test's docker command performing an implied pull.
However, some number of tests have hard-coded timeouts for specific
docker commands (like list).  This means the implied pull can easily
cause timeout errors where pulling the image is otherwise
inconsequential.  Fix this by symlinking ``docker_test_images`` from
pretests into intratests.  This way it will run before all and in-between
every test.

Signed-off-by: Chris Evich <cevich@redhat.com>