### PR TITLE
Add a fixme: Don't leave bad-examples lying around

### DIFF
--- a/dockertest/output/dockerversion.py
+++ b/dockertest/output/dockerversion.py
@@ -41,6 +41,7 @@ class DockerVersion(object):
                                                      shell=True,
                                                      close_fds=True)
         self.version_string = version_string
+        # FIXME: This should call super(...).__init__(...) (my bad)
 
     def _oops(self, what):
         raise DockerOutputError("Couldn't parse %s from %s" %


### PR DESCRIPTION
This is mostly just in case anyone takes this class as a starting place
for something else.  It really should call super() otherwise
mult-inheritance subclasses can easily do very odd/unexpected things.

Signed-off-by: Chris Evich <cevich@redhat.com>