### PR TITLE
syslog test: try reading more syslog lines

### DIFF
--- a/subtests/docker_cli/syslog/syslog.py
+++ b/subtests/docker_cli/syslog/syslog.py
@@ -21,6 +21,7 @@ Prerequisites
 import os
 import os.path
 import datetime
+from autotest.client.shared import utils
 from dockertest.subtest import Subtest
 from dockertest.output import mustpass
 from dockertest.dockercmd import DockerCmd
@@ -69,6 +70,7 @@ class syslog(Subtest):
         self.verify_message_logged()
 
     def verify_message_logged(self):
+        utils.run("journalctl --flush")
         for line in self.stuff['syslog_fh']:
             if line.strip().endswith(self.stuff["msg"]):
                 self.loginfo("Found in syslog: %s" % line.strip())


### PR DESCRIPTION
i.e. bump up seek from -4k to -8k. Also, improve the
diagnostics:

  - test failed
  - Did not find expected message 'foo' in last N lines of syslog

...so if/when we see this again the poor test engineer has
some chance of understanding what happened and then investigating.

Signed-off-by: Ed Santiago <santiago@redhat.com>