### PR TITLE
workarounds for user namespace testing

### DIFF
--- a/dockertest/subtest.py
+++ b/dockertest/subtest.py
@@ -28,6 +28,7 @@ from xceptions import DockerTestNAError
 from xceptions import DockerTestError
 from xceptions import DockerSubSubtestNAError
 from dockertest.environment import selinux_is_enforcing
+import dockertest.docker_daemon as docker_daemon
 
 
 class Subtest(subtestbase.SubBase, test.test):
@@ -241,6 +242,12 @@ class SubSubtest(subtestbase.SubBase):
         self.tmpdir = tempfile.mkdtemp(prefix=classname + '_',
                                        suffix='tmpdir',
                                        dir=self.parent_subtest.tmpdir)
+        # When running with user namespaces, docker needs to see tmpdirs
+        if docker_daemon.user_namespaces_enabled():
+            uid = docker_daemon.user_namespaces_uid()
+            gid = docker_daemon.user_namespaces_gid()
+            os.chown(self.tmpdir, uid, gid)
+            os.chown(self.parent_subtest.tmpdir, uid, gid)
 
     @property
     def sub_stuff(self):

--- a/subtests/docker_cli/run_dns/run_dns.py
+++ b/subtests/docker_cli/run_dns/run_dns.py
@@ -19,6 +19,7 @@ from dockertest import subtest
 from dockertest.dockercmd import DockerCmd
 from dockertest.output import mustpass, mustfail
 from dockertest.images import DockerImage
+import dockertest.docker_daemon
 
 
 class run_dns(subtest.Subtest):
@@ -66,8 +67,11 @@ class run_dns(subtest.Subtest):
     def run_once(self):
         super(run_dns, self).run_once()
         fin = DockerImage.full_name_from_defaults(self.config)
-        self.stuff['subargs'] = ['--privileged', '--rm', fin,
-                                 "cat /etc/resolv.conf"]
+        privileged = ['--privileged']
+        if dockertest.docker_daemon.user_namespaces_enabled():
+            privileged.append('--userns=host')
+        self.stuff['subargs'] = privileged + ['--rm', fin,
+                                              "cat /etc/resolv.conf"]
         self.test_good()
         self.test_bad()
 

--- a/subtests/docker_cli/run_volumes_selinux/run_volumes_selinux.py
+++ b/subtests/docker_cli/run_volumes_selinux/run_volumes_selinux.py
@@ -27,6 +27,7 @@ from dockertest.environment import get_selinux_context
 from dockertest.output import wait_for_output
 from dockertest.containers import DockerContainers
 from dockertest.images import DockerImage
+import dockertest.docker_daemon as docker_daemon
 
 
 class run_volumes_selinux(subtest.SubSubtestCaller):
@@ -115,6 +116,10 @@ class selinux_base(subtest.SubSubtest):
         else:
             tmp = self.tmpdir
         volume = tempfile.mkdtemp(prefix=self.__class__.__name__, dir=tmp)
+        if docker_daemon.user_namespaces_enabled():
+            os.chown(volume,
+                     docker_daemon.user_namespaces_uid(),
+                     docker_daemon.user_namespaces_gid())
         self.sub_stuff['volumes'].add(volume)
         host_file = os.path.join(volume, "hostfile")
         open(host_file, 'w').write("01")

--- a/subtests/docker_cli/selinux_labels/test.sh
+++ b/subtests/docker_cli/selinux_labels/test.sh
@@ -77,7 +77,7 @@ check_label "container with overriden type" \
             "svirt_qemu_net_t"
 
 check_label "privileged container" \
-            "docker run --rm --privileged $image cat /proc/self/attr/current" \
+            "docker run --rm --privileged --userns=host $image cat /proc/self/attr/current" \
             "spc_t"
 
 check_label "confined container: root dir" \


### PR DESCRIPTION
Fixes the following test failures when running with user namespaces:

  - run_dns : Privileged mode is incompatible with user namespaces
    Solution: run docker client with '--userns=host' option
              when running with userns

  - run_volumes_selinux : permission denied
                  cause : subtest creates a tmpdir
               solution : chown the tmpdir when running with userns

  - selinux_labels      : Privileged mode is incompatible with user namespaces
               solution : run docker client with '--userns=host' option

  - top                 : incorrect userid (not 'root')
               solution : read /etc/subuid when running with userns

  - anything with -v    : permission denied
                  cause : tmp dirs are 700 owned by root
               solution : chown when running with userns

Signed-off-by: Ed Santiago <santiago@redhat.com>