### PR TITLE
HUGE: pylint cleanup for Fedora 26

### DIFF
--- a/dockertest/config.py
+++ b/dockertest/config.py
@@ -382,14 +382,14 @@ class Config(dict):
         """
         defaults_dict = configs_dict['DEFAULTS']
         def_warn = defaults_dict.get('__example__', '').lower()
-        if def_warn is not '':
+        if def_warn:
             def_warn = set(get_as_list(def_warn))
         else:
             def_warn = set()
         # Need to detect __example__ options that differ w/ existing
         old_sec = configs_dict[section]
         sec_warn = newcd.get_other('__example__', '').lower()
-        if sec_warn is not '':
+        if sec_warn:
             sec_warn = set(get_as_list(sec_warn))
         else:
             sec_warn = set()
@@ -405,7 +405,7 @@ class Config(dict):
                 sec_warn.remove(warn_option)  # change was made
             # else, contents unmodified, allow through
         # Re-form it back into a CSV
-        if len(sec_warn) > 0:
+        if sec_warn:
             newcd['__example__'] = ', '.join(sec_warn)
         else:
             # Everything overriden, prevent defaults creeping in
@@ -506,8 +506,8 @@ def none_if_empty(dict_like, key_name=None):
         keys = dict_like.keys()
     else:
         keys = [key_name]
-    for key_name in keys:
-        value = dict_like.get(key_name, "")
+    for key in keys:
+        value = dict_like.get(key, "")
         if(isinstance(value, (str, unicode)) and
            len(value.strip()) < 1):
-            dict_like[key_name] = None
+            dict_like[key] = None

--- a/dockertest/containers.py
+++ b/dockertest/containers.py
@@ -154,8 +154,7 @@ class DockerContainer(object):  # pylint: disable=R0902
         """
         if len(container_id) == 12:
             return container_id == self.long_id[:12]
-        else:
-            return container_id == self.long_id
+        return container_id == self.long_id
 
     def cmp_name(self, container_name):
         """
@@ -342,9 +341,9 @@ class DockerContainers(object):
                                         self.timeout)
             if cmdresult.exit_status == 0:
                 _json = json.loads(cmdresult.stdout.strip())
-                if len(_json) > 0:
+                if _json:
                     # No items in _json list should be empty either
-                    if all([len(item) > 0 for item in _json]):
+                    if all([bool(item) for item in _json]):
                         return _json
             #  failed command, empty list, or empty list item
             return None
@@ -380,7 +379,7 @@ class DockerContainers(object):
         cnts = self.list_containers_with_name(str(container_name))
         if len(cnts) == 1:
             return self.json_by_long_id(cnts[0].long_id)
-        elif len(cnts) == 0:
+        elif not cnts:
             raise ValueError("Container not found with name %s"
                              % container_name)
         else:
@@ -480,8 +479,7 @@ class DockerContainers(object):
         if self.remove_args is not None:
             return dkrcmd("rm %s %s" % (self.remove_args, container_id),
                           self.timeout)
-        else:
-            return dkrcmd("rm %s" % (container_id), self.timeout)
+        return dkrcmd("rm %s" % (container_id), self.timeout)
 
     def remove_by_obj(self, container_obj):
         """
@@ -502,7 +500,7 @@ class DockerContainers(object):
         cnts = self.list_containers_with_name(str(name))
         if len(cnts) == 1:
             return self.remove_by_obj(cnts[0])
-        elif len(cnts) == 0:
+        elif not cnts:
             raise ValueError("Container not found with name %s"
                              % name)
         else:
@@ -546,7 +544,7 @@ class DockerContainers(object):
         cnts = self.list_containers_with_name(str(name))
         if len(cnts) == 1:
             return self.wait_by_obj(cnts[0])
-        elif len(cnts) == 0:
+        elif not cnts:
             raise ValueError("Container not found with name %s"
                              % name)
         else:

--- a/dockertest/docdeps.py
+++ b/dockertest/docdeps.py
@@ -50,8 +50,7 @@ class DocItem(DocItemBase):
             _dct = newone.asdict()
             _dct['value'] = cls.empty_value
             return cls(**_dct)
-        else:
-            return newone
+        return newone
 
     def __cmp__(self, other):
         """Compare to another instance, ignoring ``desc`` and ``value``."""
