### PR TITLE
Reenable deferred_deletion test

### DIFF
--- a/subtests/docker_cli/deferred_deletion/deferred_deletion.py
+++ b/subtests/docker_cli/deferred_deletion/deferred_deletion.py
@@ -1,0 +1,145 @@
+r"""
+Summary
+---------
+
+Test deferred deletion: device mapper will not delete a docker
+filesystem if it's still in use.
+
+This test is only applicable if docker daemon is run with:
+
+    --storage-opts dm.use_deferred_deletion=true
+
+(this is detected and enabled by the docker-storage-setup script)
+
+That suffices on Fedora. On RHEL it's more complicated: the 7.2 version
+of docker-storage-setup blindly enabled the option even though it
+didn't actually work due to a kernel bug. 7.4 introduced a kernel with
+a fix, but disabled by default. We therefore need to differentiate
+between systems with (1) enabled incorrectly and correctly. We do
+so by checking that the sysctl knob /proc/sys/fs/may_detach_mounts
+(introduced in kernel 3.10.0-632) exists and is 1.
+
+We abort with TestNAError if any precondition fails.
+
+Note that we need to do all the important work from inside a
+helper script, because our autotest process will only have access
+to the container's mounts if MountFlags=slave is *absent* from
+the docker systemd unit file; by default that option is present,
+and it is not clear if/when it will be removed. To make sure
+we have access to the container's mounts we need to nsenter
+the docker daemon's mount namespace, and we can't do that within
+autotest (using ctypes.CDLL and setns) because autotest is
+multithreaded and setns() doesn't allow that.
+
+Operational Summary
+----------------------
+
+#. Run a docker container
+#. Run a test script inside docker mount space that will:
+#. - Find out the local (host) mountpoint of the container's root filesystem.
+#. - cd into that directory
+#. - Read the Deferred-Deletion count from 'docker info'.
+#. - Remove the container.
+#. - Read the Deferred-Deletion count; confirm that it has grown by one.
+#. - cd back out of the container rootfs
+#. - Read the Deferred-Deletion count; confirm that it has gone back down.
+
+"""
+
+import os
+from autotest.client import utils
+import dockertest.docker_daemon
+from dockertest import subtest
+from dockertest.containers import DockerContainers
+from dockertest.dockercmd import AsyncDockerCmd
+from dockertest.images import DockerImage
+from dockertest.output.validate import mustpass
+from dockertest.xceptions import DockerTestNAError
+
+
+class deferred_deletion(subtest.Subtest):
+
+    def initialize(self):
+        super(deferred_deletion, self).initialize()
+
+        docker_cmdline = dockertest.docker_daemon.cmdline()
+        self.failif_not_in("dm.use_deferred_deletion=true",
+                           str(docker_cmdline),
+                           "docker daemon command-line options",
+                           DockerTestNAError)
+
+        self._rhel72_bug_workaround()
+
+        self.stuff['dc'] = DockerContainers(self)
+
+    def _rhel72_bug_workaround(self):
+        """
+        On RHEL, docker daemon may be running with deferred_deletion
+        enabled incorrectly.
+        """
+
+        try:
+            self.failif_not_redhat()
+        except DockerTestNAError:
+            return                   # Fedora or CentOS
+
+        # RHEL
+        sysctl_knob = "/proc/sys/fs/may_detach_mounts"
+        self.failif(not os.path.exists(sysctl_knob),
+                    "sysctl knob %s does not exist; this system is"
+                    " not likely to support deferred deletion" % sysctl_knob,
+                    DockerTestNAError)
+
+        with open(sysctl_knob, 'rb') as fs_may_detach_mounts:
+            enabled = int(fs_may_detach_mounts.read().strip())
+            self.failif(not enabled,
+                        "sysctl knob %s is '%s'; this test is only valid"
+                        " when it is '1'" % (sysctl_knob, enabled),
+                        DockerTestNAError)
+
+    def run_once(self):
+        super(deferred_deletion, self).run_once()
+
+        self._start_idle_container()
+
+        # Run our testing script
+        helper = os.path.join(self.bindir, 'test-deferred-deletion.sh')
+        result = utils.run("nsenter -t %d -m %s %s %s"
+                           % (dockertest.docker_daemon.pid(), helper,
+                              self.stuff['container_name'],
+                              self.stuff['trigger_file']),
+                           ignore_status=True)
+        self.stuff['result'] = result
+
+    def postprocess(self):
+        super(deferred_deletion, self).postprocess()
+        mustpass(self.stuff['result'])
+
+        # Helper script should be silent; treat any output as a warning
+        if self.stuff['result'].stdout:
+            self.logwarning(self.stuff['result'].stdout)
+
+    def _start_idle_container(self):
+        """
+        Start a container. We only need it briefly, until we (the test,
+        running in host space) can cd into its root filesystem. Container
+        will spin idly until a semaphore file is removed.
+        """
+        c_name = self.stuff['dc'].get_unique_name()
+
+        fin = DockerImage.full_name_from_defaults(self.config)
+        self.stuff['trigger_file'] = trigger_file = 'DELETE-ME'
+        subargs = ['--rm', '--name=' + c_name, fin,
+                   'bash -c "echo READY;touch /%s;'
+                   ' while [ -e /%s ]; do sleep 0.1; done"'
+                   % (trigger_file, trigger_file)]
+        dkrcmd = AsyncDockerCmd(self, 'run', subargs)
+        dkrcmd.execute()
+        dkrcmd.wait_for_ready(c_name)
+        self.stuff['container_name'] = c_name
+
+    def cleanup(self):
+        super(deferred_deletion, self).cleanup()
+        if self.config['remove_after_test']:
+            if 'container_name' in self.stuff:
+                self.stuff['dc'].clean_all([self.stuff['container_name']])

