### PR TITLE
cp/every_last test: add python3 support

### DIFF
--- a/config_defaults/subtests/docker_cli/cp.ini
+++ b/config_defaults/subtests/docker_cli/cp.ini
@@ -4,6 +4,8 @@ subsubtests = simple,every_last,volume_mount
 [docker_cli/cp/simple]
 
 [docker_cli/cp/every_last]
+#: name of python executable. Usually python; need python3 on F26+ docker image
+python_path = python
 #: **quoted** CSV of directory/file prefixes to skip
 exclude_paths = "/dev", "/proc", "/sys", "/tmp", "/run/secrets"
 #: copy symlinks


### PR DESCRIPTION
The cp/every_last test invokes a hairy python script (via
command line) in a container. This fails when using a
Fedora 26 image.

First failure: fedora26 image includes /usr/bin/python3
but no plain python.

 * Solution: parameterize the name of the python executable,
   using new .ini field. CI environment using Fedora images
   can replace python with python3

Second failure: test fails with:

    TypeError: write() argument must be str, not bytes

 * Cause: python3 seems stricter about writing binary data to
   stdout; probably a UTF-8 requirement.

 * Solution: use stdout.buffer if available (python3 only),
   otherwise continue using stdout for output.

Signed-off-by: Ed Santiago <santiago@redhat.com>

[--args=docker_cli/cp]