### PR TITLE
Fix run_volumes_selinux depending on ls command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,24 @@ matrix:
 git:
     submodules: false
 
+addons:
+  apt:
+    packages:
+        - python-pyxattr
+        - libattr1-dev
+
 install:
     - pip install Pylint==1.5.5 Pep8==1.6.2 Sphinx==1.2.2
     - pip install Autotest==0.16.2
     - pip install inspektor==0.2.0
     - pip install unittest2==0.8.0
+    - pip install pyxattr==0.5.1
 
 script:
     - SPHINXOPTS="-W" make
     - ./run_checkdocs.py
     - ./run_unittests.sh
+    - python -c "import xattr; exit(int('get' not in dir(xattr)))"
     - ./run_pylint.sh --FF
     - inspekt style --disable E501,E265,W601,E402,E731,E221
 

--- a/subtests/docker_cli/run_volumes_selinux/run_volumes_selinux.py
+++ b/subtests/docker_cli/run_volumes_selinux/run_volumes_selinux.py
@@ -2,19 +2,18 @@
 Summary
 -------
 
-Tests the --volume ::Z feature (automatic selinux context setting).
+Tests the --volume ::Z and ::z feature (automatic selinux context setting).
 
 
 Operational Summary
 -------------------
 
-1.  Start container using volume with z/Z set
+1.  Start container using volume with z or Z set
 2.  Check context and file creation within the container
-3.  Start another container --volumes-from $cont1
-4.  Check context and file creation
-5.  Try writing using $cont1
-6.  Verify (only) all created files are present
+3.  Start another container --volumes-from $first_container
+4.  Verify context and file creation from first, second, and host
 """
+
 import os
 import shutil
 import tempfile
@@ -23,25 +22,11 @@ from dockertest import config
 from dockertest import xceptions
 from dockertest import subtest
 from dockertest import dockercmd
-from dockertest import environment
+from dockertest.environment import set_selinux_context
+from dockertest.environment import get_selinux_context
 from dockertest.output import wait_for_output
 from dockertest.containers import DockerContainers
 from dockertest.images import DockerImage
-
-
-def set_selinux_context(pwd, context=None, recursive=True):
-    """ Wrapper around environment.set_selinux_context """
-    return environment.set_selinux_context(pwd, context, recursive)
-
-
-def get_selinux_context(pwd):
-    """ Wrapper around ls to get selinux context """
-    out = utils.run("ls -d --scontext %s" % pwd,
-                    10, verbose=False).stdout.strip().splitlines()
-    if len(out) != 1:
-        raise ValueError("Unable to get %s scontext, multiple dirs match:\n%s"
-                         % (pwd, out))
-    return out[0].split()[0]
 
 
 class run_volumes_selinux(subtest.SubSubtestCaller):
@@ -59,8 +44,8 @@ class selinux_base(subtest.SubSubtest):
         """
         super(selinux_base, self).initialize()
         if utils.run("selinuxenabled", 10, True).exit_status:
-            raise xceptions.DockerTestNAError("Selinux not enabled on this "
-                                              "machine.")
+            raise xceptions.DockerTestNAError("Selinux not enabled on this"
+                                              " machine.")
         # Substuff
         config.none_if_empty(self.config)
         self.sub_stuff['dc'] = DockerContainers(self)
@@ -126,8 +111,8 @@ class selinux_base(subtest.SubSubtest):
         open(host_file, 'w').write("01")
         set_selinux_context(volume, context, True)
         _context = get_selinux_context(volume)
-        self.failif(context not in _context, "Newly set context was not set "
-                    "properly (set %s, get %s)" % (context, _context))
+        self.failif(context not in _context, "Newly set context was not set"
+                    " properly (set %s, get %s)" % (context, _context))
         self.check_context_recursive(volume, _context)
         return volume
 
@@ -149,7 +134,10 @@ class selinux_base(subtest.SubSubtest):
                       get_selinux_context(volume))
         self.logdebug("Touching /tmp/test/%s in container"
                       % filename)
-        os.write(cont.stdin, "touch /tmp/test/%s\necho RET: $?\n" % filename)
+        # Some filesystems don't synchronize directory cache flushes if
+        # pagecache for a file isn't also dirty.  Always updating
+        # content is easier that checking filesystem from inside a container.
+        os.write(cont.stdin, "date > /tmp/test/%s\necho RET: $?\n" % filename)
         match = wait_for_output(lambda: cont.stdout, r'RET:\s+0$', timeout=10)
         if should_fail:
             self.failif(match, "File creation passed unexpectedly:"
@@ -174,13 +162,16 @@ class selinux_base(subtest.SubSubtest):
         :param volume: path to shared volume dir (on host)
         :param exp_files: expected files (relative to volume)
         """
+        # Make sure disk matches pagecache
+        # (See also, os.write() comment in touch_and_check())
+        utils.run("sync", 10)
         exp_files = set('%s/%s' % (volume, _) for _ in exp_files)
         act_files = set()
         for pwd, _, filenames in os.walk(volume):
             for filename in filenames:
                 act_files.add('%s/%s' % (pwd, filename))
         self.failif(exp_files.symmetric_difference(act_files), "Not all files"
-                    "present in volume:\nDiff: %s\nAct: %s\nExp: %s"
+                    " present in volume:\nDiff: %s\nAct: %s\nExp: %s"
                     % (exp_files.symmetric_difference(act_files), act_files,
                        exp_files))
 


### PR DESCRIPTION
This test will fail if the --scontext option happens to not exist.
In any case, options to the 'ls' command could be different across
distros / versions or change unpredictably (WRT docker autotest).
Instead, add an API call to retrieve the context directly from the
extended attribute value.  This works on all filesystems and whether or
not SELinux is enabled.

Signed-off-by: Chris Evich <cevich@redhat.com>