### PR TITLE
Adding a waittime parameter to start subsubtest

### DIFF
--- a/config_defaults/subtests/docker_cli/start.ini
+++ b/config_defaults/subtests/docker_cli/start.ini
@@ -1,5 +1,5 @@
 [docker_cli/start]
-subsubtests = simple,short_term_app,long_term_app,rerun_long_term_app
+subsubtests = simple, short_term_app, long_term_app, rerun_long_term_app
 #: max time to wait for container to start
 docker_start_timeout = 30.0
 #: max time to wait for container to finish (docker wait)
@@ -8,6 +8,8 @@ docker_run_timeout = 30.0
 docker_attach = yes
 #: Run interactive container -i
 docker_interactive = yes
+#: docker command wait time
+dkrcmd_waittime = 60
 #: Specifies the executed command inside the container
 run_cmd =
 
@@ -23,6 +25,8 @@ run_cmd = ls -l /etc
 
 [docker_cli/start/long_term_app]
 run_cmd = sleep 100
+dkrcmd_waittime = 105
 
 [docker_cli/start/rerun_long_term_app]
 run_cmd = sleep 100
+dkrcmd_waittime = 105

--- a/subtests/docker_cli/start/start.py
+++ b/subtests/docker_cli/start/start.py
@@ -71,7 +71,7 @@ class start_base(SubSubtest):
         self.loginfo("Starting container...")
         self.loginfo("Executing background command: %s" % dkrcmd.command)
         dkrcmd.execute()
-        dkrcmd.wait(60)
+        dkrcmd.wait(self.config['dkrcmd_waittime'])
         self.sub_stuff["dkrcmd"] = dkrcmd
 
     def complete_docker_command_line(self):


### PR DESCRIPTION
To address recent failures, I added a dkrcmd_waittime for dkrcmd.wait of start subtest to have enough time for long_term_app and rerun_long_term_app 'sleep 100' command to finish instead of bailing after 60 sec.