@@ -235,10 +234,8 @@ class ConfigINIParser(tuple):
                 # Last chance to remove leading/trailing whitespace
                 state['desc'] = state['desc'].strip()
                 return True
-            else:
-                return False
-        else:
             return False
+        return False
 
     @classmethod
     def parse_non_section(cls, line, state):
@@ -256,11 +253,10 @@ class ConfigINIParser(tuple):
                 # Don't leave unnecessary whitespace if first is empty string
                 state['value'] = ('%s%s' % (state['value'], line)).strip()
                 return None  # Next line could value-continue also
-            else:  # line is junk
-                if cls.state_complete(state):
-                    return DocItem(**state)
-                else:
-                    return None  # ignore junk
+            # line is junk
+            if cls.state_complete(state):
+                return DocItem(**state)
+            return None  # ignore junk
         else:  # line contains at least an unseen option
             # Must be new option+value for desc already recorded or
             # a new undocumented after a prev. undocumented option-doc
@@ -425,7 +421,7 @@ class DocBase(object):
             dct.update(self.get_sub_method_dct())
         if self.sub_method_args is not None:
             dct.update(self.get_sub_method_args_dct())
-        if len(dct) > 0:
+        if dct:
             output_string = self.do_sub_str(self.fmt, dct)
         else:  # No substitutions to perform!
             output_string = self.fmt

--- a/dockertest/dockercmd.py
+++ b/dockertest/dockercmd.py
@@ -66,8 +66,7 @@ class DockerCmdBase(object):
         else:
             # Allow consecutive runs with modifications
             self.subargs = [arg.strip()
-                            for arg in subargs
-                            if arg is not None or arg is not '']
+                            for arg in subargs if arg]
         if timeout is None:
             # Defined in [DEFAULTS] guaranteed to exist
             self.timeout = float(subtest.config['docker_timeout'])
@@ -250,7 +249,7 @@ class DockerCmdBase(object):
                                   self.docker_options.strip())
         if self.subcmd is not None:
             complete = "%s %s" % (complete.strip(), self.subcmd.strip())
-        if len(self.subargs) > 0:
+        if self.subargs:
             complete = "%s %s" % (complete.strip(), " ".join(self.subargs))
         return complete.strip()
 
@@ -263,11 +262,6 @@ class DockerCmd(DockerCmdBase):  # pylint: disable=R0903
     Setup a call docker subcommand as if by CLI w/ subtest config integration
     Execute docker subcommand with arguments and a timeout.
     """
-
-    def __init__(self, subtest, subcmd, subargs=None, timeout=None,
-                 verbose=True):
-        super(DockerCmd, self).__init__(subtest, subcmd, subargs,
-                                        timeout, verbose)
 
     def execute(self, stdin=None):
         """
@@ -302,11 +296,6 @@ class AsyncDockerCmd(DockerCmdBase):
     """
     #: Private, class assumes exclusive access and no locking is performed
     _async_job = None
-
-    def __init__(self, subtest, subcmd, subargs=None, timeout=None,
-                 verbose=True):
-        super(AsyncDockerCmd, self).__init__(subtest, subcmd, subargs,
-                                             timeout, verbose)
 
     def execute(self, stdin=None):
         """
@@ -474,22 +463,19 @@ class AsyncDockerCmd(DockerCmdBase):
     def stdout(self):
         if self._async_job is None:
             return None
-        else:
-            return self._async_job.get_stdout()
+        return self._async_job.get_stdout()
 
     @property
     def stderr(self):
         if self._async_job is None:
             return None
-        else:
-            return self._async_job.get_stderr()
+        return self._async_job.get_stderr()
 
     @property
     def exit_status(self):
         if self._async_job is None:
             return None
-        else:
-            return self._async_job.sp.poll()
+        return self._async_job.sp.poll()
 
     @property
     def duration(self):

--- a/dockertest/documentation.py
+++ b/dockertest/documentation.py
@@ -68,7 +68,7 @@ class DefaultDoc(DocBase):
         """
         Represent entire contents of defaults configuration section.
         """
-        if len(self.docitems) == 0:
+        if not self.docitems:
             raise ValueError("No defaults.ini options were parsed from %s"
                              % self.ini_path)
         _fmt = ''
