### PR TITLE
Workaround RH BZ 1393572 & docker_cli/negativeusage/iv4

### DIFF
--- a/config_defaults/subtests/docker_cli/negativeusage.ini
+++ b/config_defaults/subtests/docker_cli/negativeusage.ini
@@ -64,11 +64,13 @@ subcmd = run
 subarg = -p,192.168.9.1:9000,%%(FQIN)s,/bin/true
 stderr = Invalid hostPort
 
-# Note: This exposes RH BZ 1393572 and will need updating if/when it's status changes.
 [docker_cli/negativeusage/iv4]
 subcmd = run
 subarg = -e,PATH=/tmp,%%(FQIN)s,true
-stderr = exec\: \"true\"\: executable file not found in \$PATH
+# N/B: This (commented) 'stderr' exposes RH BZ 1393572.
+# stderr = exec\: \"true\"\: executable file not found in \$PATH
+# Workaround bug to receive some benefit from this sub-subtest running/passing
+stderr = executable file not found
 extcmd = 127
 
 [docker_cli/negativeusage/ip1]


### PR DESCRIPTION
I realize this test failure is subject of some debate.  However that's orthagonal to getting some useful runtime out of it, while we wait (maybe indefinitely) for a bug fix.   The original reproducer and a comment about the BZ is preserved in the configuration.