### PR TITLE
Revert "Functionality for restarting docker daemon (#635)"

### DIFF
--- a/config_defaults/intratests.ini
+++ b/config_defaults/intratests.ini
@@ -1,5 +1,5 @@
 [garbage_check]
-subsubtests = containers,images,nones,config
+subsubtests = containers,images,nones
 #: If leftover images / containers are found, they should be removed.
 remove_garbage = yes
 #: If images / containers exist after attempted removal, fail the test

--- a/dockertest/docker_daemon.py
+++ b/dockertest/docker_daemon.py
@@ -9,12 +9,8 @@ import httplib
 import logging
 import socket
 import json
-import os
 import re
 from autotest.client import utils
-
-# File extension used for preserving original docker config file
-PRESERVED_EXTENSION = '.docker-autotest-preserved'
 
 
 class ClientBase(object):
@@ -203,93 +199,3 @@ def cmdline(process_id=None):
         process_id = pid()
     ps_command = 'ps -o command= -p %d' % int(process_id)
     return utils.run(ps_command).stdout.strip().split()
-
-
-def assert_pristine_environment():
-    """
-    Barf if there are any leftover .docker-autotest-preserved files
-    in /etc/sysconfig; this would indicate that a previous test
-    failed to clean up properly, and our system is in an
-    undefined state.
-    """
-    for suffix in ['', '-latest']:
-        path = '/etc/sysconfig/docker%s%s' % (suffix, PRESERVED_EXTENSION)
-        if os.path.exists(path):
-            raise RuntimeError("Leftover backup file: %s. System is"
-                               " in undefined state! Please examine that"
-                               " and its original file; if appropriate,"
-                               " mv it back into place." % path)
-
-
-def edit_options_file(remove=None, add=None):
-    """
-    Write a new /etc/sysconfig/docker* file with new OPTIONS string.
-    Preserve the original.
-
-    :param remove: string or list of strings - option(s) to remove from line
-    :param add: string or list of strings - option(s) to add to line
-    """
-    sysconfig_file = '/etc/sysconfig/%s' % which_docker()
-    sysconfig_bkp = sysconfig_file + PRESERVED_EXTENSION
-    if os.path.exists(sysconfig_bkp):
-        raise RuntimeError("Backup file already exists: %s" % sysconfig_bkp)
-    sysconfig_tmp = sysconfig_file + '.tmp'
-    with open(sysconfig_file, 'r') as sysconfig_fh_in:
-        with open(sysconfig_tmp, 'w') as sysconfig_fh_out:
-            for line in sysconfig_fh_in:
-                if line.startswith('OPTIONS='):
-                    line = edit_options_string(line, remove=remove, add=add)
-                sysconfig_fh_out.write(line)
-    os.link(sysconfig_file, sysconfig_bkp)
-    os.rename(sysconfig_tmp, sysconfig_file)
-
-
-def edit_options_string(line, remove=None, add=None):
-    """
-    Helper for edit_options_file(). Given an OPTIONS='...' string,
-    returns OPTIONS='...' with the given options removed and/or added
-    and a trailing newline.
-
-    :param line: string of the form OPTIONS='something'
-    :param remove: string or list of strings - option(s) to remove from line
-    :param add: string or list of strings - option(s) to add to line
-    """
-    if not line.startswith('OPTIONS='):
-        raise ValueError("input line does not start with OPTIONS= : %s" % line)
-    line = line[8:].rstrip()
-    quote = ''
-    if line[0] == '"' or line[0] == "'":
-        quote = line[0]
-        if line[-1] != quote:
-            raise ValueError("mismatched quotes in %s" % line)
-        line = line[1:-1]
-    if remove:
-        removes = remove if isinstance(remove, list) else [remove]
-        for remove_opt in removes:
-            if remove_opt in line:
-                line = line.replace(remove_opt, '')
-    if add:
-        adds = add if isinstance(add, list) else [add]
-        for add_opt in adds:
-            if add_opt not in line:
-                line = line + ' ' + add_opt
-    return 'OPTIONS=%s%s%s\n' % (quote, line.strip(), quote)
-
-
-def revert_options_file():
-    """
-    Revert back to preserved /etc/sysconfig/docker* file.
-
-    This function is safe to invoke even if the preserved file doesn't
-    exist; the only situation in which that makes sense is in a test's
-    cleanup() method if test prep has failed before edit_options_file().
-
-    Note that we automatically invoke restart(): there is no possible
-    situation in which it makes sense to revert options without restarting
-    docker daemon.
-    """
-    sysconfig_file = '/etc/sysconfig/%s' % which_docker()
-    sysconfig_bkp = sysconfig_file + PRESERVED_EXTENSION
-    if os.path.exists(sysconfig_bkp):
-        os.rename(sysconfig_bkp, sysconfig_file)
-        restart()

