### PR TITLE
Workaround docker-latest build re: BZ 1403326

### DIFF
--- a/config_defaults/subtests/docker_cli/build.ini
+++ b/config_defaults/subtests/docker_cli/build.ini
@@ -26,6 +26,12 @@ use_config_repo = yes
 #: no ``-f`` (use ``Dockerfile``).
 minus_eff =
 
+#: Whether or not to examine docker-build output for terminal escape codes
+#: as part of the ``postive()`` or ``negative()`` post-processing commands.
+#: Defaults to disabled, Docker-1.13 ignores $TERM for build
+#: sub-command (BZ1403326)
+enable_nonprintables_check = no
+
 #: Comma-separated post-process checks to call, in order, with optional
 #: string parameter enclosed in ``('``, ``')``.  Check commands are:{n}
 #: {n}
@@ -81,8 +87,8 @@ docker_registry_user = rhel7
 docker_repo_name = rhel
 docker_repo_tag = latest
 postproc_cmd_csv = positive(),
-                   rx_out('^Schazam!$'),
-                   rx_out('^foobar$'),
+                   rx_out('Schazam!$'),
+                   rx_out('foobar$'),
                    rx_out('\s*Successfully built\s*(\w{64}|\w{12})'),
                    cnt_count('0'),
                    img_exst(),
@@ -98,7 +104,7 @@ docker_registry_user = stackbrew
 docker_repo_name = centos
 docker_repo_tag = latest
 postproc_cmd_csv = positive(),
-                   rx_out('^It works!$'),
+                   rx_out('It works!$'),
                    rx_out('\s*Successfully built\s*(\w{64}|\w{12})'),
                    cnt_count('0'),
                    img_exst(),
@@ -107,8 +113,8 @@ postproc_cmd_csv = positive(),
 [docker_cli/build/bad]
 dockerfile_dir_path = /bad
 postproc_cmd_csv = negative(),
-                   rx_out('^Schazam!$'),
-                   !rx_out('^foobar$'),
+                   rx_out('Schazam!$'),
+                   !rx_out('foobar$'),
                    !rx_err('Successfully built')
                    rx_err('returned a non-zero code'),
                    cnt_count('1'),
@@ -121,8 +127,8 @@ postproc_cmd_csv = negative(),
 dockerfile_dir_path = /bad
 docker_build_options = --rm=true,--no-cache=true,--quiet=true,--force-rm=false
 postproc_cmd_csv = negative(),
-                   !rx_out('^Schazam!$'),
-                   !rx_out('^foobar$'),
+                   !rx_out('Schazam!$'),
+                   !rx_out('foobar$'),
                    !rx_err('Successfully built')
                    rx_err('returned a non-zero code'),
                    cnt_count('1'),
@@ -134,8 +140,8 @@ postproc_cmd_csv = negative(),
 dockerfile_dir_path = /bad
 docker_build_options = --rm=true,--no-cache=true,--quiet=false,--force-rm=true
 postproc_cmd_csv = negative(),
-                   rx_out('^Schazam!$'),
-                   !rx_out('^foobar$'),
+                   rx_out('Schazam!$'),
+                   !rx_out('foobar$'),
                    !rx_err('Successfully built')
                    rx_err('returned a non-zero code'),
                    cnt_count('0'),
@@ -159,7 +165,7 @@ docker_build_options = --rm=true,--no-cache=true,--quiet=false,--force-rm=false
 postproc_cmd_csv = positive(),
                    rx_out('\s*Successfully built\s*(\w{64}|\w{12})'),
                    !rx_out('Using cache')
-                   rx_out('^Schazam!$'),
+                   rx_out('Schazam!$'),
                    cnt_count('0'),
                    img_count('2'),
                    img_exst(),
@@ -172,7 +178,7 @@ docker_build_options2 = --rm=true,--no-cache=false,--quiet=false,--force-rm=fals
 postproc_cmd_csv2 = positive(),
                     rx_out('Using cache')
                     rx_out('\s*Successfully built\s*(\w{64}|\w{12})'),
-                    !rx_out('^Schazam!$'),
+                    !rx_out('Schazam!$'),
                     cnt_count('0'),
                     img_count('2'),
                     img_exst(),
@@ -229,8 +235,8 @@ postproc_cmd_csv = positive(),
 dockerfile_dir_path = /onbuild/first
 postproc_cmd_csv = positive(),
                    rx_out('\s*Successfully built\s*(\w{64}|\w{12})'),
