### PR TITLE
Switch default testing to RHEL from CentOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/stackbrew/centos:7
+FROM docker.io/stackbrew/centos:latest
 MAINTAINER cevich@redhat.com
 RUN echo -e "\nIt works!\n"

--- a/config_defaults/defaults.ini
+++ b/config_defaults/defaults.ini
@@ -31,15 +31,15 @@ __example__ = docker_repo_name, docker_repo_tag, preserve_fqins
 
 #: Default registry settings for testing
 #: (blank if not applicable)
-docker_repo_name = centos
+docker_repo_name = rhel
 #: Default image settings for testing
 #: (blank if not applicable)
-docker_repo_tag = 7
+docker_repo_tag = latest
 
 #: remote components (host:port)
-docker_registry_host = docker.io
+docker_registry_host = registry.access.redhat.com
 #: remote components (username)
-docker_registry_user = stackbrew
+docker_registry_user = rhel7
 
 ##### Operational testing options
 
@@ -47,9 +47,7 @@ docker_registry_user = stackbrew
 remove_after_test = yes
 
 #: CSV of possibly existing **full** image names to preserve.
-preserve_fqins = docker.io/stackbrew/centos:7,
-                 docker.io/stackbrew/centos:centos7,
-                 docker.io/stackbrew/centos:latest
+preserve_fqins = registry.access.redhat.com/rhel7/rhel:latest
 
 #: CSV of possibly existing **full** container names to preserve.
 preserve_cnames =

--- a/config_defaults/pretests.ini
+++ b/config_defaults/pretests.ini
@@ -5,7 +5,7 @@ subsubtests = puller,builder
 #: to prefetch before the build subtests because those count images
 #: before & after the test. One way to cross-check this value is:
 #:    find . -name Dockerfile|xargs grep -h FROM|sort -u
-extra_fqins_csv = docker.io/stackbrew/centos:7
+extra_fqins_csv = docker.io/stackbrew/centos:latest
 #: Whether or not to update ``config_custom/defaults.ini``'s preserve_fqins
 #: with any images pulled, built, etc. from sub-subtests.
 update_defaults_ini = True

--- a/config_defaults/subtests/docker_cli/build.ini
+++ b/config_defaults/subtests/docker_cli/build.ini
@@ -80,8 +80,13 @@ docker_registry_host = docker.io
 docker_registry_user = stackbrew
 docker_repo_name = centos
 docker_repo_tag = latest
-# Inherits options from main subtest section (above)
-# no need to repeat them here.
+postproc_cmd_csv = positive(),
+                   rx_out('^Schazam!$'),
+                   rx_out('^foobar$'),
+                   rx_out('\s*Successfully built\s*(\w{64}|\w{12})'),
+                   cnt_count('0'),
+                   img_exst(),
+                   intr_exst()
 
 [docker_cli/build/git_path]
 __example__ = dockerfile_dir_path, postproc_cmd_csv
@@ -93,7 +98,8 @@ docker_registry_user = stackbrew
 docker_repo_name = centos
 docker_repo_tag = latest
 postproc_cmd_csv = positive(),
-                   rx_out('Removing intermediate container'),
+                   rx_out('^Schazam!$'),
+                   rx_out('^foobar$'),
                    rx_out('\s*Successfully built\s*(\w{64}|\w{12})'),
                    cnt_count('0'),
                    img_exst(),

--- a/config_defaults/subtests/docker_cli/build.ini
+++ b/config_defaults/subtests/docker_cli/build.ini
@@ -79,7 +79,7 @@ dockerfile_dir_path = https://raw.githubusercontent.com/autotest/autotest-docker
 docker_registry_host = docker.io
 docker_registry_user = stackbrew
 docker_repo_name = centos
-docker_repo_tag = 7
+docker_repo_tag = latest
 # Inherits options from main subtest section (above)
 # no need to repeat them here.
 
@@ -91,7 +91,7 @@ dockerfile_dir_path = git://github.com/autotest/autotest-docker.git
 docker_registry_host = docker.io
 docker_registry_user = stackbrew
 docker_repo_name = centos
-docker_repo_tag = 7
+docker_repo_tag = latest
 postproc_cmd_csv = positive(),
                    rx_out('Removing intermediate container'),
                    rx_out('\s*Successfully built\s*(\w{64}|\w{12})'),

--- a/config_defaults/subtests/docker_cli/create.ini
+++ b/config_defaults/subtests/docker_cli/create.ini
@@ -43,5 +43,5 @@ cmd = '/bin/command/does/not/exist'
 __example__ = remote_image_fqin, docker_timeout
 docker_timeout = 240
 #: Fully qualified image name of **remote** repository to test automatic pull.
-remote_image_fqin = stackbrew/centos:7
+remote_image_fqin = docker.io/stackbrew/centos:latest
 run_options_csv =

