### PR TITLE
Add logging of docker/container-related RPM versions

### DIFF
--- a/config_defaults/docker_test_images.ini
+++ b/config_defaults/docker_test_images.ini
@@ -14,7 +14,3 @@ update_defaults_ini = True
 #: build_name = skip-if-commented-out
 #: build_dockerfile = skip-if-commented-out
 build_opts_csv = --no-cache,--pull,--force-rm,--volume=/:/host
-
-[log_versions]
-#: CSV of rpm names to store in sysinfo/key_rpms
-key_rpms = docker-selinux,container-selinux,runc,atomic,skopeo

--- a/config_defaults/log_versions.ini
+++ b/config_defaults/log_versions.ini
@@ -1,0 +1,3 @@
+[log_versions]
+#: CSV of rpm names to store in sysinfo/key_rpms
+key_rpms = docker-selinux,container-selinux,runc,atomic,skopeo

--- a/config_defaults/pretests.ini
+++ b/config_defaults/pretests.ini
@@ -14,3 +14,7 @@ update_defaults_ini = True
 #: build_name = skip-if-commented-out
 #: build_dockerfile = skip-if-commented-out
 build_opts_csv = --no-cache,--pull,--force-rm,--volume=/:/host
+
+[log_versions]
+#: CSV of rpm names to store in sysinfo/key_rpms
+key_rpms = docker-selinux,container-selinux,runc,atomic,skopeo

--- a/pretests/log_versions/log_versions.py
+++ b/pretests/log_versions/log_versions.py
@@ -39,7 +39,7 @@ class log_versions(subtest.Subtest):
         self.write_sysinfo('docker_rpm_active', self._rpmq(which_docker()))
         self.write_sysinfo('docker_rpm_current', self._rpmq('docker'))
         self.write_sysinfo('docker_rpm_latest', self._rpmq('docker-latest'))
-        for rpm in get_as_list(self.config.get(key_rpms, '')):
+        for rpm in get_as_list(self.config.get('key_rpms', '')):
             self.write_sysinfo('key_rpms', self._rpmq(rpm))
 
     def write_sysinfo(self, filename, content):

--- a/pretests/log_versions/log_versions.py
+++ b/pretests/log_versions/log_versions.py
@@ -2,13 +2,13 @@ r"""
 Summary
 -------
 
-Preserve docker versions in state files.
+Preserve docker and related RPM versions, in sysinfo files.
 
 Operational Summary
 -------------------
 
 #. Run 'docker version'; use DockerVersion module to parse output
-#. Run 'rpm -q docker|docker-latest' (whichever one is in use)
+#. Run 'rpm -q <list of packages>'
 #. Preserve output in sysinfo files
 
 """
@@ -19,6 +19,7 @@ from dockertest import subtest
 from dockertest.dockercmd import DockerCmd
 from dockertest.output import DockerVersion, mustpass
 from dockertest.docker_daemon import which_docker
+from dockertest.config import get_as_list
 
 
 class log_versions(subtest.Subtest):
@@ -38,13 +39,15 @@ class log_versions(subtest.Subtest):
         self.write_sysinfo('docker_rpm_active', self._rpmq(which_docker()))
         self.write_sysinfo('docker_rpm_current', self._rpmq('docker'))
         self.write_sysinfo('docker_rpm_latest', self._rpmq('docker-latest'))
+        for rpm in get_as_list(self.config.get(key_rpms, '')):
+            self.write_sysinfo('key_rpms', self._rpmq(rpm))
 
     def write_sysinfo(self, filename, content):
         """
         Write the given content to sysinfodir/filename
         """
         path = os.path.join(self.job.sysinfo.sysinfodir, filename)
-        with open(path, 'wb') as outfile:
+        with open(path, 'a+b') as outfile:
             outfile.write(content)
 
     @staticmethod


### PR DESCRIPTION
For testing/debugging purposes, sometimes additional context from
of other RPM versions is needed.  However, simply listing all
installed RPMss would become burdensome to store and parse.
Instead, feed the ``log_versions`` pre-test a configurable list of
names, and have it store those rpms versions (if installed) into a
separate ``key_rpms`` file.  This file can then be picked up later by
automation to provide additional context when necessary.

Signed-off-by: Chris Evich <cevich@redhat.com>