### PR TITLE
new test: oci_umount_bz1472121

### DIFF
--- a/config_defaults/subtests/docker_cli/run_volumes.ini
+++ b/config_defaults/subtests/docker_cli/run_volumes.ini
@@ -1,5 +1,5 @@
 [docker_cli/run_volumes]
-subsubtests = volumes_rw, volumes_one_source, oci_umount
+subsubtests = volumes_rw, volumes_one_source, oci_umount, oci_umount_bz1472121
 #: These must be setup prior to testing
 __example__ = host_paths, cntr_paths
 #: Command-line string, required to succeed prior to testing (if any).


### PR DESCRIPTION
Intended as a short-lived test, to be removed maybe Sept 2017.
Purpose is to confirm that this regression is fixed on all
distributed builds of docker.

This tests for a corner case in oci-umount that triggers
a SEGV. Test fails (correctly) in docker-1.12.6-47.git0fdc778.el7,
passes in -48.

Signed-off-by: Ed Santiago <santiago@redhat.com>