### PR TITLE
Remove annoying warning

### DIFF
--- a/dockertest/subtestbase.py
+++ b/dockertest/subtestbase.py
@@ -76,8 +76,6 @@ class SubBase(object):
             self.logdebug("WARNING: Recommended options not customized:")
             for nco in get_as_list(not_customized):
                 self.logdebug("WARNING: %s" % nco)
-            self.logwarning("WARNING: Test results may be externally "
-                            "dependent! (See debug log for details)")
         msg = "%s configuration:\n" % self.__class__.__name__
         for key, value in self.config.items():
             if key == '__example__' or key.startswith('envcheck'):


### PR DESCRIPTION
WARNING: Test results may be externally dependent! (See debug log for details

This message only points to a possible source of problems, it's
excessive logging at the WARNING level is basically just noise.

Since there's already a more specific warning at the DEBUG level, this
one can simply be killed outright.

Signed-off-by: Chris Evich <cevich@redhat.com>