@@ -146,11 +146,11 @@ class ConfigDoc(DocBase):
         Represent entire contents of configuration section (if any)
         """
         # Handle simple case first
-        if len(self.docitems) == 0:
+        if not self.docitems:
             return ''
         _fmt = '\n\nConfiguration\n---------------\n\n'
         ssns = ["``%s``" % ssn for ssn in self.docitems.subsub_names]
-        if len(ssns) > 0:
+        if ssns:
             subsublist = ':Sub-subtests: %s' % ', '.join(ssns)
             _fmt = '%s%s\n\n' % (_fmt, subsublist)
         general_fmt = self._general_fmt()  # Could be empty
@@ -217,7 +217,7 @@ class ConfigDoc(DocBase):
         # Unroll each section's items under one heading per section
         lines = []
         for subsub_name in subsubs:
-            if len(subsubs[subsub_name]) == 0:
+            if not subsubs[subsub_name]:
                 continue  # Skip sections w/o any content
             lines.append('')  # blank before section content
             lines.append('``%s`` Sub-subtest' % subsub_name)  # Section heading

--- a/dockertest/images.py
+++ b/dockertest/images.py
@@ -227,8 +227,7 @@ class DockerImage(object):  # pylint: disable=R0902
 
         if len(image_id) == 12:
             return image_id == self.short_id
-        else:
-            return image_id == self.long_id
+        return image_id == self.long_id
 
     def cmp_full_name_with_component(self, repo, tag=None,
                                      repo_addr=None, user=None):
@@ -599,8 +598,7 @@ class DockerImages(object):
         if self.remove_args is not None:
             return dkrcmd("rmi %s %s"
                           % (self.remove_args, image_id), self.timeout)
-        else:
-            return dkrcmd("rmi %s" % image_id, self.timeout)
+        return dkrcmd("rmi %s" % image_id, self.timeout)
 
     def remove_image_by_full_name(self, full_name):
         """
@@ -616,8 +614,7 @@ class DockerImages(object):
         if self.remove_args is not None:
             return dkrcmd("rmi %s %s"
                           % (self.remove_args, full_name), self.timeout)
-        else:
-            return dkrcmd("rmi %s" % full_name, self.timeout)
+        return dkrcmd("rmi %s" % full_name, self.timeout)
 
     def remove_image_by_image_obj(self, image_obj):
         """

--- a/dockertest/output/dockerinfo.py
+++ b/dockertest/output/dockerinfo.py
@@ -106,7 +106,7 @@ class DockerInfo(object):
         if sub_key is None:
             return self.info_table[normalized_key]
         sub_fields = self.info_table[normalized_key + '...']
-        if len(sub_key) == 0:
+        if not sub_key:
             return sub_fields
         return sub_fields[_normalize(sub_key)]
 

--- a/dockertest/output/texttable.py
+++ b/dockertest/output/texttable.py
@@ -18,7 +18,7 @@ class ColumnRanges(Mapping):
     """
 
     # Too few pub. methods, pylint doesn't count abstract __special_methods__
-    # pylint: disable=R0903
+    # pylint: disable=R0903, W0231
 
     __slots__ = ('ranges', 'columns', 'count')
 
@@ -135,6 +135,7 @@ class TextTable(MutableSet, Sequence):
     _rows = None
 
     def __init__(self, table, columnranges=None, header=None, tabledata=None):
+        # pylint: disable=W0231
         if columnranges is not None and header is not None:
             raise ValueError("Cannot specify both columnranges and header "
                              "parameters")
@@ -205,11 +206,11 @@ class TextTable(MutableSet, Sequence):
         self.conform_or_raise(value)
         return self._rows.append(value)
 
-    def discard(self, index):
+    def discard(self, value):
         """
         Wraps del texttable[index[
         """
