### PR TITLE
fix namespace designation WRT fedora_test_image

### DIFF
--- a/config_defaults/docker_test_images.ini
+++ b/config_defaults/docker_test_images.ini
@@ -11,6 +11,6 @@ extra_fqins_csv = docker.io/stackbrew/centos:latest
 update_defaults_ini = True
 
 #: Name of image, dockerfile location, and options to build.  For example:
-#: build_name = localhost/fedora_test_image:latest
+#: build_name = fedora_test_image:latest
 #: build_dockerfile = https://github.com/autotest/autotest-docker/raw/master/fedora_test_image.tar.gz
 build_opts_csv = --no-cache,--pull,--force-rm

--- a/index.rst
+++ b/index.rst
@@ -192,7 +192,7 @@ to the steps above, a custom test-image must be configured for building.
         [root@docker client]# $EDITOR tests/docker/config_custom/defaults.ini
 
         ...
-        docker_registry_host = localhost
+        docker_registry_host =
         docker_registry_user =
         docker_repo_name = fedora_test_image
         docker_repo_tag = latest
@@ -209,7 +209,7 @@ to the steps above, a custom test-image must be configured for building.
         [root@docker client]# $EDITOR tests/docker/config_custom/docker_test_images.ini
 
         ...
-        build_name = localhost/fedora_test_image:latest
+        build_name = fedora_test_image:latest
         build_dockerfile = https://github.com/autotest/autotest-docker/raw/master/fedora_test_image.tar.gz
         build_opts_csv = --no-cache,--pull,--force-rm
         ...


### PR DESCRIPTION
If it's there, then docker feels compelled to try and contact the
localhost registry (which doesn't exist).  Instead, if the
default test image was deleted, we want tests to fail as early as
possible.

Also updated documentation.  This change needs to be paired with
a similar change being made in ADEPT.

Signed-off-by: Chris Evich <cevich@redhat.com>

[skip-ci]