### PR TITLE
Support > 1 image in systemd_in_container test

### DIFF
--- a/config_defaults/subtests/docker_cli/systemd_in_container.ini
+++ b/config_defaults/subtests/docker_cli/systemd_in_container.ini
@@ -1,0 +1,5 @@
+[docker_cli/systemd_in_container]
+
+#: When non-empty, a CSV list of additional images to run this test against.
+#: *N/B:* The default test image is always exercized.
+fqins_to_test =

--- a/config_defaults/subtests/docker_cli/systemd_in_container.ini
+++ b/config_defaults/subtests/docker_cli/systemd_in_container.ini
@@ -2,4 +2,4 @@
 
 #: When non-empty, a CSV list of additional images to run this test against.
 #: *N/B:* The default test image is always exercized.
-fqins_to_test =
+fqins_to_test = fedora:latest,centos:latest


### PR DESCRIPTION
For images based on the base-image, it's useful to confirm they retain
support for running systemd.  Enable this (optionally) by iterating over
an CSV list of FQINs from the test configuration.  This way failure of
the test against any one image doesn't impact testing of the othe

# Not yet ready for any testing, just a quickly written-idea.
[skip-ci]
[--args=docker_cli/systemd_in_container]