--- a/subtests/docker_cli/deferred_deletion/test-deferred-deletion.sh
+++ b/subtests/docker_cli/deferred_deletion/test-deferred-deletion.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Helper script for the deferred-deletion test. We need this to be outside
+# of python because (1) we need to nsenter the docker daemon mount namespace,
+# and (2) autotest runs multithreaded so setns() will not work. So our
+# autotest invokes us via nsenter.
+#
+# We are given the name of a running docker container. From that we:
+#
+#  1) Find out its local mount point. cd into it.
+#  2) Run 'docker info' to get the Deferred Deletion count. Save it.
+#  3) Stop the container and wait for it to be gone.
+#  4) Run 'docker info' and get new Deferred Deletion count. It should be
+#     one more than what we got in step (2).
+#  5) cd outside of the container's mount point.
+#  6) Wait up to 30 seconds, running 'docker info' frequently to check
+#     Deferred Deletion count. If it goes back to the value in step (2), pass.
+#
+deferred_count() {
+    docker info | grep 'Deferred Deleted Device Count:' | awk -F: '{print $2}'
+}
+
+wait_for_container_to_die() {
+    wait_until=$(expr $SECONDS + 5)
+
+    while [ $SECONDS -le $wait_until ]; do
+        found=$(docker ps -a --quiet --filter=name=$c_name)
+        if [ -z "$found" ]; then
+            return
+        fi
+        sleep 0.1
+    done
+
+    echo "FATAL: Container failed to exit properly"
+    exit 1
+}
+
+
+c_name=${1?FATAL: Missing CONTAINER_NAME argument}
+trigger_file=${2?FATAL: Missing TRIGGER_FILE argument}
+
+# Ask docker for the devmapper name of the container filesystem...
+dname=$(docker inspect --format '{{.GraphDriver.Data.DeviceName}}' $c_name)
+
+# ...then from that find the path to the local mount.
+mountpoint=$(findmnt --noheadings --output TARGET --source /dev/mapper/$dname)
+if [ -z "$mountpoint" ]; then
+    echo "FATAL: No mount point for /dev/mapper/$dname" >&2
+    exit 1
+fi
+
+cd "$mountpoint/rootfs" || exit 1
+
+# Container is running; count on a test system should always be 0, but
+# don't enforce that.
+starting_count=$(deferred_count)
+if [ $starting_count -ne 0 ]; then
+    echo "WARNING: Deferred-Delete count from 'docker info' is $starting_count (I expected 0). This may mean your system has still-undeleted containers."
+fi
+
+# The container is spinning, it will stop as soon as this file is removed.
+rm -f $trigger_file
+wait_for_container_to_die
+
+# Check count again, it should be 1
+now_count=$(deferred_count)
+expected_count=$(expr $starting_count + 1)
+if [ $now_count -ne $expected_count ]; then
+    echo "FATAL: deferred count is $now_count; I expected $expected_count"
+    exit 1
+fi
+
+# cd out of the container, then wait for count to go back down
+cd /
+
+wait_until=$(expr $SECONDS + 30)
+while [ $SECONDS -le $wait_until ]; do
+    now_count=$(deferred_count)
+    if [ $now_count -eq $starting_count ]; then
+        exit 0
+    fi
+    sleep 0.1
+done
+
+echo "FATAL: deferred count never went back to $starting_count"
+exit 1


### PR DESCRIPTION
Per vgoyal: the functionality is still important, let's not
allow it to regress. This reintroduces the test, with a
few minor changes from before:

  * Remove the check for devicemapper: docker-storage-setup
    only enables deferred_deletion on devicemapper. Even
    the broken RHEL 7.2 version.
  * Don't just check for the existence of /proc/sys/fs/may_detach_mounts;
    read it and confirm that it's enabled.
  * Only do the /proc/sys/fs/may_detach_mounts check on RHEL.
    This lets the test run on Fedora, which never had the
    kernel bug requiring that sysctl switch.

Signed-off-by: Ed Santiago <santiago@redhat.com>