### PR TITLE
Pr653 cleanup

### DIFF
--- a/config_defaults/subtests/docker_cli/systemd.ini
+++ b/config_defaults/subtests/docker_cli/systemd.ini
@@ -1,8 +1,30 @@
 [docker_cli/systemd]
-docker_timeout = 300
-#: Systemd unit file
+subsubtests = systemd_pull, systemd_build, systemd_run
+
+[docker_cli/systemd/systemd_pull]
+#: systemd unit file
+sysd_unit_file = docker-pull.service
+#: name of an image to pull
+image_name = centos
+
+[docker_cli/systemd/systemd_build]
+#: systemd unit file
+sysd_unit_file = docker-build.service
+#: name of an image to build
+image_name = centos_p4321
+#: build options when building an image
+unit_opts = --force-rm
+#: for Dockerfile FROM variable 
+img_frm = centos:latest
+
+[docker_cli/systemd/systemd_run]
+#: systemd unit file
 sysd_unit_file = p4321.service
-#: Systemd unit file destination
-sysd_unitf_dest = /etc/systemd/system/p4321.service
-#: build image name
-name = p4321
+#: name of an image build and run
+image_name = centos_p4321
+#: unit file build options when building an image
+unit_opts = --force-rm
+#: build options 
+build_opt = %(unit_opts)s -t %(image_name)s
+#: for Dockerfile FROM variable 
+img_frm = centos:latest

--- a/config_defaults/subtests/docker_cli/systemd.ini
+++ b/config_defaults/subtests/docker_cli/systemd.ini
@@ -1,30 +1,31 @@
 [docker_cli/systemd]
 subsubtests = systemd_pull, systemd_build, systemd_run
 
+#: base image for Dockerfile. Not used in every test.
+dockerfile_base_image = centos:latest
+#: systemd unit file (basename only). Each subsubtest has a file by this
+#: name in our source dir; we copy it into /etc/systemd/system, replacing
+#: a given string `foo` inside curly braces with the corresponding `foo`
+#: config setting defined below.
+sysd_unit_file = FIXME
+
 [docker_cli/systemd/systemd_pull]
-#: systemd unit file
 sysd_unit_file = docker-pull.service
 #: name of an image to pull
 image_name = centos
 
 [docker_cli/systemd/systemd_build]
-#: systemd unit file
 sysd_unit_file = docker-build.service
 #: name of an image to build
 image_name = centos_p4321
 #: build options when building an image
 unit_opts = --force-rm
-#: for Dockerfile FROM variable 
-img_frm = centos:latest
 
 [docker_cli/systemd/systemd_run]
-#: systemd unit file
 sysd_unit_file = p4321.service
 #: name of an image build and run
 image_name = centos_p4321
 #: unit file build options when building an image
 unit_opts = --force-rm
-#: build options 
+#: build options
 build_opt = %(unit_opts)s -t %(image_name)s
-#: for Dockerfile FROM variable 
-img_frm = centos:latest

--- a/subtests/docker_cli/systemd/Dockerfile
+++ b/subtests/docker_cli/systemd/Dockerfile
@@ -1,4 +1,5 @@
-FROM centos:latest
+# The value of FROM is to be set by test from systemd.ini
+FROM {base_img}
 RUN yum install -y python && \
     yum update -y && \
     yum clean all

--- a/subtests/docker_cli/systemd/Dockerfile
+++ b/subtests/docker_cli/systemd/Dockerfile
@@ -1,8 +1,5 @@
 # The value of FROM is to be set by test from systemd.ini
-FROM {base_img}
-RUN yum install -y python && \
-    yum update -y && \
-    yum clean all
+FROM {dockerfile_base_image}
 ADD /p4321-server.py /usr/bin/
 RUN chmod 755 /usr/bin/p4321-server.py
 EXPOSE 4321

--- a/subtests/docker_cli/systemd/docker-build.service
+++ b/subtests/docker_cli/systemd/docker-build.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=docker-autotest systemd build image subtest. If you see this file on a live system it means something has failed very badly
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/docker build {options} -t {name} {dockerfiledir}
+RemainAfterExit=yes

