### PR TITLE
Fix build logging missing some format parameters.

### DIFF
--- a/subtests/docker_cli/build/build.py
+++ b/subtests/docker_cli/build/build.py
@@ -243,11 +243,11 @@ class postprocessing(object):
             output = build_def.dockercmd.stderr
         mobj = re.search(parameter, output, re.MULTILINE)
         if command.startswith('rx'):
-            self.logdebug("%s() Matched regex: %s", command,
+            self.logdebug("%s(%s) Matched regex: %s", command,
                           parameter, bool(mobj))
             return bool(mobj)  # matched at least one line
         else:  # must not match
-            self.logdebug("%s() Not-matched regex: %s", command,
+            self.logdebug("%s(%s) Not-matched regex: %s", command,
                           parameter, not bool(mobj))
             return not bool(mobj)  # matched on any line
 


### PR DESCRIPTION
Signed-off-by: Chris Evich <cevich@redhat.com>