### PR TITLE
Addendum to #672

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *~
 *.pyc
 .*.swp
+results2junitc
 docs_build
 config_custom/*.ini
 cscope.files

--- a/config_defaults/defaults.ini
+++ b/config_defaults/defaults.ini
@@ -27,8 +27,7 @@ docker_timeout = 300.0
 #: CSV list of options recommended for customization.  Tests will
 #: issue warnings when left unmodified from default values.  **This
 #: option is compounded from defaults, not overwritten!**
-__example__ = docker_repo_name, docker_repo_tag, preserve_fqins,
-              preserve_cnames
+__example__ = docker_repo_name, docker_repo_tag, preserve_fqins
 
 #: Default registry settings for testing
 #: (blank if not applicable)

--- a/config_defaults/subtests/docker_cli/negativeusage.ini
+++ b/config_defaults/subtests/docker_cli/negativeusage.ini
@@ -64,6 +64,7 @@ subcmd = run
 subarg = -p,192.168.9.1:9000,%%(FQIN)s,/bin/true
 stderr = Invalid hostPort
 
+# Note: This exposes RH BZ 1393572 and will need updating if/when it's status changes.
 [docker_cli/negativeusage/iv4]
 subcmd = run
 subarg = -e,PATH=/tmp,%%(FQIN)s,true

--- a/config_defaults/subtests/docker_cli/run.ini
+++ b/config_defaults/subtests/docker_cli/run.ini
@@ -66,8 +66,7 @@ cmd = 'sleep 5s && echo "%(secret_sauce)s"'
 
 [docker_cli/run/run_remote_tag]
 #: Change this to an image remotely available within test environment
-__example__ = remote_image_fqin, docker_timeout
-docker_timeout = 60
+__example__ = remote_image_fqin
 #: Fully qualified image name stored on a remote registry, not local.
 remote_image_fqin = stackbrew/centos:7
 run_options_csv =

--- a/run_unittests.sh
+++ b/run_unittests.sh
@@ -1,22 +1,15 @@
 #!/bin/bash
 
+# Exit non-zero on the first error
+set -e
+
 export PYTHONPATH=$(dirname $0)
 
 echo ""
 echo ""
 for unittest in dockertest/*_unittests.py
 do
-    ${unittest} --failfast --quiet --buffer &
-done
-wait %- &> /dev/null
-RET=$?
-while [ $RET -ne 127 ]
-do
-    if [ $RET -ne 0 ]; then exit $RET; fi
-
-    sleep "0.1s"
-    wait %- &> /dev/null
-    RET=$?
+    ${unittest} --failfast --quiet --buffer
 done
 
 # Tests below need to include autotest modules; make sure we can access them.
@@ -38,7 +31,7 @@ fi
 # own discovery.
 for unittest in $(find . -name 'test_*.py' | sort); do
     echo \$ python $unittest
-    python $unittest -v || exit 1
+    python $unittest -v
 done
 
 echo ""


### PR DESCRIPTION
Fixes several test failures on the latest/greatest RHEL w/ docker-1.12.5.

The 'display failing output check in build test' commit depends on #672 being merged first.