### PR TITLE
selinux_labels: fix deprecated usage

### DIFF
--- a/subtests/docker_cli/selinux_labels/test.sh
+++ b/subtests/docker_cli/selinux_labels/test.sh
@@ -68,12 +68,12 @@ check_label "confined container" \
             "docker run --rm $image cat /proc/self/attr/current" \
             "container_t" "svirt_lxc_net_t"
 
-check_label "container with label:disable" \
-            "docker run --rm --security-opt label:disable $image cat /proc/self/attr/current" \
+check_label "container with label=disable" \
+            "docker run --rm --security-opt label=disable $image cat /proc/self/attr/current" \
             "spc_t"
 
 check_label "container with overriden type" \
-            "docker run --rm --security-opt label:type:svirt_qemu_net_t $image cat /proc/self/attr/current" \
+            "docker run --rm --security-opt label=type:svirt_qemu_net_t $image cat /proc/self/attr/current" \
             "svirt_qemu_net_t"
 
 check_label "privileged container" \
@@ -85,7 +85,7 @@ check_label "confined container: root dir" \
             "container_file_t" "svirt_sandbox_file_t"
 
 check_label "container with overridden range" \
-            "docker run --rm --security-opt label:level:s0:c1,c2 $image cat /proc/self/attr/current" \
+            "docker run --rm --security-opt label=level:s0:c1,c2 $image cat /proc/self/attr/current" \
             "s0:c1,c2"
 
 exit $rc


### PR DESCRIPTION
The docker '--security-opt' option requires 'label=xxx'; but
for historical reasons accepts the now-deprecated 'label:xxx'
format. We've been using the latter; switch to the new form.

Signed-off-by: Ed Santiago <santiago@redhat.com>