### PR TITLE
log_versions: handle missing rpms

### DIFF
--- a/pretests/log_versions/log_versions.py
+++ b/pretests/log_versions/log_versions.py
@@ -49,4 +49,9 @@ class log_versions(subtest.Subtest):
 
     @staticmethod
     def _rpmq(package_name):
-        return utils.run("rpm -q %s" % package_name).stdout
+        # Most systems will not have docker-latest. And in some rare cases,
+        # a system with docker-latest might not have docker.
+        nvr = utils.run("rpm -q %s" % package_name, ignore_status=True).stdout
+        if 'is not installed' in nvr:
+            return ''
+        return nvr


### PR DESCRIPTION
A given system may have docker but not docker-latest (or,
rarely, vice-versa). Such situations lead to CmdError
failure in the log_versions pretest.

Solution: allow errors in 'rpm -q' command. If 'is not installed'
appears in command output, return empty string which will in turn
be written to the docker_rpm_xxx file.

Alternate solutions considered: returning the 'is not installed'
string itself, or dealing with it in write_sysinfo() by not
writing the docker_rpm_xxx file. IMO both of those make it
harder for client code.

Signed-off-by: Ed Santiago <santiago@redhat.com>