### PR TITLE
info subtest: handle overlay2 driver

### DIFF
--- a/subtests/docker_cli/info/test_info.py
+++ b/subtests/docker_cli/info/test_info.py
@@ -83,5 +83,63 @@ class TestVerifyPoolName(TestCase):
                            " list '['rhel-docker--pool_tdata',"
                            " 'rhel-docker--pool_tmeta']'")
 
+
+class TestBuildTable(TestCase):
+
+    def test_docker_info_parsing(self):
+        # Typical output from docker info. The '%s' tests trailing whitespace
+        docker_info = """Containers: 0
+ Running: 0
+ Paused: 0
+ Stopped: 0
+Images: 3
+Server Version: 1.12.6
+Storage Driver: devicemapper
+ Pool Name: vg--docker-docker--pool
+ Pool Blocksize: 524.3 kB
+ Data file: %s
+ Library Version: 1.02.135-RHEL7 (2016-11-16)
+Logging Driver: journald
+Plugins:
+ Volume: local lvm
+ Network: host null bridge overlay
+ID: 5UCC:ANAG:4BIE:2KK6:VGP4:XKVO:5HB5:RPOA:PFLJ:HXRF:FCDV
+Insecure Registries:
+ 127.0.0.0/8""" % ''
+        actual = info.info._build_table(docker_info)  # pylint: disable=W0212
+
+        # How we expect _build_table() to parse that.
+        expect = {
+            'Containers': '0',
+            'Containers...': {
+                'Running': '0',
+                'Paused': '0',
+                'Stopped': '0',
+            },
+            'Images': '3',
+            'Server Version': '1.12.6',
+            'Storage Driver': 'devicemapper',
+            'Storage Driver...': {
+                'Pool Name': 'vg--docker-docker--pool',
+                'Pool Blocksize': '524.3 kB',
+                'Data file': '',
+                'Library Version': '1.02.135-RHEL7 (2016-11-16)',
+            },
+            'Logging Driver': 'journald',
+            'Plugins': '',
+            'Plugins...': {
+                'Volume': 'local lvm',
+                'Network': 'host null bridge overlay',
+            },
+            'ID': '5UCC:ANAG:4BIE:2KK6:VGP4:XKVO:5HB5:RPOA:PFLJ:HXRF:FCDV',
+            'Insecure Registries': '',
+            'Insecure Registries...': {
+                '127.0.0.0/8': '',
+            }
+        }
+
+        self.maxDiff = None
+        self.assertEqual(actual, expect, "parsed output from docker info")
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Up until now, the 'docker info' test has only had
to deal with devicemapper. Now there's overlay2,
and the docker info output for it is significantly
different. Much of the devicemapper validation is
not applicable to overlay2.

Split the storage-handler validation into individual
functions for each driver: currently devicemapper
and overlay2, each of which has different tunables.
As more back ends are added, we can add new functions
to check their settings.

Also: rewrite _build_table() so it handles sub-elements,
and add a unit test.

Signed-off-by: Ed Santiago <santiago@redhat.com>