-        return self.__delitem__(index)
+        return self.__delitem__(value)
 
     def append(self, value):
         """

--- a/dockertest/output/unseenlines.py
+++ b/dockertest/output/unseenlines.py
@@ -112,7 +112,7 @@ class UnseenLines(object):
 
     def peek(self):
         """Inspect incomplete-line buffer w/o integrating new I/O"""
-        if len(self.strbuffer):
+        if self.strbuffer:
             if self.log_fn is not None and callable(self.log_fn):
                 self.log_fn("(peek) %s" % self.strbuffer)
         return str(self.strbuffer)  # return a copy
@@ -312,9 +312,8 @@ class UnseenlineMatchPeek(UnseenlineMatch):
         if nextline is None and unseenlines.peek() != '':
             # Current-state only, does NOT gather new I/O
             return unseenlines.peek()
-        else:
-            # Could be None
-            return nextline
+        # Could be None
+        return nextline
 
 
 class NoUnseenlineMatch(UnseenlineMatch):

--- a/dockertest/output/validate.py
+++ b/dockertest/output/validate.py
@@ -169,8 +169,7 @@ class OutputGoodBase(AllGoodBase):
             msg = super(OutputGoodBase, self).__str__()
             return "%s\nSTDOUT:\n%s\nSTDERR:\n%s" % (msg, self.stdout_strip,
                                                      self.stderr_strip)
-        else:
-            return super(OutputGoodBase, self).__str__()
+        return super(OutputGoodBase, self).__str__()
 
     def callable_args(self, name):
         if name.endswith('_stdout'):
@@ -190,9 +189,9 @@ class OutputGoodBase(AllGoodBase):
                 detail = 'Command '
                 if exit_status != 0:
                     detail += 'exit %d ' % exit_status
-                if len(stdout) > 0:
+                if stdout > 0:
                     detail += 'stdout "%s" ' % stdout
-                if len(stderr) > 0:
+                if stderr:
                     detail += 'stderr "%s".' % stderr
                 self.details[checker] = detail
                 duplicate = True  # all other failures will be same

--- a/dockertest/subtestbase.py
+++ b/dockertest/subtestbase.py
@@ -72,7 +72,7 @@ class SubBase(object):
         self.log_step_msg('initialize')
         # Issue warnings for failed to customize suggested options
         not_customized = self.config.get('__example__', None)
-        if not_customized is not None and not_customized is not '':
+        if not_customized:
             self.logdebug("WARNING: Recommended options not customized:")
             for nco in get_as_list(not_customized):
                 self.logdebug("WARNING: %s" % nco)

--- a/dockertest/textwriter.py
+++ b/dockertest/textwriter.py
@@ -427,7 +427,7 @@ class TextTranslator(nodes.NodeVisitor):
         self.end_state(first='[%s] ' % self._footnote)
 
     def visit_citation(self, node):
-        if len(node) and isinstance(node[0], nodes.label):
+        if node and isinstance(node[0], nodes.label):
             self._citlabel = node[0].astext()
         else:
             self._citlabel = ''

--- a/run_pylint.sh
+++ b/run_pylint.sh
@@ -60,6 +60,17 @@ import autotest.common
 import dockertest
 "
 
+declare -a PYLINT_OPTS=(-rn
+                        --output-format=colorized
+                        --rcfile=/dev/null
+                        --deprecated-modules=regsub,TERMIOS,Bastion,rexec,pdb
+                        --msg-template="${MSGFMT}")
+
+# pylint 1.7.1 (f26) has an annoying "Your code has been rated at" message
+if pylint --help 2>/dev/null | grep -q -- -score; then
+    PYLINT_OPTS+=("--score=n")
+fi
+
 # Run from top-level dir
 MYDIR=$(dirname "$0")
 if [ "$PWD" != "$MYDIR" ]
@@ -113,23 +124,19 @@ run_ff() {
 check_dockertest() {
     WHAT="$1"
     echo -e "Checking: ${WHAT} "
-    run_ff pylint -rn --init-hook="$INIT_HOOK" \
+    run_ff pylint "${PYLINT_OPTS[@]}" \
+           --init-hook="$INIT_HOOK" \
            --disable="$DISABLEMSG" \
            --max-args=6 \
            --min-public-methods=2\
            --no-docstring-rgx='(__.*__)|(_.*)|(__init__)' \
-           --output-format="colorized" \
-           --rcfile=/dev/null \
-           --deprecated-modules=regsub,TERMIOS,Bastion,rexec,pdb \
-           --msg-template="$MSGFMT" "${WHAT}"
+           "${WHAT}"
     # Just print FIXME/TODO warnings, don't fail on them.
-    pylint -rn --init-hook="$INIT_HOOK" \
+    pylint "${PYLINT_OPTS[@]}" \
+               --init-hook="$INIT_HOOK" \
                --disable=all \
                --enable=W0511 \
-               --output-format="colorized" \
-               --rcfile=/dev/null \
-               --deprecated-modules=regsub,TERMIOS,Bastion,rexec,pdb \
-               --msg-template="$MSGFMT" "${WHAT}"
+               "${WHAT}"
     if [ -n "$PEP8" ]
     then
         run_ff $PEP8 --ignore=$PEP8IGNORE "$WHAT"
@@ -149,23 +156,19 @@ check_dockertests() {
 check_subtest() {
     WHAT="$1"
     echo -e "Checking: ${WHAT} "
-    run_ff pylint -rn --init-hook="$SUBTESTINIT_HOOK" \
+    run_ff pylint "${PYLINT_OPTS[@]}" \
+           --init-hook="$SUBTESTINIT_HOOK" \
            --disable="$SUBTESTDISABLEMSG" \
            --max-args=8 \
            --max-locals=20 \
            --min-public-methods=1\
-           --output-format="colorized" \
-           --rcfile=/dev/null \
-           --deprecated-modules=regsub,TERMIOS,Bastion,rexec,pdb \
-           --msg-template="$MSGFMT" "${WHAT}"
+           "${WHAT}"
     # Just print FIXME/TODO warnings, don't fail on them.
-    pylint -rn --init-hook="$SUBTESTINIT_HOOK" \
+    pylint "${PYLINT_OPTS[@]}" \
+               --init-hook="$SUBTESTINIT_HOOK" \
                --disable=all \
                --enable=W0511 \
-               --output-format="colorized" \
-               --rcfile=/dev/null \
-               --deprecated-modules=regsub,TERMIOS,Bastion,rexec,pdb \
-               --msg-template="$MSGFMT" "${WHAT}"
+               "${WHAT}"
     if [ -n "$PEP8" ]
     then
         run_ff $PEP8 --ignore=$PEP8IGNORE "$WHAT"

--- a/subtests/docker_cli/build/build.py
+++ b/subtests/docker_cli/build/build.py
@@ -163,7 +163,7 @@ class postprocessing(object):
         result = []
         commands = []
         for command_param in get_as_list(build_def.postproc_cmd_csv):
-            if command_param is '' or command_param is None:
+            if not command_param:
                 continue
             mobj = self.RE_CSVCMD.search(command_param)
             if not mobj:
@@ -212,20 +212,18 @@ class postprocessing(object):
                              skip=skip, ignore_error=True)
             if opg:
                 return build_def.dockercmd.cmdresult.exit_status == 0
-            else:
-                self.logwarning('Positive output expected but check'
-                                ' failed: %s', str(opg))
-                return False
+            self.logwarning('Positive output expected but check'
+                            ' failed: %s', str(opg))
+            return False
         elif command == 'negative':
             # Verify non-zero exit status and no panics
             notbad = OutputNotBad(build_def.dockercmd.cmdresult,
                                   skip=skip, ignore_error=True)
             if notbad:
                 return build_def.dockercmd.cmdresult.exit_status != 0
-            else:
-                self.logwarning('Negative output expected, but'
-                                ' this is worse: %s', str(notbad))
-                return False
+            self.logwarning('Negative output expected, but'
+                            ' this is worse: %s', str(notbad))
+            return False
         else:
             raise DockerTestError("Command error: %s" % command)
 
@@ -241,10 +239,10 @@ class postprocessing(object):
             self.logdebug("%s(%s) Matched regex: %s", command,
                           parameter, bool(mobj))
             return bool(mobj)  # matched at least one line
-        else:  # must not match
-            self.logdebug("%s(%s) Not-matched regex: %s", command,
-                          parameter, not bool(mobj))
-            return not bool(mobj)  # matched on any line
+        # must not match
+        self.logdebug("%s(%s) Not-matched regex: %s", command,
+                      parameter, not bool(mobj))
+        return not bool(mobj)  # matched on any line
 
     def count_postprocess(self, build_def, command, parameter):
         del build_def  # not used
@@ -281,7 +279,7 @@ class postprocessing(object):
         self.logdebug("%s() current images:\n%s", command,
                       '\n'.join([img.full_name
                                  for img in images
-                                 if img.full_name is not '']))
+                                 if img.full_name]))
         matches = [img
                    for img in images
                    if img.cmp_greedy_full_name(build_def.image_name)]
@@ -290,7 +288,7 @@ class postprocessing(object):
             if len(matches) != 1:
                 return False
         else:  # negative test
-            if len(matches) != 0:
+            if matches:
                 return False
         return True
 

--- a/subtests/docker_cli/events/events.py
+++ b/subtests/docker_cli/events/events.py
@@ -213,7 +213,7 @@ class events(Subtest):
         cid = self.stuff['nfdc_cid'] = cmdresult.stdout.strip()
         while True:
             _json = dc.json_by_long_id(cid)
-            if len(_json) > 0 and _json[0]["State"]["Running"]:
+            if _json and _json[0]["State"]["Running"]:
                 self.loginfo("Waiting for test container to exit...")
                 time.sleep(3)
             else:

--- a/subtests/docker_cli/images/images.py
+++ b/subtests/docker_cli/images/images.py
@@ -19,9 +19,6 @@ from dockertest.images import DockerImages
 class images(subtest.Subtest):
     config_section = 'docker_cli/images'
 
-    def initialize(self):
-        super(images, self).initialize()
-
     def run_once(self):
         super(images, self).run_once()
         # 1. Run with no options

--- a/subtests/docker_cli/kill_bad/kill_bad.py
+++ b/subtests/docker_cli/kill_bad/kill_bad.py
@@ -79,12 +79,6 @@ class kill_bad_base(subtest.SubSubtest):
         self.logdebug("Killing nonexisting containe.")
         mustfail(DockerCmd(self, 'kill', [nonexisting_name]).execute(), 1)
 
-    def postprocess(self):
-        """
-        No postprocess required.
-        """
-        super(kill_bad_base, self).postprocess()
-
     def cleanup(self):
         super(kill_bad_base, self).cleanup()
         if self.config['remove_after_test']:

--- a/subtests/docker_cli/negativeusage/negativeusage.py
+++ b/subtests/docker_cli/negativeusage/negativeusage.py
@@ -201,10 +201,10 @@ class Base(subtest.SubSubtest):
         super(Base, self).cleanup()
         if not self.config['remove_after_test']:
             return
-        if len(self.sub_stuff.get('RUNCNTR', [])):
+        if self.sub_stuff.get('RUNCNTR', []):
             dockercmd.DockerCmd(self, 'kill',
                                 [self.sub_stuff['RUNCNTR']]).execute()
-        if len(self.sub_stuff.get('STPCNTR', [])):
+        if self.sub_stuff.get('STPCNTR', []):
             dockercmd.DockerCmd(self, 'rm',
                                 ['--force', '--volumes',
                                  self.sub_stuff['STPCNTR']]).execute()

--- a/subtests/docker_cli/pull/wrong_registry_addr.py
+++ b/subtests/docker_cli/pull/wrong_registry_addr.py
@@ -14,9 +14,9 @@ from dockertest.output import OutputNotBad
 class wrong_registry_addr(pull_base):
 
     @staticmethod
-    def check_registry(addr):
-        # addr is expected to be incorrect
-        del addr
+    def check_registry(registry_addr):
+        # registry_addr is expected to be incorrect
+        del registry_addr
 
     def outputcheck(self):
         # Only verify no panics or really bad stuff

--- a/subtests/docker_cli/run_cgroups/cpushares.py
+++ b/subtests/docker_cli/run_cgroups/cpushares.py
@@ -43,8 +43,7 @@ class cpu_base(cgroups_base):
                    docker_cpushares == json_cpushares]
         if all(matches):
             return {'PASS': msg, 'FAIL': None}
-        else:
-            return {'FAIL': msg, 'PASS': None}
+        return {'FAIL': msg, 'PASS': None}
 
     def initialize(self):
         super(cpu_base, self).initialize()

--- a/subtests/docker_cli/run_cgroups/memory.py
+++ b/subtests/docker_cli/run_cgroups/memory.py
@@ -47,13 +47,12 @@ class memory_base(cgroups_base):
                 result = {'PASS': msg}
 
                 return result
-            else:
-                msg = ("container_memory is %s, "
-                       "unit %s, cgroup_memory is %s, status Unknown"
-                       % (container_memory, unit, cgroup_memory))
-                result = {'FAIL': msg}
+            msg = ("container_memory is %s, "
+                   "unit %s, cgroup_memory is %s, status Unknown"
+                   % (container_memory, unit, cgroup_memory))
+            result = {'FAIL': msg}
 
-                return result
+            return result
 
         if container_memory != cgroup_memory:
             msg = ("container_memory is %s "
@@ -61,12 +60,11 @@ class memory_base(cgroups_base):
                    % (container_memory, unit, cgroup_memory))
             result = {'FAIL': msg}
             return result
-        else:
-            msg = ("container_memory is %s, "
-                   "unit %s, cgroup_memory is %s"
-                   % (container_memory, unit, cgroup_memory))
-            result = {'PASS': msg}
-            return result
+        msg = ("container_memory is %s, "
+               "unit %s, cgroup_memory is %s"
+               % (container_memory, unit, cgroup_memory))
+        result = {'PASS': msg}
+        return result
 
     @staticmethod
     def combine_subargs(name, option, image, sub_command):
@@ -127,10 +125,9 @@ class memory_base(cgroups_base):
             memory.append(memory_value.split(unit)[0])
             memory.append(unit)
             return memory
-        else:
-            memory.append(memory_value)
-            memory.append(' ')
-            return memory
+        memory.append(memory_value)
+        memory.append(' ')
+        return memory
 
     def initialize(self):
         super(memory_base, self).initialize()
@@ -142,7 +139,7 @@ class memory_base(cgroups_base):
 
         if self.config['expect_success'] == "PASS":
             memory_value = str(self.config['memory_value'])
-            if memory_value is not '0':
+            if memory_value != '0':
                 for unit in unit_list:
                     memory_list.append(memory_value + unit)
             else:
@@ -197,10 +194,10 @@ class memory_base(cgroups_base):
                     ("expected this_result to be a dict; it's a %s" %
                      this_result.__class__))
         status = this_result.keys().pop()
-        if status is "PASS":
+        if status == "PASS":
             self.logdebug(this_result)
             passed.append(True)
-        elif status is 'FAIL':
+        elif status == 'FAIL':
             self.logerror(this_result)
             passed.append(False)
         else:
@@ -213,10 +210,10 @@ class memory_base(cgroups_base):
                         ("expected this_result to be a dict; it's a %s" %
                          this_result.__class__))
             status = this_result.keys().pop()
-            if status is "FAIL":
+            if status == "FAIL":
                 self.logdebug("Expected fail: %s", this_result)
                 passed.append(True)
-            elif status is 'FAIL':
+            elif status == 'FAIL':
                 self.logerror("Unexpected pass: %s", this_result)
                 passed.append(False)
             else:

--- a/subtests/docker_cli/run_volumes/run_volumes.py
+++ b/subtests/docker_cli/run_volumes/run_volumes.py
@@ -97,7 +97,9 @@ class volumes_base(SubSubtest):
             os.mkdir(host_path)
             # keys must coorespond with those used in *_template strings
             args = self.make_test_files(host_path)
-            args += (host_path, cntr_path)
+            # Inexplicable: pylint 1.7.1 (F26) can't grok '+= (host,cntr)'
+            args += (host_path)
+            args += (cntr_path)
             # list of dicts {'read_fn', 'write_fn', 'read_data', ...}
             test_dict = self.make_test_dict(*args)
             # unique cidfile for each container
@@ -276,7 +278,7 @@ class oci_umount(volumes_base):
                     should_not_be_mounted.append(line.strip())
         except IOError:
             raise DockerTestNAError("oci-umount not installed or configured")
-        if len(should_not_be_mounted) == 0:
+        if not should_not_be_mounted:
             raise DockerTestNAError("oci-umount is disabled")
         self.stuff['should_not_be_mounted'] = should_not_be_mounted
 

--- a/subtests/docker_cli/version/version.py
+++ b/subtests/docker_cli/version/version.py
@@ -27,9 +27,6 @@ from dockertest.docker_daemon import SocketClient
 
 class version(subtest.Subtest):
 
-    def initialize(self):
-        super(version, self).initialize()
-
     def run_once(self):
         super(version, self).run_once()
         # 1. Run with no options

--- a/subtests/example/example.py
+++ b/subtests/example/example.py
@@ -40,6 +40,7 @@ class example(subtest.Subtest):
         """
         super(example, self).initialize()  # Prints out basic info
         # Do Something useful here, store run_once input in 'stuff'
