### PR TITLE
run_flags: only run when storage == devicemapper

### DIFF
--- a/subtests/docker_cli/run_flags/run_flags.py
+++ b/subtests/docker_cli/run_flags/run_flags.py
@@ -12,34 +12,29 @@ daemon. Check for presence of expected option flags.
 
 import dockertest.docker_daemon
 from dockertest import subtest
-from dockertest.xceptions import DockerTestFail
+from dockertest.xceptions import DockerTestNAError
 
 
 class run_flags(subtest.SubSubtestCaller):
     pass
 
 
-class run_flags_base(subtest.SubSubtest):
-
-    def has_storage_opt(self, wanted):
-        docker_cmdline = dockertest.docker_daemon.cmdline()
-        self.logdebug("docker daemon command line: %s", docker_cmdline)
-        last_opt = ''
-        for opt in docker_cmdline:
-            if opt == wanted and last_opt == '--storage-opt':
-                return True
-            last_opt = opt
-        self.logwarning("Option '%s' not in %s" % (wanted, docker_cmdline))
-        return False
-
-
-class run_flags_deferred_removal(run_flags_base):
+class run_flags_deferred_removal(subtest.SubSubtest):
     """
-    deferred REMOVAL should always be set in all docker versions we test.
+    deferred removal option should always be set when running
+    with devicemapper.
     """
 
     def postprocess(self):
         super(run_flags_deferred_removal, self).postprocess()
-        if self.has_storage_opt('dm.use_deferred_removal=true'):
-            return
-        raise DockerTestFail("missing option: dm.use_deferred_removal")
+        docker_cmdline = ' '.join(dockertest.docker_daemon.cmdline())
+
+        # deferred removal only meaningful with devicemapper
+        self.failif_not_in(' --storage-driver devicemapper',
+                           docker_cmdline,
+                           "docker command-line options",
+                           DockerTestNAError)
+
+        self.failif_not_in(' --storage-opt dm.use_deferred_removal=true',
+                           docker_cmdline,
+                           "docker command-line options")


### PR DESCRIPTION
The 'use_deferred_removal' flag is only required (and only
appropriate) when using devicemapper. The world is moving
toward overlay2. Skip this test when not on devicemapper.

Also, significant cleanup: use simple string check instead
of cumbersome list iteration; use failif_not_in(); remove
no-longer-used helper code. (Background: this subtest
originally also had a check for deferred deletion so it
made sense to refactor commonalities.)

Signed-off-by: Ed Santiago <santiago@redhat.com>

[--args=docker_cli/run_flags]