### PR TITLE
Fix pull timeout

### DIFF
--- a/dockertest/dockercmd_unittests.py
+++ b/dockertest/dockercmd_unittests.py
@@ -319,6 +319,14 @@ class AsyncDockerCmd(DockerCmdTestBase):
         cmdresult = docker_cmd.execute()
         self.assertTrue(isinstance(cmdresult, FakeCmdResult))
         self.assertEqual(docker_cmd.wait(123).duration, 123)
+
+        # Exercize timeout w/o mocking time.time
+        from dockertest.xceptions import DockerCommandError
+        docker_cmd.timeout = -1
+        # Need to use attribute lookup for property call
+        self.assertRaises(DockerCommandError, getattr, docker_cmd, 'done')
+
+        docker_cmd.timeout = 99999999
         self.assertTrue(docker_cmd.done)
         self.assertEqual(docker_cmd.stdout, "STDOUT")
         self.assertEqual(docker_cmd.stderr, "STDERR")

--- a/subtests/docker_cli/pull/pull.py
+++ b/subtests/docker_cli/pull/pull.py
@@ -75,8 +75,9 @@ class pull_base(SubSubtest):
         self.sub_stuff['di'] = DockerImages(self)
         image_fn = self.init_image_fn()
         # set by run_once()
+        timeo = self.config['docker_pull_timeout']
         self.sub_stuff['image_list'] = []
-        dkrcmd = AsyncDockerCmd(self, 'pull', [image_fn])
+        dkrcmd = AsyncDockerCmd(self, 'pull', [image_fn], timeout=timeo)
         dkrcmd.quiet = False
         self.sub_stuff['dkrcmd'] = dkrcmd
         self.clean_all()


### PR DESCRIPTION
there's an inf. loop in ``while not dockercmd.done``