### PR TITLE
docker_cli/info: Accept multiple storage driver names

### DIFF
--- a/config_defaults/subtests/docker_cli/info.ini
+++ b/config_defaults/subtests/docker_cli/info.ini
@@ -10,3 +10,5 @@ data_total_error = 0.25
 meta_error = 1.00
 #: Docker reported size may vary +/- by this percent from on-disk sizes
 meta_total_error = 0.25
+#: List of acceptable storage drivers, delimited by ``|`` characters
+storage_drivers = devicemapper|overlay2

--- a/subtests/docker_cli/info/info.py
+++ b/subtests/docker_cli/info/info.py
@@ -56,8 +56,9 @@ class info(subtest.Subtest):
         outputgood = OutputGood(self.stuff['cmdresult'])
         info_map = self._build_table(outputgood.stdout_strip)
         # Verify some individual items
-        self.failif_ne(info_map['Storage Driver'].lower(), 'devicemapper',
-                       'Storage Driver')
+        self.failif_not_in(self.config['storage_drivers'],
+                           info_map['Storage Driver'].lower(),
+                           'Storage Driver')
         self.failif_ne(info_map['Data file'].lower(), '',
                        'Data file')
         self.failif_ne(info_map['Metadata file'].lower(), '',


### PR DESCRIPTION
In addition to ``devicemapper``, newer versions of docker may use
``overlay2`` (or other storage drivers).  Instead of validating a single
hard-coded value, use a configurable list of values that's easy to
maintain.

N/B: This is an incomplete update to this test.  There are other info. fields
which also need updating. e.g.:

```
Storage Driver: overlay2
 Backing Filesystem: xfs
Logging Driver: journald
Cgroup Driver: systemd
```