### PR TITLE
run_cgroup_parent test: don't require a controller

### DIFF
--- a/subtests/docker_cli/run_cgroup_parent/run_cgroup_parent.py
+++ b/subtests/docker_cli/run_cgroup_parent/run_cgroup_parent.py
@@ -103,7 +103,7 @@ class run_cgroup_parent_base(SubSubtest):
         # ...where <path> must exactly match the one in our test setup.
         stdout = cmdresult.stdout.strip()
         if path_exp:
-            re_cgroup = re.compile(r'^(\d+):([^:]+):(.*)')
+            re_cgroup = re.compile(r'^(\d+):([^:]*):(.*)')
             found_match = False
             for line in stdout.split("\n"):
                 m = re.match(re_cgroup, line)


### PR DESCRIPTION
Fedora 26 /proc/1/cgroup includes the line '0::/init.scope',
i.e. the second field is empty. Our code was not expecting
that. Deal with it.

Signed-off-by: Ed Santiago <santiago@redhat.com>

[--args=docker_cli/run_cgroup_parent]