### PR TITLE
Add class to cache NVRA queries from rpm command

### DIFF
--- a/dockertest/environment.py
+++ b/dockertest/environment.py
@@ -9,6 +9,8 @@ Low-level/standalone host-environment handling/checking utilities/classes/data
 
 import warnings
 import subprocess
+from collections import Mapping
+from collections import namedtuple
 # N/B: This module is automaticly generated from libselinux, so the
 # python docs are terrible.  The C library man(3) pages provided by
 # the 'libselinux-devel' RPM package (or equivilent) are much better.
@@ -91,3 +93,95 @@ def docker_rpm():
     """
     cmd = "rpm -q %s" % which_docker()
     return subprocess.check_output(cmd, shell=True).strip()
+
+
+class RPMS(Mapping):
+    """
+    Read-only mapping of rpm names to ``nvra_type`` instances
+
+    :param args: Same as standard ``dict()`` positional arguments.
+    :param dargs: Same as standard ``dict()`` keyword arguments.
+    """
+
+    #: Class to use for representing nvra values, the first index
+    #: must be the package name.
+    nvra_type = namedtuple('nvra_type',
+                           ('name', 'version', 'release', 'arch'))
+    nvra_len = len(nvra_type._fields)
+
+    #: Query command to use for looking up a package NVRA must
+    #: return line-delimited items of hash-delimited fields
+    #: suitable for initializing ``nvra_type``.
+    rpmcmd = ("/usr/bin/rpm", "-q", "--qf", '%{N}#%{V}#%{R}#%{ARCH}\n')
+
+    #: Callable to use for executing rpmcmd
+    execute = staticmethod(subprocess.check_output)
+
+    #: Private, do not use
+    _cache = None
+    _alldone = None
+
+    def __new__(cls, *args, **dargs):
+        del args, dargs  # not used
+        if cls._cache is None:
+            cls.flush()
+        return object.__new__(cls)
+
+    def __init__(self, *args, **dargs):
+        # Support dict API
+        if not self._cache and (args or dargs):
+            argtest = dict(*args, **dargs)
+            for key, value in argtest.iteritems():
+                try:
+                    self._cache[key] = self.nvra_type(*value)
+                except TypeError:
+                    raise TypeError("Initializer key %s's value %s"
+                                    " incompatible with %s"
+                                    % (key, value, self.nvra_type))
+
+    @classmethod
+    def _store(cls, name):
+        cmd = list(cls.rpmcmd) + [name]
+        xcept_fmt = ("%s did not return expected line-delimited"
+                     " items of hash-delimited fields as"
+                     " output: %s")
+        output = cls.execute(cmd)
+        for value in output.strip().splitlines():
+            # Use a field-delimiter incompatible with any field value
+            new_nvra = cls.nvra_type(*value.strip().split('#'))
+            if len(new_nvra) != cls.nvra_len:
+                raise ValueError(xcept_fmt % (' '.join(cmd), output))
+            new_name = new_nvra[0]  # documented in class attr. defs. above
+            cls._cache[new_name] = new_nvra
+
+    @classmethod
+    def __getitem__(cls, key):
+        # Don't allow passing arguments to query directly
+        if not key.startswith('-') and key not in cls._cache:
+            cls._store(key)
+        return cls._cache[key]
+
+    @classmethod
+    def fill(cls, method_name=None):
+        """
+        Query and cache details from all packages
+
+        :param method_name: Optional, return cache method with this name
+        """
+        if not cls._alldone:
+            cls._store('-a')  # This is going to take a long while
+            cls._alldone = True
+        if method_name:
+            return getattr(cls._cache, method_name)
+
+    # All of these require a full query
+    __iter__ = classmethod(lambda cls: cls.fill('__iter__')())
+    __len__ = classmethod(lambda cls: cls.fill('__len__')())
+    __contains__ = classmethod(lambda cls, item:
+                               cls.fill('__contains__')(item))
+
+    @classmethod
+    def flush(cls):
+        """Flush cache of RPM NVRAs to force fresh queries on access"""
+        cls._cache = dict()
+        cls._alldone = False

--- a/dockertest/environment_unittests.py
+++ b/dockertest/environment_unittests.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+
+# Pylint runs from a different directory, it's fine to import this way
+# pylint: disable=W0403
+
+import unittest
+
+class FakeCheckOutput(object):
+
+    exception = None
+    callcount = 0
+    command = None
+    name = None
+    version = '1.0'
+    release = 'a'
+    arch = '8088'
+    output_fmt = '%s#%s#%s#%s\n'
+    allnvras = (('one', 2, 3, 4),
+                ('five', '6', '7', '8'),
+                ('a', 'b', 'c', 'd'))
+
+    def __call__(self, command, *args, **dargs):
+        del args  # don't care
+        del dargs  # also don't care
+        self.callcount += 1
+        self.command = command
+        # Don't modify the input container value
+        self.name = list(command).pop()
+        if self.exception:
+            was = self.exception
+            self.exception = None
+            raise was("Raised by FakeCheckOutput")
+        if self.name in ['-a', '--all']:
+            return ''.join([self.output_fmt % nvra for nvra in self.allnvras])
+        return self.output_fmt % (self.name, self.version,
+                                  self.release, self.arch)
+
+    def reset(self):
+        self.exception = None
+        self.callcount = 0
+        self.command = None
+        self.name = None
+
+
+class TestRPMS(unittest.TestCase):
+
+    def setUp(self):
+        from dockertest import environment
+        self.environment = environment
+        self.fakecheckoutput = FakeCheckOutput()
+        self.fakecheckoutput.reset()
+        self.environment.RPMS.flush()
+        self.original_execute = self.environment.RPMS.execute
+        self.environment.RPMS.execute = staticmethod(self.fakecheckoutput)
+
+    def teardown(self):
+        self.fakecheckoutput.reset()
+        self.environment.RPMS.flush()
+        self.environment.RPMS.execute = self.original_execute
+
+    def test_init(self):
+        self.environment.RPMS()
+        self.assertEqual(self.fakecheckoutput.callcount, 0)
+
+    def test_existing(self):
+        original_type = self.environment.RPMS.nvra_type
+        try:
+            self.environment.RPMS.nvra_type = staticmethod(str)
+            initializer = dict(foo=('bar',), baz=('foo',))
+            expected = dict(foo=str(*initializer['foo']), baz=str(*initializer['baz']))
+            actual = self.environment.RPMS(**initializer)
+            for key in ('foo', 'baz'):
+                self.assertEqual(expected[key], actual[key])
+            self.assertEqual(self.fakecheckoutput.callcount, 0)
+        finally:
+            self.environment.RPMS.nvra_type = original_type
+
+    def test_callout(self):
+        original_type = self.environment.RPMS.nvra_type
+        try:
+            self.environment.RPMS.nvra_type = staticmethod(lambda *args: tuple(args))
+            rpms = self.environment.RPMS()
+            sfco = self.fakecheckoutput
+            self.assertEqual(rpms['foobar'], (sfco.name, sfco.version, sfco.release, sfco.arch))
+            self.assertEqual(sfco.callcount, 1)
+            # Make sure cache is utilized
+            self.assertEqual(rpms['foobar'], (sfco.name, sfco.version, sfco.release, sfco.arch))
+            self.assertEqual(sfco.callcount, 1)
+        finally:
+            self.environment.RPMS.nvra_type = original_type
+
+    def test_callout_badfmt(self):
+        original_type = self.environment.RPMS.nvra_type
+        self.fakecheckoutput.output_fmt = '%s,%s,%s,%s\n'
+        try:
+            self.environment.RPMS.nvra_type = staticmethod(lambda *args: tuple(args))
+            rpms = self.environment.RPMS()
+            sfco = self.fakecheckoutput
+            self.assertEqual(sfco.callcount, 0)
+            self.assertRaises(ValueError, rpms.__getitem__, 'foobar')
+        finally:
+            self.environment.RPMS.nvra_type = original_type
+
+    def test_all(self):
+        original_type = self.environment.RPMS.nvra_type
+        try:
+            self.environment.RPMS.nvra_type = staticmethod(lambda *args: tuple(args))
+            expected = dict([(str(nvra[0]),
+                              tuple([str(x) for x in nvra]))
+                             for nvra in self.fakecheckoutput.allnvras])
+            rpms = self.environment.RPMS()
+            self.assertEqual(len(rpms), 3)
+            for key in expected.keys():
+                self.assertTrue(key in rpms)
+                self.assertEqual(expected[key], rpms[key])
+            self.assertEqual(self.fakecheckoutput.callcount, 1)
+            self.assertEqual(rpms['foobar'], ('foobar', '1.0', 'a', '8088'))
+        finally:
+            self.environment.RPMS.nvra_type = original_type
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add a read-only dict-like interface for querying RPM NVRA's by package
name.  Support caching of previous queries within the class so all calls
in the same process-space can benefit.  Add unittests for exercising the
new class's major features.

Signed-off-by: Chris Evich <cevich@redhat.com>

[skip-ci]