### PR TITLE
Add test: Verify yum -y update works in container

### DIFF
--- a/config_defaults/subtests/docker_cli/run.ini
+++ b/config_defaults/subtests/docker_cli/run.ini
@@ -1,5 +1,5 @@
 [docker_cli/run]
-subsubtests = run_true,run_false,run_interactive,run_attach_stdout,run_remote_tag,run_names,run_tmpfs,run_passwd,run_install
+subsubtests = run_true,run_false,run_interactive,run_attach_stdout,run_remote_tag,run_names,run_tmpfs,run_passwd,run_install,run_update
 #: The most basic sub-subtests can be generated from a generic
 #: class at runtime, set 'yes' to enable this feature.
 generate_generic = no
@@ -77,3 +77,7 @@ cmd = /bin/true
 install_cmd = yum install --disablerepo="*" --enablerepo="base" --assumeyes yajl
 #: Full command to run in commited container to verify installation
 verify_cmd = bash -c "echo '[{}]' | json_verify -q"
+
+[docker_cli/run/run_update]
+generate_generic = yes
+cmd = 'yum --assumeyes update'

--- a/config_defaults/subtests/docker_cli/run.ini
+++ b/config_defaults/subtests/docker_cli/run.ini
@@ -5,7 +5,7 @@ subsubtests = run_true,run_false,run_interactive,run_attach_stdout,run_remote_ta
 generate_generic = no
 #: CSV of options and arguments to use on docker command line,
 #: with the exception of --name, image, and contained command.
-run_options_csv = --rm,--attach=stdout,--sig-proxy=true
+run_options_csv = --rm
 #: Set 'yes' to append ``--name`` with a test-specific random name.
 run_append_name = yes
 #: CSV docker run COMMAND argument to prefix ``cmd`` option (below)


### PR DESCRIPTION
Extremely simple test, runs the ``yum -y update`` command inside a
container, verifying exit status 0.  Additionally, this test
configuration acts as a placeholder, to be overridden by a more
complex for testing other distros, such as RHEL.

In particular, RHEL maintains patches against upstream docker that
manipulate behavior in subtle ways.  For example, by sharing a
special "secrets" volume mount, to enable subscription-manager
to do it's job inside a RHEL base-image container.

This test enables both verifying the simple case, and the more complex
code paths present where additional docker behavior is involved.

Signed-off-by: Chris Evich <cevich@redhat.com>