+        self.stuff['sample_key'] = 'a'
 
     def setup(self):
         """
@@ -47,6 +48,7 @@ class example(subtest.Subtest):
         """
         super(example, self).setup()  # Prints out basic info
         # Do Something useful here
+        self.stuff['something_else'] = 'b'
 
     def run_once(self):
         """
@@ -54,6 +56,7 @@ class example(subtest.Subtest):
         """
         super(example, self).run_once()  # Prints out basic info
         # Do Something useful here, store results in 'stuff'
+        self.stuff['dc'] = 'DockerCmd(...)'
 
     def postprocess_iteration(self):
         """
@@ -61,6 +64,7 @@ class example(subtest.Subtest):
         """
         super(example, self).postprocess_iteration()  # Prints out basic info
         # Do Something useful here, check 'stuff' for iteration-errors
+        self.stuff['postprocess_iteration'] = 'nobody ever uses this'
 
     def postprocess(self):
         """
@@ -68,6 +72,7 @@ class example(subtest.Subtest):
         """
         super(example, self).postprocess()  # Prints out basic info
         # Do Something useful here, check 'stuff' for overall errors
+        self.stuff['postprocess'] = 'this is where you check results'
 
     def cleanup(self):
         """
@@ -75,3 +80,4 @@ class example(subtest.Subtest):
         """
         super(example, self).cleanup()  # Prints out basic info
         # Do Something useful here, leave environment as we received it
