### PR TITLE
Fix missing pyxattr module in Fedora Atomic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
     - pip install Autotest==0.16.2
     - pip install inspektor==0.2.0
     - pip install unittest2==0.8.0
+    # TODO: Use libselinux-python equivilent instead
     - pip install pyxattr==0.5.1
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,25 +14,25 @@ matrix:
 git:
     submodules: false
 
+# Allow importing modules that can't be installed with pip
+virtualenv:
+    system_site_packages: true
+
 addons:
   apt:
     packages:
-        - python-pyxattr
-        - libattr1-dev
+        - python-selinux
 
 install:
     - pip install Pylint==1.5.5 Pep8==1.6.2 Sphinx==1.2.2
     - pip install Autotest==0.16.2
     - pip install inspektor==0.2.0
     - pip install unittest2==0.8.0
-    # TODO: Use libselinux-python equivilent instead
-    - pip install pyxattr==0.5.1
 
 script:
     - SPHINXOPTS="-W" make
     - ./run_checkdocs.py
     - ./run_unittests.sh
-    - python -c "import xattr; exit(int('get' not in dir(xattr)))"
     - ./run_pylint.sh --FF
     - inspekt style --disable E501,E265,W601,E402,E731,E221
 

--- a/dockertest/environment.py
+++ b/dockertest/environment.py
@@ -7,7 +7,6 @@ Low-level/standalone host-environment handling/checking utilities/classes/data
        in autotest!
 """
 
-import errno
 import subprocess
 import selinux
 
@@ -31,6 +30,7 @@ def set_selinux_context(pwd, context=None, recursive=True):
     _cmd = ("type -P selinuxenabled || exit 0 ; "
             "selinuxenabled || exit 0 ; "
             "chcon -%st %s %s" % (flags, context, pwd))
+    # FIXME: Should use selinux.setfilecon()
     cmd = subprocess.Popen(_cmd, stdout=subprocess.PIPE,
                            stderr=subprocess.PIPE, shell=True)
     if cmd.wait() != 0:
@@ -44,12 +44,7 @@ def get_selinux_context(path):
     When selinux is enabled, return the context of ``path``
     :param path: Full or relative path to a file or directory
     :return: SELinux context as a string or None if not set
+    :raises IOError: When file does not exist.
     """
-    try:
-        # First list item is null-terminated string length
-        return selinux.getfilecon(path)[1]
-    except IOError, xcpt:
-        if xcpt.errno == errno.ENOENT:
-            return None
-        else:
-            raise
+    # First list item is null-terminated string length
+    return selinux.getfilecon(path)[1]

--- a/dockertest/environment.py
+++ b/dockertest/environment.py
@@ -7,19 +7,32 @@ Low-level/standalone host-environment handling/checking utilities/classes/data
        in autotest!
 """
 
+import warnings
 import subprocess
 import selinux
 
 
-# FIXME: pwd is misleading, it should be 'path'
-def set_selinux_context(pwd, context=None, recursive=True):
+def set_selinux_context(path=None, context=None, recursive=True, pwd=None):
     """
     When selinux is enabled it sets the context by chcon -t ...
-    :param pwd: target directory
+    :param path: Relative/absolute path to file/directory to modify
     :param context: desired context (svirt_sandbox_file_t by default)
     :param recursive: set context recursively (-R)
+    :param pwd: target path (deprecated, was first argument name)
     :raise OSError: In case of failure
     """
+    # This is here to catch any callers using pwd as a keyword argument.
+    # Moving it to the end of the list is safe because there only ever
+    # was a single positional argument in this function (preserves API)
+    if pwd is not None:
+        warnings.warn("Use of the pwd argument is deprecated,"
+                      " use path (first positional) instead",
+                      DeprecationWarning)
+        path = pwd
+    # Catch callers that only use ketword arguments but fail to pass
+    # either ``pwd`` or ``path``.
+    if path is None:
+        raise TypeError("The path argument is required")
     if context is None:
         context = "svirt_sandbox_file_t"
     if recursive:
@@ -43,8 +56,9 @@ def get_selinux_context(path):
     """
     When selinux is enabled, return the context of ``path``
     :param path: Full or relative path to a file or directory
-    :return: SELinux context as a string or None if not set
-    :raises IOError: When file does not exist.
+    :return: SELinux context as a string
+    :raises IOError: As per usual.  Documented here as it's
+    a behavior difference from ``set_selinux_context()``.
     """
     # First list item is null-terminated string length
     return selinux.getfilecon(path)[1]

--- a/dockertest/environment.py
+++ b/dockertest/environment.py
@@ -7,17 +7,9 @@ Low-level/standalone host-environment handling/checking utilities/classes/data
        in autotest!
 """
 
