### PR TITLE
Fix docker_cli/pull default user value

### DIFF
--- a/config_defaults/subtests/docker_cli/pull.ini
+++ b/config_defaults/subtests/docker_cli/pull.ini
@@ -11,6 +11,7 @@ __example__ = docker_repo_name, docker_repo_tag,
 docker_repo_name = busybox
 docker_repo_tag = buildroot-2014.02
 docker_registry_host = docker.io
+docker_registry_user =
 
 [docker_cli/pull/wrong_tag]
 docker_expected_exit_status = 1


### PR DESCRIPTION
When a subtest/sub-subtest overrides one of the test-image component
values, it must set unused components to empty, otherwise they will
inherit possibly-incorrect values from defaults.ini

Signed-off-by: Chris Evich <cevich@redhat.com>