+        self.stuff['cleanup'] = 'blah blah'


### PR DESCRIPTION
This is the usual new-Fedora cleanup checkin. It resolves
problems detected by a new version of pylint (1.7.1, up
from 1.6.4 in f25).

The vast majority of the fixes were simple and need little explanation:
    C1801:[...]: Do not use `len(SEQUENCE)` as condition value  (26)
    R1705:[...]: Unnecessary "else" after "return"              (25)
    R0123:[...]: Comparison to literal                          (13)

  (number in parentheses is the total count of this warning).

This one needs just a minor note:

    W0235:[...]: Useless super delegation in method 'xxxxxx'    (12)
        -- mostly fixed by removing superfluous code. In the case
           of example.py, I just added useless demo code that
           references self.stuff[].

The rest need explaining:

    W0221:[...]: X.lmnop: Parameters differ from overridden 'lmnop' method
        -- 3 instances. Solved by renaming args or, in one case,
           adding positional parameters matching the base method.

    W0231:[...]: X.__init__: __init__ method from base class 'Y' is not called
        -- 3 instances. Not fixed, because as best I can tell it's
           a false positive! The base class does not have an __init__()!
           If I add a super(), pylint complains with:
               E1101:139,8: TextTable.__init__: Super of 'TextTable' has no '__init__' member
           So I just added pylint disable directives... which, I fear,
           may cause earlier-pylint (such as in the one in CI) to fail.
           I'll deal with that if/when it happens.

    R1704:[...]: fname: Redefining argument with the local name 'kname'
        -- Good catch. Fixed.

    E0012:[...]: Bad option value 'R0204'
        -- Sigh. pylint has a habit of abandoning error codes, then
           treating them as errors if it sees them in a 'pylint ignore'
           directive. This makes it hard to write such directives and
           run pylint on multiple environments. Fortunately, in this
           case the directive was unnecessary: it was much easier to
           just fix the code.

    E1121:[...]: volumes_base.init_path_info: Too many positional arguments for staticmethod call
        -- Saving the best for last. This one baffles me; I'm pretty
           sure it's a bug in pylint.

And, finally, there's run_pylint.sh. The reason for changing it is
that the new pylint has an unwelcome and undesired "Your code has
been rated at N.M/10" message. It clutters the log output and adds
no useful value... so we disable it. The reason the changes are so
huge in here is because I cleaned up duplication.

Signed-off-by: Ed Santiago <santiago@redhat.com>