### PR TITLE
Add supporting class for testing with bash

### DIFF
--- a/config_custom/control.ini
+++ b/config_custom/control.ini
@@ -1,0 +1,83 @@
+# Autotest-control configuration, not consumed by dockertest or subtests
+# directly.  Though job.resultdir will contain an updated reference copy.
+
+[Control]
+
+# Subtests/sub-subtest names to run (CSV, in order)
+# **instead** of searching the subtests directory.
+# Any also specified by the --args i=<csv> sub-option and
+# are not on this list, will prefix resulting list (also in order)
+
+# e.g. "docker_cli/version"
+include =
+
+# Subtests/sub-subtest names to remove from include (above)
+# in addition to any specified by --args x=<csv> sub-option.
+# e.g. "docker_cli/run,docker_cli/attach/no_stdin"
+exclude = example,subexample,bashexample,pretest_example,intratest_example,
+          posttest_example
+
+# Subtests/Sub-subtest to consider for inclusion before
+# consulting include/exclude (above).
+subthings = dummy/test
+
+# Directory relative to control file, where pre-test modules
+# are located.  These execute in alpha-order before any other
+# modules.
+pretests =
+
+# Directory relative to control file, where sub-test modules
+# are located.  These are the main testing module content,
+# controlled by subthings, include, and exclude (above).
+subtests = subtests
+
+# Directory relative to control file, where intra-test modules
+# are located.  These are executed in alpha-order, in-between
+# each subtest module.
+intratests =
+
+# Directory relative to control file, where post-test modules
+# are located.  These execute in alpha-order, after all subtest
+# modules.
+posttests =
+
+[Bugzilla]
+
+# If non-empty, enable automatic additions to exclude list,
+# by bugzilla status.  Bugzilla server url to connect to
+url = https://bugzilla.redhat.com/xmlrpc.cgi
+
+# Authentication options if required
+username =
+password =
+
+# This will automatically be populated
+# with names of subtests/sub-subtests excluded
+# in results reference control.ini.  Though you may add
+# items here but they will have the same effect as if they
+# were added in 'exclude' (above)
+excluded =
+
+# Bugzilla bug field name that encodes the subtest/sub-subtest
+# name to exclude.  The format searched for is '<key_match>:<subthing>'
+# where key_match is defined below.  e.g. 'whiteboard' will look for
+# <key_match>:<subthing> in the 'whiteboard' bug field.
+key_field = status_whiteboard
+
+# Value that must match inside key_field for query (below), this allows
+# differientiation between different jobs/configurations matching
+# their own set of bugs.  It's used along with the key_field (above)
+key_match = docker-autotest
+
+[Query]
+
+# All keys/values defined here will be passed as arguments to
+# Bugzilla.build_query() in addition to 'status' and
+# 'key_match' above.
+
+product = Red Hat Enterprise Linux 7, Fedora
+component = docker, docker-latest, docker-distribution, docker-registry,
+            atomic, rhel-server-atomic, rhel-server-docker, rhel-tools-docker,
+            rsyslog-docker, sadc-docker, sssd-docker, runc, skopeo,
+            ostree, rpm-ostree, docker-selinux, container-selinux
+status = NEW, ASSIGNED, POST, MODIFIED, ON_DEV, VERIFIED

--- a/config_custom/defaults.ini
+++ b/config_custom/defaults.ini
@@ -1,0 +1,55 @@
+[DEFAULTS]
+# Don't change this file, or any file under this tree!
+#
+# Instead, copy the files you want to modify under config_custom/
+# (anywhere), and modify those copyies.  They will override
+# all settings and sections defined here (config_defaults/)
+
+##### API Version number applying to all bundled tests
+config_version = 0.8.7
+
+#: Autotest version dependency for framework (or override for individual tests)
+autotest_version = @!NOVERSIONCHECK!@
+
+##### docker command options
+
+#: Docker default options (before subcommand)
+docker_path = /usr/bin/docker
+
+#: Global docker client command options to use (CSV)
+docker_options =
+
+#: Max runtime in seconds for any docker command (auto-converts to float)
+docker_timeout = 300.0
+
+##### docker content options
+
+#: CSV list of options recommended for customization.  Tests will
+#: issue warnings when left unmodified from default values.  **This
+#: option is compounded from defaults, not overwritten!**
+__example__ = docker_repo_name, docker_repo_tag, preserve_fqins
+
+#: remote components (host:port)
+docker_registry_host = registry.access.redhat.com
+#: remote components (username)
+docker_registry_user = rhel7
+#: Default registry settings for testing
+#: (blank if not applicable)
+docker_repo_name = rhel
+#: Default image settings for testing
+#: (blank if not applicable)
+docker_repo_tag = latest
+
+##### Operational testing options
+
+#: Attempt to remove all created containers/images during test
+remove_after_test = yes
+
+#: CSV of possibly existing **full** image names to preserve.
+preserve_fqins = registry.access.redhat.com/rhel7/rhel:latest
+
+#: CSV of possibly existing **full** container names to preserve.
+preserve_cnames =
+
+#: Verify the system has SELinux set to enforcing mode.
+verify_enforcing = yes

--- a/config_custom/intratests.ini
+++ b/config_custom/intratests.ini
@@ -1,0 +1,6 @@
+[garbage_check]
+subsubtests = containers,images,nones,config
+#: If leftover images / containers are found, they should be removed.
+remove_garbage = no
+#: If images / containers exist after attempted removal, fail the test
+fail_on_unremoved = no

--- a/config_defaults/control.ini
+++ b/config_defaults/control.ini
@@ -14,7 +14,7 @@ include =
 # Subtests/sub-subtest names to remove from include (above)
 # in addition to any specified by --args x=<csv> sub-option.
 # e.g. "docker_cli/run,docker_cli/attach/no_stdin"