--- a/config_defaults/subtests/docker_cli/run.ini
+++ b/config_defaults/subtests/docker_cli/run.ini
@@ -68,7 +68,7 @@ cmd = 'sleep 5s && echo "%(secret_sauce)s"'
 #: Change this to an image remotely available within test environment
 __example__ = remote_image_fqin
 #: Fully qualified image name stored on a remote registry, not local.
-remote_image_fqin = stackbrew/centos:7
+remote_image_fqin = docker.io/stackbrew/centos:latest
 run_options_csv =
 cmd = /bin/true
 

--- a/config_defaults/subtests/docker_cli/tag.ini
+++ b/config_defaults/subtests/docker_cli/tag.ini
@@ -7,11 +7,10 @@ subsubtests = change_tag,change_repository,change_user,double_tag,double_tag_for
 #: testing repo_name_prefix
 tag_repo_name_prefix = test
 #: Works best with remote registry provided repository
-__example__ = docker_registry_host, docker_registry_user, docker_repo_name, docker_repo_tag
 docker_repo_name = centos
 docker_repo_tag = 7
 docker_registry_user = stackbrew
-docker_registry_host =
+docker_registry_host = docker.io
 
 [docker_cli/tag/change_tag]
 

--- a/index.rst
+++ b/index.rst
@@ -83,7 +83,7 @@ Prerequisites
     *  Red Hat Enterprise Linux 7 Server (preferred for development)
     *  Red Hat Enterprise Linux Atomic Host (preferred for testing)
     *  Fedora 22 or later including Atomic (not all tests may function)
-    *  Other platforms (such as Ubuntu) un-maintained but possible.
+    *  Other platforms (such as CentOs, SLES, Ubuntu) un-maintained but possible.
 
 *  Platform Applications/tools
 

--- a/subtests/docker_cli/build/addurl/Dockerfile
+++ b/subtests/docker_cli/build/addurl/Dockerfile
@@ -1,3 +1,3 @@
-FROM stackbrew/centos:centos7
+FROM registry.access.redhat.com/rhel7/rhel:latest
 ENV PATH /usr/sbin:/usr/bin
 ADD <url> .

--- a/subtests/docker_cli/build/bad/Dockerfile
+++ b/subtests/docker_cli/build/bad/Dockerfile
@@ -1,4 +1,4 @@
-FROM stackbrew/centos:centos7
+FROM registry.access.redhat.com/rhel7/rhel:latest
 MAINTAINER cevich@redhat.com
 ENV PATH /usr/sbin:/usr/bin
 RUN echo "Schazam!"

--- a/subtests/docker_cli/build/dockerignore/Dockerfile
+++ b/subtests/docker_cli/build/dockerignore/Dockerfile
@@ -1,4 +1,4 @@
-FROM stackbrew/centos:7
+FROM registry.access.redhat.com/rhel7/rhel:latest
 ADD not_ignored_file not_ignored_dir testdir/
 ADD . /
 ADD / /

--- a/subtests/docker_cli/build/expose/Dockerfile
+++ b/subtests/docker_cli/build/expose/Dockerfile
@@ -1,3 +1,3 @@
-FROM stackbrew/centos:centos7
+FROM registry.access.redhat.com/rhel7/rhel:latest
 ENV PATH /usr/sbin:/usr/bin
 EXPOSE 8080

--- a/subtests/docker_cli/build/full/Dockerfile
+++ b/subtests/docker_cli/build/full/Dockerfile
@@ -1,4 +1,4 @@
-FROM stackbrew/centos:7
+FROM registry.access.redhat.com/rhel7/rhel:latest
 MAINTAINER cevich@redhat.com
 ENV PATH /usr/sbin:/usr/bin
 RUN echo "Schazam!"

--- a/subtests/docker_cli/build/jsonvol/Dockerfile
+++ b/subtests/docker_cli/build/jsonvol/Dockerfile
@@ -1,3 +1,3 @@
-FROM stackbrew/centos:centos7
+FROM registry.access.redhat.com/rhel7/rhel:latest
 ENV PATH /usr/sbin:/usr/bin
 VOLUME ["/foo", "/foo/bar", "/usr/local/lib/baz"]

--- a/subtests/docker_cli/build/part/Dockerfile
+++ b/subtests/docker_cli/build/part/Dockerfile
@@ -1,4 +1,4 @@
-FROM stackbrew/centos:centos7
+FROM registry.access.redhat.com/rhel7/rhel:latest
 MAINTAINER cevich@redhat.com
 ENV PATH /usr/sbin:/usr/bin
 RUN echo "Schazam!"


### PR DESCRIPTION
Some places, the CentOS image is still referenced because for those
specific tests, it's better to use a non-default image.  Also, in most
places, updated the CentOS tag from 7 -> latest.  Mainly for cosmetic
purposes, though it does squah any confusion that perhaps the 7-GA
version was being used.

Note: CI testing will most likely not be useful on this PR since it's setup for CentOS only (currently).