### PR TITLE
images:remove_image_by_image_obj() - remove by ID, not name

### DIFF
--- a/dockertest/images.py
+++ b/dockertest/images.py
@@ -611,11 +611,12 @@ class DockerImages(object):
 
     def remove_image_by_image_obj(self, image_obj):
         """
-        Alias for remove_image_by_full_name(image_obj.full_name)
+        Remove an image. This is simply a convenience function so
+        callers don't need to access image_obj internals.
 
-        :return: Same as remove_image_by_full_name()
+        :returns: ``autotest.client.utils.CmdResult`` instance
         """
-        return self.remove_image_by_full_name(image_obj.full_name)
+        return self.remove_image_by_id(image_obj.long_id)
 
     def clean_all(self, fqins):
         """

--- a/dockertest/images_unittests.py
+++ b/dockertest/images_unittests.py
@@ -376,15 +376,15 @@ class DockerImageTestBasic(ImageTestBase):
                          "/foo/bar rmi 123456789012")
         self.assertEqual(d.remove_image_by_full_name('fedora:latest').command,
                          "/foo/bar rmi fedora:latest")
+        img_id = ("0d20aec6529d5d396b195182c0eaa82b"
+                  "fe014c3e82ab390203ed56a774d2c404")
         image_obj = self.images.DockerImage("fedora_repo", "last_tag",
-                                            ("0d20aec6529d5d396b195182c0eaa"
-                                             "82bfe014c3e82ab390203ed56a774"
-                                             "d2c404"),
+                                            img_id,
                                             "dd",
                                             "50 MB",
                                             None, "user_user")
         self.assertEqual(d.remove_image_by_image_obj(image_obj).command,
-                         "/foo/bar rmi user_user/fedora_repo:last_tag")
+                         "/foo/bar rmi %s" % img_id)
 
     def test_docker_images_lowlevel(self):
         images = self.images.DockerImages(self.fake_subtest)


### PR DESCRIPTION
Every so often the build subtest fails and leaves behind
an untagged intermediate image. This causes a cascade of
garbage_check failures:

    Found leftover images from prior test: [DockerImage(....)]

Root cause is that garbage_check _tries_ to remove these
images, but the underlying code was calling remove_by_fullname()
and fullname is undefined because TAG is <none>.

Solution: remove by image ID (hash), not name. This is reliable.

Signed-off-by: Ed Santiago <santiago@redhat.com>