-exclude = example,subexample,pretest_example,intratest_example,
+exclude = example,subexample,bashexample,pretest_example,intratest_example,
           posttest_example
 
 # Subtests/Sub-subtest to consider for inclusion before

--- a/config_defaults/subtests/bashexample.ini
+++ b/config_defaults/subtests/bashexample.ini
@@ -1,0 +1,2 @@
+[bashexample]
+example_config_var = This value will show up in the shell environment

--- a/dockertest/subtest.py
+++ b/dockertest/subtest.py
@@ -240,7 +240,7 @@ class BashSubtest(Subtest):
 
     def run_once(self):
         """Call run_once.sh, fail test on non-zero exit"""
-        run(os.path.join(self.bindir, 'run_once.sh'),
+        run(os.path.join(self.bindir, 'run.sh'),
             stderr_is_expected=True)
 
     def cleanup(self):

--- a/subtests/bashexample/bashexample.py
+++ b/subtests/bashexample/bashexample.py
@@ -25,9 +25,9 @@ This shell-based example test does not require anything other than
 Autotest, Docker autotest, this file and three shell-shell scripts.
 """
 
-from dockertest import BashSubtest
+from dockertest.subtest import BashSubtest
 
-class bashexample(subtest.BashSubtest):
+class bashexample(BashSubtest):
     """
     Call out to ``initialize.sh``, ``run.sh`` and ``cleanup.sh``.
 

--- a/subtests/bashexample/bashexample.py
+++ b/subtests/bashexample/bashexample.py
@@ -1,0 +1,36 @@
+r"""
+Summary
+---------
+
+Textual description of *what* this subtest will exercize in general terms.
+The next section describes the steps it will take.  The ``Operational Detail``
+is optional, as is ``Prerequisites``.
+
+Operational Summary
+----------------------
+
+#. Summary of step one
+#. Summary of step two
+#. Summary of step three
+
+Operational Detail
+--------------------
+
+Example shell-based example test, nothing detailed about it.
+
+Prerequisites
+---------------
+
+This shell-based example test does not require anything other than
+Autotest, Docker autotest, this file and three shell-shell scripts.
+"""
+
+from dockertest import BashSubtest
+
+class bashexample(subtest.BashSubtest):
+    """
+    Call out to ``initialize.sh``, ``run.sh`` and ``cleanup.sh``.
+
+    Any non-zero exit (except from cleanup) will result in test failure.
+    The ``cleanup.sh`` script always runs, no matter what.
+    """

--- a/subtests/bashexample/cleanup.sh
+++ b/subtests/bashexample/cleanup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Cleanup steps must be performed here to restore the system"
+echo "as it was before initialize.sh ran."
+echo ""
+echo "The exit status of this script is reported, but ignored"
+echo ""

--- a/subtests/bashexample/initialize.sh
+++ b/subtests/bashexample/initialize.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Initialization steps should be performed here."
+echo "A non-zero exit will result in this test being skipped"
+echo ""
+echo "All configuration variables have been exported."
+echo "Including '$TMPDIR' which will automaticly be cleaned up"
+echo ""
+env

--- a/subtests/bashexample/run.sh
+++ b/subtests/bashexample/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "Test steps should be performed here.  A Non-zero"
+echo "exit will signal test-failure"
+echo ""
+echo "Current dir. ($PWD) is for results"
+echo ""
+echo "Other scripts, input data, etc. are in $(dirname $0)"
+echo ""
+echo "The same environment variables are available"
+env

--- a/subtests/dummy/test/cleanup.sh
+++ b/subtests/dummy/test/cleanup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "# docker kill $(cat that_one)"
+echo "# docker rm $(cat that_one)"
+if [ "$(cat this_one)" != "$default_fqin" ]
+then
+    echo "# docker rmi $(cat this_one)"
+fi

--- a/subtests/dummy/test/initialize.sh
+++ b/subtests/dummy/test/initialize.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+echo "$default_fqin" > this_one
+echo "$(basename $config_section)_$RANDOM" > that_one
+cat this_one that_one
+echo "# timeout $docker_timeout $docker_path pull $(cat this_one)"

--- a/subtests/dummy/test/run.sh
+++ b/subtests/dummy/test/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+pwd
+cat this_one that_one
+echo "# docker run -i --name $(cat that_one) $(cat this_one) echo 'hello world'"

--- a/subtests/dummy/test/test.py
+++ b/subtests/dummy/test/test.py
@@ -1,0 +1,36 @@
+r"""
+Summary
+---------
+
+Textual description of *what* this subtest will exercize in general terms.
+The next section describes the steps it will take.  The ``Operational Detail``
+is optional, as is ``Prerequisites``.
+
+Operational Summary
+----------------------
+
+#. Summary of step one
+#. Summary of step two
+#. Summary of step three
+
+Operational Detail
+--------------------
+
+Example shell-based example test, nothing detailed about it.
+
+Prerequisites
+---------------
+
+This shell-based example test does not require anything other than
+Autotest, Docker autotest, this file and three shell-shell scripts.
+"""
+
+from dockertest.subtest import BashSubtest
+
+class test(BashSubtest):
+    """
+    Call out to ``initialize.sh``, ``run.sh`` and ``cleanup.sh``.
+
+    Any non-zero exit (except from cleanup) will result in test failure.
+    The ``cleanup.sh`` script always runs, no matter what.
+    """


### PR DESCRIPTION
Sometimes we're in a hurry, and just need to toss a quick and
simplistic test using only shell-scripts.  Support this
with a new ``BashSubtest`` class and example implementation
in ``subtests/bashexample/``.

[skip-ci]