### PR TITLE
Simplify log_versions

### DIFF
--- a/config_defaults/log_versions.ini
+++ b/config_defaults/log_versions.ini
@@ -1,3 +1,3 @@
 [log_versions]
 #: CSV of rpm names to store in sysinfo/key_rpms
-key_rpms = docker-selinux,container-selinux,runc,atomic,skopeo
+key_rpms = docker,docker-latest,docker-selinux,container-selinux,runc,atomic,skopeo

--- a/pretests/log_versions/log_versions.py
+++ b/pretests/log_versions/log_versions.py
@@ -18,7 +18,6 @@ from autotest.client import utils
 from dockertest import subtest
 from dockertest.dockercmd import DockerCmd
 from dockertest.output import DockerVersion, mustpass
-from dockertest.docker_daemon import which_docker
 from dockertest.config import get_as_list
 
 
@@ -36,9 +35,6 @@ class log_versions(subtest.Subtest):
                 % (docker_version.client, docker_version.server))
         self.loginfo("Found %s", info)
         self.write_sysinfo('docker_version', info + "\n")
-        self.write_sysinfo('docker_rpm_active', self._rpmq(which_docker()))
-        self.write_sysinfo('docker_rpm_current', self._rpmq('docker'))
-        self.write_sysinfo('docker_rpm_latest', self._rpmq('docker-latest'))
         for rpm in get_as_list(self.config.get('key_rpms', '')):
             self.write_sysinfo('key_rpms', self._rpmq(rpm))
 


### PR DESCRIPTION
Previously versions of the various docker RPMS was collected in two
places. This is redundant possibly ambiguous, and unnecessary.  The
"active" version of docker is also meaningless since subtests are free
to restart at will.  It would only represent the active version when the
pretest runs.  Better to leave making any declaration of "active"
version up to any subtests where it matters (none currently).

Signed-off-by: Chris Evich <cevich@redhat.com>