-                   rx_out('^First!$'),
-                   !rx_out('^Schazam!$'),
+                   rx_out('First!$'),
+                   !rx_out('Schazam!$'),
                    cnt_count('0'),
                    img_count('3'),
                    img_exst(),
@@ -240,8 +246,8 @@ dockerfile_dir_path2 = /onbuild/second
 #: Second build ``postproc_cmd_csv``.
 postproc_cmd_csv2 = positive(),
                     rx_out('\s*Successfully built\s*(\w{64}|\w{12})'),
-                    rx_out('^Schazam!$'),
-                    rx_out('^Second!$'),
+                    rx_out('Schazam!$'),
+                    rx_out('Second!$'),
                     cnt_count('0'),
                     img_count('3'),
                     img_exst(),
@@ -251,8 +257,8 @@ dockerfile_dir_path3 = /onbuild/third
 #: Second build ``postproc_cmd_csv``.
 postproc_cmd_csv3 = positive(),
                     rx_out('\s*Successfully built\s*(\w{64}|\w{12})'),
-                    !rx_out('^Schazam!$'),
-                    rx_out('^Third!$'),
+                    !rx_out('Schazam!$'),
+                    rx_out('Third!$'),
                     cnt_count('0'),
                     img_count('3'),
                     img_exst(),

--- a/subtests/docker_cli/build/build.py
+++ b/subtests/docker_cli/build/build.py
@@ -201,10 +201,15 @@ class postprocessing(object):
 
     def basic_postprocess(self, build_def, command, parameter):
         del parameter  # not used
+        # June 2017: docker-1.13 ignores $TERM for build sub-command.
+        #            Jambs ANSI codes in output, BZ1403326
+        skip = ['nonprintables_check']
+        if self.config['enable_nonprintables_check']:
+            skip = None
         if command == 'positive':
             # Verify zero exit status and healthy output
             opg = OutputGood(build_def.dockercmd.cmdresult,
-                             ignore_error=True)
+                             skip=skip, ignore_error=True)
             if opg:
                 return build_def.dockercmd.cmdresult.exit_status == 0
             else:
@@ -214,7 +219,7 @@ class postprocessing(object):
         elif command == 'negative':
             # Verify non-zero exit status and no panics
             notbad = OutputNotBad(build_def.dockercmd.cmdresult,
-                                  ignore_error=True)
+                                  skip=skip, ignore_error=True)
             if notbad:
                 return build_def.dockercmd.cmdresult.exit_status != 0
             else:

--- a/subtests/docker_cli/build/expose.py
+++ b/subtests/docker_cli/build/expose.py
@@ -1,7 +1,6 @@
 import os
 from dockertest.networking import PortContainer
 from dockertest.output import mustpass
-from dockertest.output import wait_for_output
 from dockertest.dockercmd import AsyncDockerCmd
 from dockertest.dockercmd import DockerCmd
 from build import BuildSubSubtest
@@ -25,10 +24,8 @@ class expose(BuildSubSubtest):
         self.sub_stuff['async_dkrcmd'] = async_dkrcmd
         async_dkrcmd.execute(read_fd)
         os.close(read_fd)
-        os.write(write_fd, 'echo "StArTeD!"\n')
-        self.failif(not wait_for_output(lambda: async_dkrcmd.stdout,
-                                        "StArTeD!",
-                                        timeout=10), str(async_dkrcmd))
+        os.write(write_fd, '\necho "R""EADY"\n')
+        async_dkrcmd.wait_for_ready()
         return name
 
     def container_ports(self, name):


### PR DESCRIPTION
Docker ``1.12+`` regresses WRT this bug in that it adds additional
escape-codes to docker build output.  This is being (correctly)
caught by the ``OutputGood()`` check, however the bug seems
unlikely to ever be fixed.  Unfortunately, removing the check
isn't enough, because many sub-subtests also rely on regular-expression
matching against output.

For example, searching for ``^'Schazam!$'`` where the build output is:

```
Step 4/6 : RUN echo "Schazam!"
 ---> Running in cc59317feb51

[91m[0mSchazam!
 ---> 8a359f725df3
Removing intermediate container cc59317feb51
```

Would fail to match due to escape codes at the start of the important
line.  This commit adds a configurable option, defaulting to "off" which
enables checking for escape codes in ``OutputGood()``.  It also removes
the start-of-line match token from all the regex's, but leaves the
end-of-line token.  The assumption here is that escape codes will never
appear at the end of the line being matched (possibly not true).

Signed-off-by: Chris Evich <cevich@redhat.com>