--- a/dockertest/docker_daemon_unittests.py
+++ b/dockertest/docker_daemon_unittests.py
@@ -94,48 +94,6 @@ class DDTest(DDTestBase):
         self.assertEqual(i.interface, None)
 
 
-class TestStringEdit(unittest2.TestCase):
-    """
-    Tests for edit_option_string()
-    """
-
-    # Various combinations of inputs, and their expected output for
-    # the edit_options_string() function.
-    # Thanks to  https://gist.github.com/encukou/10017915  for documentation
-    # on unittest2.subTest()
-    string_edit_tests = [
-        # original         remove          add             expected
-        ['abc',            None,           None,           'abc'],
-        ['"abc"',          None,           None,           '"abc"'],
-        ['"abc"',          "abc",          "def",          '"def"'],
-        ["'--a --b --c'",  '--a',          None,           "'--b --c'"],
-        ["'--a --b --c'",  '--b',          None,           "'--a  --c'"],
-        ["'--a --b --c'",  '--c',          None,           "'--a --b'"],
-        ["'--a --b --c'",  ['--a', '--c'], None,           "'--b'"],
-        ["'--a --c'",      None,           ['--a', '--b'], "'--a --c --b'"],
-    ]
-
-    def test_edit_options_string(self):
-        import docker_daemon
-        for (opts_in, remove, add, opts_out) in self.string_edit_tests:
-            with self.subTest(name="%s -<%s> +<%s>" % (opts_in, remove, add)):
-                s_in = 'OPTIONS=%s\n' % opts_in
-                expected = 'OPTIONS=%s\n' % opts_out
-                actual = docker_daemon.edit_options_string(s_in, remove, add)
-                self.assertEqual(actual, expected)
-
-    def test_bad_input_no_prefix(self):
-        import docker_daemon
-        self.assertRaises(ValueError,
-                          docker_daemon.edit_options_string, "OPTINOS=hi")
-
-    def test_bad_input_mismatched_quotes(self):
-        import docker_daemon
-        self.assertRaises(ValueError,
-                          docker_daemon.edit_options_string,
-                          "OPTIONS='missing end quote")
-
-
 class TestWhichDocker(unittest2.TestCase):
     """
     Tests for which_docker()

--- a/intratests/garbage_check/garbage_check.py
+++ b/intratests/garbage_check/garbage_check.py
@@ -25,7 +25,6 @@ from dockertest.containers import DockerContainers
 from dockertest.images import DockerImage
 from dockertest.images import DockerImages
 from dockertest.config import get_as_list
-from dockertest.docker_daemon import assert_pristine_environment
 
 
 class DockerImageIncomplete(DockerImage):
@@ -287,10 +286,3 @@ class nones(Base):
                 self.logwarning(fail_images)
             else:
                 self.failif(fail_images, fail_images)
-
-
-class config(Base):
-
-    def postprocess(self):
-        super(config, self).run_once()
-        assert_pristine_environment()

--- a/subtests/docker_cli/liverestore/liverestore.py
+++ b/subtests/docker_cli/liverestore/liverestore.py
@@ -195,7 +195,6 @@ class liverestore(subtest.Subtest):
 
     def cleanup(self):
         super(liverestore, self).cleanup()
-        docker_daemon.revert_options_file()
         if self.config['remove_after_test']:
             if 'container_name' in self.stuff:
                 self.stuff['dc'].clean_all([self.stuff['container_name']])


### PR DESCRIPTION
This functionality (editing /etc/sysconfig/docker* and
restarting docker daemon) was never used and is unlikely
ever to be used. Let's remove it.

This reverts commit aa6b7dd55722c697e1cc133211ed1a05b4097ce2.

Signed-off-by: Ed Santiago <santiago@redhat.com>