### PR TITLE
docker 1.13 changes a word in an error message

### DIFF
--- a/subtests/docker_cli/login/login.py
+++ b/subtests/docker_cli/login/login.py
@@ -283,8 +283,8 @@ class logout_ok(login_ok):
 
     def postprocess(self):
         super(logout_ok, self).postprocess()
-        self.failif_not_in('Remove login credentials for',
-                           self.sub_stuff['cmdresult_logout'].stdout,
+        xpect = 'Remove login credentials for | Removing login credentials for'
+        self.failif_not_in(xpect, self.sub_stuff['cmdresult_logout'].stdout,
                            'stdout from docker logout')
 
 


### PR DESCRIPTION
in docker logout:

  - Remove login credentials for
  + Removing login credentials for

Deal with both.

Signed-off-by: Ed Santiago <santiago@redhat.com>