### PR TITLE
Experimental: ignore failures in known-problem subtests

### DIFF
--- a/dockertest/subtest.py
+++ b/dockertest/subtest.py
@@ -484,14 +484,19 @@ class SubSubtestCaller(Subtest):
             why = known[fullname][docker_nvr]
             self.logwarning("Known test failure on %s: %s", docker_nvr, why)
             return True
-        # This exact NVR is not known to fail, but perhaps this is just a
-        # new build that doesn't fix a previously-known problem. Look for
-        # known failures in other builds of this N-V (name, version) and
-        # issue a heads-up if appropriate.
 
+        # This exact NVR is not known to fail. What about NV?
         def _nv(nvr):
             return nvr[:nvr.rfind('-')]
         docker_nv = _nv(docker_nvr)
+
+        if docker_nv in known[fullname]:
+            why = known[fullname][docker_nv]
+            self.logwarning("Test expected to fail on all builds of %s: %s",
+                            docker_nv, why)
+            return True
+
+        # No known failures for NVR or NV. What about other builds of same NV?
         if docker_nv in [_nv(x) for x in known[fullname]]:
             self.logwarning("This test is known to fail in other %s builds",
                             docker_nv)

--- a/dockertest/subtest.py
+++ b/dockertest/subtest.py
@@ -30,17 +30,11 @@ from xceptions import DockerTestError
 from xceptions import DockerSubSubtestNAError
 
 
-MEMO_CACHE = {}
-
-
 def docker_rpm():
     """
     Returns the full NVRA of the currently-installed docker or docker-latest
     """
-    if 'docker_rpm' not in MEMO_CACHE:
-        rpm = utils.run("rpm -q %s" % which_docker()).stdout.strip()
-        MEMO_CACHE['docker_rpm'] = rpm
-    return MEMO_CACHE['docker_rpm']
+    return utils.run("rpm -q %s" % which_docker()).stdout.strip()
 
 
 def known_failures():
@@ -50,25 +44,18 @@ def known_failures():
     whose key is docker NVRA (e.g. docker-1.12.5-8.el7.x86_64),
     value of that is a string description of the problem (e.g.
     a bz number and comment).
-
-    FIXME: file path is hardcoded for development purposes; it
-    should be centrally accessible somewhere, possibly provided
-    at setup time by ADEPT.
     """
-    if 'known_failures' not in MEMO_CACHE:
-        known = {}
-        import csv
-        # FIXME: how to determine path to top-level directory?
-        path_known = '/var/lib/autotest/client/tests/docker/known_failures.csv'
-        with open(path_known, 'rb') as csv_fh:
-            csv_reader = csv.reader(csv_fh)
-            for row in csv_reader:
-                if row[1] not in known:
-                    known[row[1]] = {}
-                # Each row is: NVR, subtest, description
-                known[row[1]][row[0]] = row[2]
-        MEMO_CACHE['known_failures'] = known
-    return MEMO_CACHE['known_failures']
+    known = {}
+    import csv
+    path_known = os.path.join(config.CONFIGCUSTOMS, 'known_failures.csv')
+    with open(path_known, 'rb') as csv_fh:
+        csv_reader = csv.reader(csv_fh)
+        for row in csv_reader:
+            if row[1] not in known:
+                known[row[1]] = {}
+            # Each row is: NVR, subtest, description
+            known[row[1]][row[0]] = row[2]
+    return known
 
 
 class Subtest(subtestbase.SubBase, test.test):


### PR DESCRIPTION
  https://trello.com/c/qqlVHKRX/353-5-silence-known-ci-failures

A common pattern seems to be:

  1) New docker introduces a regression
  2) Wait months for docker to fix
  3) Wait more months for new RPM build

It is frustrating to see those failures over and over on each
test run.

This commit introduces a mechanism for associating a docker build
(exact NVR), a subtest, and a comment describing the known failure.
If we see this failure, we treat it as a skipped test. Bonus: if
we see a failure in a subtest, and there's a known-failure for
a different NVR but same NV (e.g. docker-1.12.5-6 but not -7),
emit a warning near the failure message; this can help a
maintainer update the known-failures list.

Problems this solves:

  * constant failures in ADEPT nightly runs with same NVR
  * constant failures in ADEPT runs on github PRs

Problems this does not solve:

  * ADEPT runs on new builds which do not address known failures
  * ADEPT runs on docker PRs which "  "    " "    " "    " "
    (theoretical concern only: that is still just a pipe dream)

Signed-off-by: Ed Santiago <santiago@redhat.com>