### PR TITLE
Followup: removing images

### DIFF
--- a/dockertest/images.py
+++ b/dockertest/images.py
@@ -614,8 +614,15 @@ class DockerImages(object):
         Remove an image. This is simply a convenience function so
         callers don't need to access image_obj internals.
 
+        If the image has a tag, we try removing it by name: this is
+        robust when the same image might be tagged differently.
+        If there's no tag, as can happen during an incomplete
+        build subtest, try removing by ID.
+
         :returns: ``autotest.client.utils.CmdResult`` instance
         """
+        if image_obj.tag and image_obj.tag != '<none>':   # the usual case
+            return self.remove_image_by_full_name(image_obj.full_name)
         return self.remove_image_by_id(image_obj.long_id)
 
     def clean_all(self, fqins):

--- a/dockertest/images_unittests.py
+++ b/dockertest/images_unittests.py
@@ -384,7 +384,16 @@ class DockerImageTestBasic(ImageTestBase):
                                             "50 MB",
                                             None, "user_user")
         self.assertEqual(d.remove_image_by_image_obj(image_obj).command,
+                         "/foo/bar rmi user_user/fedora_repo:last_tag")
+
+        image_notag = self.images.DockerImage("fedora_repo", "<none>",
+                                              img_id,
+                                              "dd",
+                                              "50 MB",
+                                              None, "user_user")
+        self.assertEqual(d.remove_image_by_image_obj(image_notag).command,
                          "/foo/bar rmi %s" % img_id)
+
 
     def test_docker_images_lowlevel(self):
         images = self.images.DockerImages(self.fake_subtest)


### PR DESCRIPTION
The previous PR was buggy: docker can't remove an image by ID
if the image is tagged more than once, e.g.

    docker.io/fedora     latest     b0b140824a48
    docker.io/fedora     7          b0b140824a48

The error is:

    conflict: unable to delete b0b140824a48 (must be forced) - image is referenced in multiple repositories

Solution: only remove by ID if the image has no tag. Otherwise
(default case) remove by fullname. This may not always work;
we may need to fall back to:

    docker rmi $(docker images -f dangling=true -q)

Unfortunately, I can't manage to reliably reproduce the
case where an image has a name but no tag; this means I
can't actually test this code.

Signed-off-by: Ed Santiago <santiago@redhat.com>