### PR TITLE
docker-1.13 changes error code for rhel-push-plugin

### DIFF
--- a/config_defaults/subtests/redhat/rhel_push_plugin.ini
+++ b/config_defaults/subtests/redhat/rhel_push_plugin.ini
@@ -23,11 +23,13 @@ expected_stderr = Error response from daemon: authorization denied by plugin rhe
 [redhat/rhel_push_plugin/push_vendor_ok]
 image_vendor = Not Red Hat, Ltd.
 expected_stderr = unauthorized: authentication required
+                | denied: requested access to the resource is denied
 
 # rhel-push-plugin shouldn't catch this, because it's not RHEL
 [redhat/rhel_push_plugin/push_name_ok]
 image_name = free_warez_from_red_hat
 expected_stderr = unauthorized: authentication required
+                | denied: requested access to the resource is denied
 
 # ...and this is OK because it's not docker.io (hardcoded in the plugin)
 [redhat/rhel_push_plugin/push_registry_ok]


### PR DESCRIPTION
from ErrorCodeUnauthorized to ErrorCodeDenied. Accept
either error message.

Signed-off-by: Ed Santiago <santiago@redhat.com>