### PR TITLE
Fix selinux_labels bash script to exit with a code

### DIFF
--- a/subtests/docker_cli/selinux_labels/selinux_labels.py
+++ b/subtests/docker_cli/selinux_labels/selinux_labels.py
@@ -43,6 +43,7 @@ class selinux_labels(subtest.Subtest):
                      % (join(self.bindir, 'test.sh'),
                         self.stuff['di'].default_image),
                      ignore_status=True)
+        self.logdebug(str(result))
         self.stuff['result'] = result
 
     def postprocess(self):

--- a/subtests/docker_cli/selinux_labels/test.sh
+++ b/subtests/docker_cli/selinux_labels/test.sh
@@ -87,3 +87,5 @@ check_label "confined container: root dir" \
 check_label "container with overridden range" \
             "docker run --rm --security-opt label:level:s0:c1,c2 $image cat /proc/self/attr/current" \
             "s0:c1,c2"
+
+exit $rc


### PR DESCRIPTION
The script was setting the return-code variable but never actually
exiting with it.  Add exit statement at the end to fix that.

Signed-off-by: Chris Evich <cevich@redhat.com>