### PR TITLE
Corner case: fix KeyError in syslog cleanup

### DIFF
--- a/subtests/docker_cli/syslog/syslog.py
+++ b/subtests/docker_cli/syslog/syslog.py
@@ -83,5 +83,6 @@ class syslog(Subtest):
     def cleanup(self):
         super(syslog, self).cleanup()
         if self.config['remove_after_test']:
-            dkrcmd = DockerCmd(self, 'rm', [self.stuff['container_name']])
-            dkrcmd.execute()
+            if 'container_name' in self.stuff:
+                dkrcmd = DockerCmd(self, 'rm', [self.stuff['container_name']])
+                dkrcmd.execute()


### PR DESCRIPTION
If syslog.initialize() bails out with TestNAError (because
of missing syslog file), cleanup() still tries to remove
the nonexistent container. Solution: check first.

Signed-off-by: Ed Santiago <santiago@redhat.com>