### PR TITLE
rhbz1741718 - docker cp to /var/lib/foo -> /foo

### DIFF
--- a/config_defaults/subtests/docker_cli/cp.ini
+++ b/config_defaults/subtests/docker_cli/cp.ini
@@ -1,5 +1,5 @@
 [docker_cli/cp]
-subsubtests = simple,every_last,volume_mount,cp_symlink
+subsubtests = simple,every_last,volume_mount,cp_symlink,cp_in_varlib
 
 [docker_cli/cp/simple]
 
@@ -14,3 +14,15 @@ exclude_symlinks = yes
 __example__ = max_files
 #: maximum number of files to try
 max_files = 100
+
+[docker_cli/cp/cp_symlink]
+#: path where we cp the file, i.e. the argument to docker cp
+cp_dest = /mylink
+#: where we expect the file to end up inside the container
+destdir = /tmp
+
+[docker_cli/cp/cp_in_varlib]
+#: path where we cp the file, i.e. the argument to docker cp
+cp_dest = /var/lib/%%s
+#: where we expect the file to end up inside the container
+destdir = /var/lib


### PR DESCRIPTION
If docker storage is in /var/lib/docker/<etc> (default) and
you try to cp a file into <container>:/var/lib/myfile, docker
strips off the /var/lib/ prefix and places the file as /myfile.

New test confirmed to fail under docker-1.13.1-103.git7f2769b.el7
and to pass under hand-patched docker [1]

 [1] https://github.com/projectatomic/docker/pull/357

Since code is almost identical to cp_symlink(), I refactored
that a little bit and added some config_default settings.

Signed-off-by: Ed Santiago <santiago@redhat.com>