### PR TITLE
run_flags: kernel 3.10.0-632 supports deferred_deletion

### DIFF
--- a/subtests/docker_cli/run_flags/run_flags.py
+++ b/subtests/docker_cli/run_flags/run_flags.py
@@ -26,6 +26,7 @@ class run_flags_base(subtest.SubSubtest):
 
     def has_storage_opt(self, wanted):
         docker_cmdline = dockertest.docker_daemon.cmdline()
+        self.logdebug("docker daemon command line: %s", docker_cmdline)
         last_opt = ''
         for opt in docker_cmdline:
             if opt == wanted and last_opt == '--storage-opt':
@@ -71,7 +72,7 @@ class run_flags_deferred_deletion(run_flags_base):
         """
         Fail with N/A if kernel doesn't support deferred deletion.
         """
-        required = LooseVersion("3.999")    # FIXME once we ID a good version
+        required = LooseVersion("3.10.0-632")    # in RHEL 7.4
         actual = LooseVersion(os.uname()[2])
         if actual < required:
             raise DockerTestNAError("Deferred deletion functionality"


### PR DESCRIPTION
Kernel 3.10.0-632.el7 (RHEL 7.4 beta) supports the desired
deferred_deletion option. We've been waiting for this.
Update the 3.999 placeholder and remove the FIXME. We now
expect docker-storage-setup to identify this feature and
enable it.

Also, add a debug log so investigators can see the full
docker command line. Possibly useful if test virt has
been wiped.

Signed-off-by: Ed Santiago <santiago@redhat.com>