### PR TITLE
Update DockerVersion with proper cache

### DIFF
--- a/dockertest/output/dockerversion.py
+++ b/dockertest/output/dockerversion.py
@@ -214,7 +214,6 @@ class DockerVersion(object):
         """
         return self._version('server')
 
-
     @staticmethod
     def _require(wanted, name, other_version):
         required_version = LooseVersion(wanted)

--- a/dockertest/output_unittests.py
+++ b/dockertest/output_unittests.py
@@ -126,6 +126,7 @@ class DockerVersionTest(unittest.TestCase):
     def setUp(self):
         import output
         self.output = output
+        self.output.DockerVersion.flush_cache()
 
     def test_client(self):
         version_string = ("Client version: 0.9.0\n"


### PR DESCRIPTION
Previously this class's methods duplicated a lot of code because
values were buffered as instance attributes.  However some values
were actually cached as class attributes.  Fix both by moving the
buffer items into a class-attribute dictionary.

De-duplicate all the separate client/server methods to use common
private-methods.

Add a method for flushing the cache, to help support unittesting.

Update unittests to flush cache prior to each test.

Signed-off-by: Chris Evich <cevich@redhat.com>

[--args=docker_cli/version]