### PR TITLE
Fix two build sub-subtsts

### DIFF
--- a/config_defaults/subtests/docker_cli/build.ini
+++ b/config_defaults/subtests/docker_cli/build.ini
@@ -76,9 +76,9 @@ __example__ = dockerfile_dir_path, postproc_cmd_csv
 use_config_repo = no
 dockerfile_dir_path = https://raw.githubusercontent.com/autotest/autotest-docker/master/subtests/docker_cli/build/full/Dockerfile
 # Hard code this to base-image used in remote dockerfile (above)
-docker_registry_host = docker.io
-docker_registry_user = stackbrew
-docker_repo_name = centos
+docker_registry_host = registry.access.redhat.com
+docker_registry_user = rhel7
+docker_repo_name = rhel
 docker_repo_tag = latest
 postproc_cmd_csv = positive(),
                    rx_out('^Schazam!$'),
@@ -98,8 +98,7 @@ docker_registry_user = stackbrew
 docker_repo_name = centos
 docker_repo_tag = latest
 postproc_cmd_csv = positive(),
-                   rx_out('^Schazam!$'),
-                   rx_out('^foobar$'),
+                   rx_out('^It works!$'),
                    rx_out('\s*Successfully built\s*(\w{64}|\w{12})'),
                    cnt_count('0'),
                    img_exst(),


### PR DESCRIPTION
The docker_cli/build/git_path output checks don't match the behavior
from the Docker file.  Fix this.

The base-image configured for docker_cli/build/http_path doesn't match
the content of it's Dockerfile.  Fix this.

Signed-off-by: Chris Evich <cevich@redhat.com>