--- a/subtests/docker_cli/systemd/docker-build.service
+++ b/subtests/docker_cli/systemd/docker-build.service
@@ -3,5 +3,5 @@ Description=docker-autotest systemd build image subtest. If you see this file on
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/docker build {options} -t {name} {dockerfiledir}
+ExecStart=/usr/bin/docker build {unit_opts} -t {image_name} {tmpdir}
 RemainAfterExit=yes

--- a/subtests/docker_cli/systemd/docker-pull.service
+++ b/subtests/docker_cli/systemd/docker-pull.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=docker-autotest systemd pull image subtest. If you see this file on a live system it means something has failed very badly
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/docker pull {name}
+RemainAfterExit=yes

--- a/subtests/docker_cli/systemd/docker-pull.service
+++ b/subtests/docker_cli/systemd/docker-pull.service
@@ -3,5 +3,5 @@ Description=docker-autotest systemd pull image subtest. If you see this file on 
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/docker pull {name}
+ExecStart=/usr/bin/docker pull {image_name}
 RemainAfterExit=yes

--- a/subtests/docker_cli/systemd/p4321.service
+++ b/subtests/docker_cli/systemd/p4321.service
@@ -2,6 +2,6 @@
 Description=docker-autotest systemd subtest. If you see this file on a live system it means something has failed very badly
 
 [Service]
-ExecStart=/usr/bin/docker run -p 4321:4321 --name p4321 p4321
-ExecStop=-/usr/bin/docker stop p4321
-ExecStop=/usr/bin/docker rm -f p4321
+ExecStart=/usr/bin/docker run -p 4321:4321 --name {name} {name}
+ExecStop=-/usr/bin/docker stop {name}
+ExecStop=/usr/bin/docker rm -f {name}

--- a/subtests/docker_cli/systemd/p4321.service
+++ b/subtests/docker_cli/systemd/p4321.service
@@ -2,6 +2,6 @@
 Description=docker-autotest systemd subtest. If you see this file on a live system it means something has failed very badly
 
 [Service]
-ExecStart=/usr/bin/docker run -p 4321:4321 --name {name} {name}
-ExecStop=-/usr/bin/docker stop {name}
-ExecStop=/usr/bin/docker rm -f {name}
+ExecStart=/usr/bin/docker run -p 4321:4321 --name {image_name} {image_name}
+ExecStop=-/usr/bin/docker stop {image_name}
+ExecStop=/usr/bin/docker rm -f {image_name}

--- a/subtests/docker_cli/systemd/systemd.py
+++ b/subtests/docker_cli/systemd/systemd.py
@@ -1,86 +1,160 @@
-"""
+r"""
 Summary
 -------
-Testing basic container as systemd service
+
+This is to test basic container as systemd service using a predefined unit
+file. Image pulling, building, and running are performed.
 
 Operational Summary
 ---------------------
-This is to test container as systemd service using a predefined unit file
-(``p4321.service``) and a ``script p4321-server.py``. An image is built with
-this script added. Systemd starts a container using this image & the container
-writes current time to port ``4321``. From host, the socket is read and the
-value is checked to see if it is a digit. Finally, container is stopped
-through systemd and system is cleaned up.
 
