### PR TITLE
Fix looking for excluded sub-subtest configs

### DIFF
--- a/dockertest/subtest.py
+++ b/dockertest/subtest.py
@@ -394,11 +394,11 @@ class SubSubtestCaller(Subtest):
             if len(children) < 1:
                 return  # No children specified
             # Any children NOT listed in fullnames are 'undefined'
-            # unless they were excluded by (an old) bugzilla
-            missing_section = children - fullnames - bzexclude
+            # unless they were excluded
+            missing_section = children - fullnames - bzexclude - excludes
             if missing_section:
                 msg = ("Sub-subtest(s) %s referenced in control include, "
-                       "exclude, and/or subthings but not defined in "
+                       "and/or subthings but not defined in "
                        'subsubtests = %s'
                        % (missing_section, self.subsubtest_names))
                 raise DockerTestError(msg)


### PR DESCRIPTION
With a setup to run tests on Fedora 26 (pre-built image),
given the following in ``config_custom/control.ini``

exclude = docker_test_images/puller
subthings = docker_cli/dockerhelp

and the following in ``config_custom/subtests.ini``

[docker_test_images]
subsubtests = builder
extra_fqins_csv =
build_name = fedora_test_image:latest
build_dockerfile = https://github.com/autotest/autotest-docker/raw/master/fedora_test_image.tar.gz
build_opts_csv = --pull,--force-rm
update_defaults_ini = True

The ``SubSubtestCaller`` caller class will fail with an error trying to
find 'docker_test_images/puller' (referenced by exclude) in
``subsubtests``.  This was originally intended to track down missing,
but expected sub-subtests during configuration processing.

It already (correctly) ignores bugzilla excludes, but for some reason checks
explicitly excluded items.  However, we absolutely don't care about
missing and excluded sub-subtests, because they won't be run.  Fix this
by removing all the explicitly excluded sub-subtests, from the check for
missing config. sections.

Signed-off-by: Chris Evich <cevich@redhat.com>