-import sys
 import errno
 import subprocess
-try:
-    # TODO: Get python-selinux module working in travis (ubuntu)
-    import selinux
-except ImportError:
-    # This always fails on travis with: no get in xattr (E0611)
-    # dispite successful 'pip install pyxattr==0.5.1'.  A test
-    # for this name has been added to .travis.yml directly.
-    from xattr import get as getxattr  # pylint: disable=E0611
+import selinux
 
 
 # FIXME: pwd is misleading, it should be 'path'
@@ -54,14 +46,10 @@ def get_selinux_context(path):
     :return: SELinux context as a string or None if not set
     """
     try:
-        if 'selinux' in sys.modules:
-            # First list item is null-terminated string length
-            return selinux.getfilecon(path)[1]
-        else:
-            # may include null-termination in string
-            return getxattr(path, 'security.selinux').replace('\000', '')
-    except (IOError, OSError), xcpt:
-        if xcpt.errno in [errno.EOPNOTSUPP, errno.ENOENT]
+        # First list item is null-terminated string length
+        return selinux.getfilecon(path)[1]
+    except IOError, xcpt:
+        if xcpt.errno == errno.ENOENT:
             return None
         else:
             raise

--- a/dockertest/environment.py
+++ b/dockertest/environment.py
@@ -7,12 +7,17 @@ Low-level/standalone host-environment handling/checking utilities/classes/data
        in autotest!
 """
 
+import sys
 import errno
 import subprocess
-# This always fails on travis with: no get in xattr (E0611)
-# dispite successful 'pip install pyxattr==0.5.1'.  A test
-# for this name has been added to .travis.yml directly.
-from xattr import get as getxattr  # pylint: disable=E0611
+try:
+    # TODO: Get python-selinux module working in travis (ubuntu)
+    import selinux
+except ImportError:
+    # This always fails on travis with: no get in xattr (E0611)
+    # dispite successful 'pip install pyxattr==0.5.1'.  A test
+    # for this name has been added to .travis.yml directly.
+    from xattr import get as getxattr  # pylint: disable=E0611
 
 
 # FIXME: pwd is misleading, it should be 'path'
@@ -49,10 +54,14 @@ def get_selinux_context(path):
     :return: SELinux context as a string or None if not set
     """
     try:
-        # may include null-termination in string
-        return getxattr(path, 'security.selinux').replace('\000', '')
-    except IOError, xcpt:
-        if xcpt.errno == errno.EOPNOTSUPP:
+        if 'selinux' in sys.modules:
+            # First list item is null-terminated string length
+            return selinux.getfilecon(path)[1]
+        else:
+            # may include null-termination in string
+            return getxattr(path, 'security.selinux').replace('\000', '')
+    except (IOError, OSError), xcpt:
+        if xcpt.errno in [errno.EOPNOTSUPP, errno.ENOENT]
             return None
         else:
             raise

--- a/index.rst
+++ b/index.rst
@@ -92,6 +92,7 @@ Prerequisites
     *  nfs-utils (nfs-server support daemons)
     *  Git (and basic familiarity with its operation)
     *  Python 2.6 or greater (not 3.0)
+    *  libselinux-python 2.2 (or pyxattr 0.5.1) or later
     *  Optional (for building documentation), ``make``, ``python-sphinx``,
        and ``docutils`` or equivalent for your platform.
     *  Optional (for running unittests), ``pylint``, ``pep8``,

--- a/index.rst
+++ b/index.rst
@@ -83,6 +83,7 @@ Prerequisites
     *  Red Hat Enterprise Linux 7 Server (preferred for development)
     *  Red Hat Enterprise Linux Atomic Host (preferred for testing)
     *  Fedora 22 or later including Atomic (not all tests may function)
+    *  Other platforms (such as Ubuntu) un-maintained but possible.
 
 *  Platform Applications/tools
 
@@ -92,7 +93,7 @@ Prerequisites
     *  nfs-utils (nfs-server support daemons)
     *  Git (and basic familiarity with its operation)
     *  Python 2.6 or greater (not 3.0)
-    *  libselinux-python 2.2 (or pyxattr 0.5.1) or later
+    *  libselinux-python 2.2 or later
     *  Optional (for building documentation), ``make``, ``python-sphinx``,
        and ``docutils`` or equivalent for your platform.
     *  Optional (for running unittests), ``pylint``, ``pep8``,


### PR DESCRIPTION
Also update documentation indicating hat libselinux-python or pyxattr
are required dependencies.  However, SELinux is not native under Ubuntu
(which travis CI runs) so some extra work will be needed to 100% convert
to using the preferred libselinux-python.  Added a TODO to this effect.

Signed-off-by: Chris Evich <cevich@redhat.com>