+#. Provided unitfile is edited & copied to ``/etc/systemd/system``.
+#. Image is pulled using unitfile
+#. Image is build using provided Dockedfile
+#. Container is started/run using unitfile
+
+Operational Detail
+----------------------
+
+systemd pull
+~~~~~~~~~~~~~~~~~
+#. Edit unitfile ``docker-pull.service`` & copy it to ``/etc/systemd/system``
+#. Systemd service is started using this file to pull an image.
+#. Systemd service is stoped and image removed
+
+systemd build
+~~~~~~~~~~~~~~~~~
+#. Edit unitfile ``docker-build.service`` & copy it to ``/etc/systemd/system``
+#. Edit Dockerfile
+#. Systemd service is started using this file to build an image.
+#. Systemd service is stoped and image removed
+
+systemd run
+~~~~~~~~~~~~~~~~~
+#. Edit unitfile ``p4321.service`` and copy to ``/etc/systemd/system``
+#. Edit ``Dockerfile`` and copy to test temporary directory
+#. Copy a script ``p4321-server.py`` to test temporary directory
+#. Built an image using the Dockerfile and script
+#. Systemd starts a container using this image
+#. The container writes current time to port ``4321``.
+#. From host, the socket is read and the value is checked
+#. Finally, container is stopped through systemd and system is cleaned up.
+
+Prerequisites
+----------------
+*  Docker daemon is running
+*  systemd unitfiles can be copied to ``/etc/systemd/system``
+*  systemd actions of start/status/stop & daemon-reload can be performed
+*  An image stated in systemd.ini can be pulled & build
 """
 
-import shutil
-import time
-import socket
-from os.path import exists
+from os.path import join
+from os import rename
 from os import unlink
+from shutil import copyfile
 from autotest.client import utils
-from autotest.client.shared.utils import is_port_free
-from dockertest.subtest import Subtest
-from dockertest.dockercmd import DockerCmd
+from dockertest.subtest import SubSubtest
+from dockertest.subtest import SubSubtestCaller
 from dockertest.images import DockerImages
-from dockertest.output import mustpass
 from dockertest.xceptions import DockerTestError
 
 
-class systemd(Subtest):
+class systemd(SubSubtestCaller):
+    pass
+
+
+class systemd_base(SubSubtest):
 
     def initialize(self):
-        super(systemd, self).initialize()
-        unit_file_srcpath = '{}{}'.format(self.bindir, '/p4321.service')
-        shutil.copyfile(unit_file_srcpath, self.config['sysd_unitf_dest'])
-        dkrcmd = DockerCmd(self, 'build', ['--force-rm -t',
-                                           self.config['name'], self.bindir])
-        mustpass(dkrcmd.execute())
+        super(systemd_base, self).initialize()
+        self.sub_stuff['bindir'] = self.parent_subtest.bindir
+        self.sub_stuff['tmpdir'] = self.tmpdir
+        unitfile = self.config['sysd_unit_file']
+        self.sub_stuff['unitf_dst'] = join('/etc/systemd/system', unitfile)
+        self.sub_stuff['tmpdirf'] = join(self.sub_stuff['tmpdir'], unitfile)
+        self.sub_stuff['dkrfl'] = join(self.sub_stuff['bindir'], 'Dockerfile')
+        copyfile(join(self.sub_stuff['bindir'], unitfile),
+                 self.sub_stuff['tmpdirf'])
 
     def run_once(self):
-        host = 'localhost'
-        port = 4321
         self.sysd_action('daemon-reload')
-        self.sysd_action('start', self.config['sysd_unit_file'])
-        utils.wait_for(lambda: not is_port_free(port, host), 10)
-        time_from_socket = self.read_socket(host, port)
-        self.failif(not time_from_socket.isdigit(),
-                    "Data received from container is non-numeric: '%s'"
-                    % time_from_socket)
+        for act in 'start', 'status':
+            self.sysd_action(act, self.config['sysd_unit_file'])
+
+    def postprocess(self):
+        super(systemd_base, self).postprocess()
+        imgs_fulname = DockerImages(self).list_imgs_full_name()
+        names_lst = [x.split(':')[0].split('/', -1)[-1] for x in imgs_fulname]
+        if self.config['image_name'] not in names_lst:
+            raise DockerTestError("Image %s is not present"
+                                  % self.config['image_name'])
 
     def cleanup(self):
-        super(systemd, self).cleanup()
-        filepath = self.config['sysd_unitf_dest']
-        if exists(filepath):
+        super(systemd_base, self).cleanup()
+        try:
             self.sysd_action('stop', self.config['sysd_unit_file'])
-            unlink(filepath)
+        except OSError:
+            pass
+        finally:
+            unlink(self.sub_stuff['unitf_dst'])
             self.sysd_action('daemon-reload')
-        DockerImages(self).clean_all([self.config['name']])
+        DockerImages(self).clean_all([self.config['image_name']])
 
     @staticmethod
-    def sysd_action(action=None, sysd_unit=None):
+    def sysd_action(action, sysd_unit=None):
         command = 'systemctl {}'.format(action)
         if sysd_unit:
             command = '{} {}'.format(command, sysd_unit)
         utils.run(command, ignore_status=False)
 
-    @staticmethod
-    def read_socket(host, port):
-        max_read_tries = 10
-        num_read_try = max_read_tries
-        while num_read_try:
-            # using timeout 13-sec as it's 1-sec longer than two DNS timeouts
-            s = socket.create_connection((host, port), 13)
-            s.settimeout(2.0)
-            try:
-                time_from_socket = s.recv(512).strip()
-                if time_from_socket:
-                    s.shutdown(socket.SHUT_RDWR)
-                    return time_from_socket
-                num_read_try -= 1
-            except socket.timeout:
-                pass
-            time.sleep(1.0)
-        raise DockerTestError("Failed to read from socket with %d tries"
-                              % max_read_tries)
+    def sed_file(self, vars_dict):
+        tmpdir_rf = self.sub_stuff['tmpdirf']
+        tmpdir_wf = '{}.tmp'.format(tmpdir_rf)
+        with open(tmpdir_rf, "r") as srcfile, open(tmpdir_wf, "w") as dstfile:
+            dstfile.write(srcfile.read().format(**vars_dict))
+        rename(tmpdir_wf, tmpdir_rf)
+
+
+class systemd_build(systemd_base):
+
+    """
+    To test building an image using systemd unitfile
+    """
+
+    def initialize(self):
+        # edit unitfile & copy it to /etc/systemd/system/
+        super(systemd_build, self).initialize()
+        build_dict = {'dockerfiledir': self.sub_stuff['bindir'],
+                      'options': self.config['unit_opts'],
+                      'name': self.config['image_name']}
+        self.sed_file(build_dict)
+        copyfile(self.sub_stuff['tmpdirf'], self.sub_stuff['unitf_dst'])
+        # copy Dockerfile to tmpdir, edit, then copy to bindir for build
+        self.sub_stuff['tmpdirf'] = join(self.sub_stuff['tmpdir'],
+                                         'Dockerfile')
+        tmpdirf = self.sub_stuff['tmpdirf']
+        self.sub_stuff['dkrfl_bk'] = '{}.bk'.format(tmpdirf)
+        for f in [tmpdirf, self.sub_stuff['dkrfl_bk']]:
+            copyfile(self.sub_stuff['dkrfl'], f)
+        dkrfl_dict = {'base_img': self.config['img_frm']}
+        self.sed_file(dkrfl_dict)
+        copyfile(tmpdirf, self.sub_stuff['dkrfl'])
+
+    def cleanup(self):
+        super(systemd_build, self).cleanup()
+        # restore Dockerfile to its initial state
+        copyfile(self.sub_stuff['dkrfl_bk'], self.sub_stuff['dkrfl'])
+
+
+class systemd_pull(systemd_base):
+
+    """
+    To test pulling an image using systemd unitfile
+    """
+
+    def initialize(self):
+        # edit unitfile & copy it to /etc/systemd/system/
+        super(systemd_pull, self).initialize()
+        pull_dict = {'name': self.config['image_name']}
+        self.sed_file(pull_dict)
+        copyfile(self.sub_stuff['tmpdirf'], self.sub_stuff['unitf_dst'])

--- a/subtests/docker_cli/systemd/systemd_run.py
+++ b/subtests/docker_cli/systemd/systemd_run.py
@@ -1,0 +1,75 @@
+"""
+To Test basic function of running container as systemd service using a
+predefined settings
+"""
+
+import time
+import socket
+from os.path import join
+from shutil import copy
+from shutil import copyfile
+from autotest.client import utils
+from autotest.client.shared.utils import is_port_free
+from dockertest.dockercmd import DockerCmd
+from dockertest.output import mustpass
+from dockertest.xceptions import DockerTestError
+from systemd import systemd_base
+
+
+class systemd_run(systemd_base):
+
+    def initialize(self):
+        # edit unitfile & copy it to /etc/systemd/system/
+        super(systemd_run, self).initialize()
+        run_dict = {'name': self.config['image_name']}
+        self.sed_file(run_dict)
+        copyfile(self.sub_stuff['tmpdirf'], self.sub_stuff['unitf_dst'])
+        # copy Dockerfile & p4321-server.py to tmpdir and edit Dockerfile
+        tmpdir = self.sub_stuff['tmpdir']
+        self.sub_stuff['tmpdirf'] = join(tmpdir, 'Dockerfile')
+        for f in 'Dockerfile', 'p4321-server.py':
+            copy(join(self.sub_stuff['bindir'], f), tmpdir)
+        dkrfl_dict = {'base_img': self.config['img_frm']}
+        self.sed_file(dkrfl_dict)
+        # build image using edited Dockerfile in tmpdir
+        dkrcmd = DockerCmd(self, 'build', [self.config['build_opt'], tmpdir])
+        mustpass(dkrcmd.execute())
+
+    def run_once(self):
+        self.sysd_action('daemon-reload')
+        self.sysd_action('start', self.config['sysd_unit_file'])
+
+    def postprocess(self):
+        super(systemd_run, self).postprocess()
+        host = 'localhost'
+        port = 4321
+        utils.wait_for(lambda: not is_port_free(port, host), 10)
+        time_from_socket = self.read_socket(host, port)
+        self.failif(not time_from_socket.isdigit(),
+                    "Data received from container is non-numeric: '%s'"
+                    % time_from_socket)
+
+    @staticmethod
+    def read_socket(host, port):
+        max_read_tries = 10
+        num_read_try = max_read_tries
+        while num_read_try:
+            # using timeout 13-sec as it's 1-sec longer than two DNS timeouts
+            skt = socket.create_connection((host, port), 13)
+            skt.settimeout(2.0)
+            try:
+                time_from_socket = skt.recv(512).strip()
+                if time_from_socket:
+                    skt.shutdown(socket.SHUT_RDWR)
+                    return time_from_socket
+                num_read_try -= 1
+            except socket.timeout:
+                pass
+            finally:
+                time.sleep(1.0)
+                try:
+                    skt.shutdown(socket.SHUT_RDWR)
+                except socket.error:
+                    pass
+        raise DockerTestError("Failed to read from socket with %d tries"
+                              % max_read_tries)

--- a/subtests/docker_cli/systemd/systemd_run.py
+++ b/subtests/docker_cli/systemd/systemd_run.py
@@ -5,9 +5,6 @@ predefined settings
 
 import time
 import socket
-from os.path import join
-from shutil import copy
-from shutil import copyfile
 from autotest.client import utils
 from autotest.client.shared.utils import is_port_free
 from dockertest.dockercmd import DockerCmd
@@ -19,25 +16,11 @@ from systemd import systemd_base
 class systemd_run(systemd_base):
 
     def initialize(self):
-        # edit unitfile & copy it to /etc/systemd/system/
         super(systemd_run, self).initialize()
-        run_dict = {'name': self.config['image_name']}
-        self.sed_file(run_dict)
-        copyfile(self.sub_stuff['tmpdirf'], self.sub_stuff['unitf_dst'])
-        # copy Dockerfile & p4321-server.py to tmpdir and edit Dockerfile
-        tmpdir = self.sub_stuff['tmpdir']
-        self.sub_stuff['tmpdirf'] = join(tmpdir, 'Dockerfile')
-        for f in 'Dockerfile', 'p4321-server.py':
-            copy(join(self.sub_stuff['bindir'], f), tmpdir)
-        dkrfl_dict = {'base_img': self.config['img_frm']}
-        self.sed_file(dkrfl_dict)
         # build image using edited Dockerfile in tmpdir
-        dkrcmd = DockerCmd(self, 'build', [self.config['build_opt'], tmpdir])
+        dkrcmd = DockerCmd(self, 'build', [self.config['build_opt'],
+                                           self.tmpdir])
         mustpass(dkrcmd.execute())
-
-    def run_once(self):
-        self.sysd_action('daemon-reload')
-        self.sysd_action('start', self.config['sysd_unit_file'])
 
     def postprocess(self):
         super(systemd_run, self).postprocess()


### PR DESCRIPTION
Remove some duplication; remove unnecessary intermediate steps
(i.e. use same variable names in .ini file and in source files;
don't edit files in-place, just transform as we copy); expand
brvtd variable names into legible ones; remove trailing whitespace;
add a missing super()

Signed-off-by: Ed Santiago <santiago@redhat.com>

