### PR TITLE
Fix run/run_install

### DIFF
--- a/config_defaults/subtests/docker_cli/run.ini
+++ b/config_defaults/subtests/docker_cli/run.ini
@@ -73,11 +73,13 @@ run_options_csv =
 cmd = /bin/true
 
 [docker_cli/run/run_install]
+__example__ = install_cmd,verify_cmd
 #: Full command to execute which installs something inside the container
-install_cmd = yum install --disablerepo="*" --enablerepo="base" --assumeyes yajl
+install_cmd = yum install --assumeyes yajl
 #: Full command to run in commited container to verify installation
 verify_cmd = bash -c "echo '[{}]' | json_verify -q"
 
 [docker_cli/run/run_update]
+__example__ = cmd
 generate_generic = yes
 cmd = 'yum --assumeyes update'


### PR DESCRIPTION
Previously this test's configuration assumed it was running on a CentOS
image.  Testing on CentOS by default was dropped long ago.  Update this
test's configuration to be more generic, but issue warnings if it's not
customized.

Signed-off-by: Chris Evich <cevich@redhat.com>